### PR TITLE
feat: add user package management to authentication and sidebar components

### DIFF
--- a/apps/web/app/(app)/settings/about/page.tsx
+++ b/apps/web/app/(app)/settings/about/page.tsx
@@ -1,16 +1,15 @@
+import { auth } from "@repo/auth";
+
 import { AppHeader } from "~/components/app-header";
 
-export default function SettingsAboutPage() {
+export default async function SettingsAboutPage() {
+  const session = await auth();
+
   return (
     <>
       <AppHeader items={["Settings", "About"]} />
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-          <div className="aspect-video rounded-xl bg-muted/50" />
-          <div className="aspect-video rounded-xl bg-muted/50" />
-          <div className="aspect-video rounded-xl bg-muted/50" />
-        </div>
-        <div className="min-h-screen flex-1 rounded-xl bg-muted/50 md:min-h-min" />
+        <pre>{JSON.stringify(session, null, 2)}</pre>
       </div>
     </>
   );

--- a/apps/web/components/navbar/app-sidebar.tsx
+++ b/apps/web/components/navbar/app-sidebar.tsx
@@ -24,7 +24,7 @@ import { data } from "./sidebar-config";
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { data: session } = useSession();
-
+  const hasPackage = session?.user.hasPackage || false;
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
@@ -32,8 +32,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </SidebarHeader>
       <SidebarContent>
         <NavMain items={data.stats} label="Stats" />
-        {/* <NavMain items={data.package} label="Package" /> */}
-        {/* <NavMain items={data.advanced} label="Advanced" /> */}
+        {hasPackage ? <NavMain items={data.package} label="Package" /> : null}
+        {hasPackage ? <NavMain items={data.advanced} label="Advanced" /> : null}
         <NavMain items={data.settings} label="Settings" />
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>

--- a/packages/auth/src/auth.config.ts
+++ b/packages/auth/src/auth.config.ts
@@ -16,11 +16,13 @@ export default {
     jwt: async ({ token, user }) => {
       if (user) {
         token.id = user.id;
+        token.hasPackage = user.hasPackage;
       }
       return token;
     },
     session: async ({ session, token }) => {
       session.user.id = token.id as string;
+      session.user.hasPackage = token.hasPackage as boolean;
       return session;
     },
   },

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -1,8 +1,22 @@
+/* eslint-disable no-unused-vars */
 import { PrismaAdapter } from "@auth/prisma-adapter";
-import NextAuth from "next-auth";
+import NextAuth, { type DefaultSession } from "next-auth";
 
 import { prisma } from "@repo/database";
 import authConfig from "./auth.config";
+
+ 
+declare module "next-auth" {
+  interface Session {
+    user: {
+      hasPackage: boolean;
+    } & DefaultSession["user"]
+  }
+
+  interface User {
+    hasPackage?: boolean;
+  }
+}
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   email         String?   @unique
   emailVerified DateTime?
   image         String?
+  hasPackage     Boolean   @default(false)
   accounts      Account[]
   package       Package[]
   tracks        Track[]


### PR DESCRIPTION
This pull request includes several changes to the authentication and session handling, as well as updates to the user interface to reflect these changes. The most important changes are:

### Authentication and Session Handling:

* [`packages/auth/src/auth.config.ts`](diffhunk://#diff-2df152787e3b7101ba9d386f4a93155572707095c72bffd924f0095977cb78f7R19-R25): Added `hasPackage` property to the JWT and session objects to track if a user has a package.
* [`packages/auth/src/auth.ts`](diffhunk://#diff-3e323571c96a81e686a1de01e67effe78b45a1e76486568d0e186ab7eda888e2R1-R20): Declared `hasPackage` property in the `Session` and `User` interfaces to ensure type safety.
* [`packages/database/prisma/schema.prisma`](diffhunk://#diff-3af15a46a4156a5898adbc840abd5bcc63f263b02da1069a405966839cb6a2ffR16): Added `hasPackage` field to the `User` model with a default value of `false`.

### User Interface Updates:

* [`apps/web/app/(app)/settings/about/page.tsx`](diffhunk://#diff-5d7d33f63fefb45e8f710a230a796cd8bad782fa7dfdb0777017af5fd968631bR1-R12): Modified `SettingsAboutPage` to display the session information, including the `hasPackage` property.
* [`apps/web/components/navbar/app-sidebar.tsx`](diffhunk://#diff-545c34bb3158879e8abce10713d63e9faed1805aa002e28640b23093994ba4ddL27-R36): Updated `AppSidebar` to conditionally render package-related navigation items based on the `hasPackage` property