### PR TITLE
fix: update user avatar image source (#26)

### DIFF
--- a/apps/web/components/navbar/nav-user.tsx
+++ b/apps/web/components/navbar/nav-user.tsx
@@ -62,7 +62,7 @@ export function NavUser({ user }: NavUserProps) {
                 className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
               >
                 <Avatar className="size-8 rounded-lg">
-                  <AvatarImage src={user.id ?? ""} alt={user.name ?? ""} />
+                  <AvatarImage src={user.image ?? ""} alt={user.name ?? ""} />
                   <AvatarFallback className="rounded-lg">
                     {(user.name || user.id)?.slice(0, 2)}
                   </AvatarFallback>


### PR DESCRIPTION
This pull request includes a small but important change to the `NavUser` component in the `apps/web/components/navbar/nav-user.tsx` file. The change updates the source of the avatar image to use the `user.image` property instead of the `user.id` property.

* [`apps/web/components/navbar/nav-user.tsx`](diffhunk://#diff-130fe54a1fcb9d9cf42a674c58f7e91b9dd8800e9f23be727ea41a5249a9f20cL65-R65): Updated the `AvatarImage` component to use `user.image` for the `src` attribute instead of `user.id`.