### PR TITLE
Feat/27 sidebar collapsed show submenu

### DIFF
--- a/apps/web/components/navbar/app-sidebar.tsx
+++ b/apps/web/components/navbar/app-sidebar.tsx
@@ -14,7 +14,6 @@ import {
 import { Skeleton } from "@repo/ui/skeleton";
 import { ChevronsUpDown } from "lucide-react";
 import { User } from "next-auth";
-import { useSession } from "next-auth/react";
 
 import { NavMain } from "~/components/navbar/nav-main";
 

--- a/apps/web/components/navbar/nav-main.tsx
+++ b/apps/web/components/navbar/nav-main.tsx
@@ -5,6 +5,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@repo/ui/collapsible";
+import { Separator } from "@repo/ui/separator";
 import {
   SidebarGroup,
   SidebarGroupLabel,
@@ -14,7 +15,9 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  useSidebar,
 } from "@repo/ui/sidebar";
+import { TooltipContent } from "@repo/ui/tooltip";
 import { ChevronRight, type LucideIcon } from "lucide-react";
 import { PrefetchKind } from "next/dist/client/components/router-reducer/router-reducer-types";
 import { usePathname, useRouter } from "next/navigation";
@@ -39,6 +42,7 @@ export function NavMain({
 }) {
   const pathname = usePathname();
   const router = useRouter();
+  const { open, isMobile } = useSidebar();
 
   return (
     <SidebarGroup>
@@ -56,7 +60,43 @@ export function NavMain({
             <SidebarMenuItem>
               {item.items ? (
                 <CollapsibleTrigger asChild>
-                  <SidebarMenuButton tooltip={item.title}>
+                  <SidebarMenuButton
+                    isActive={
+                      !open &&
+                      !isMobile &&
+                      (item.isActive ||
+                        item.items.some((i) => i.url === pathname))
+                    }
+                    tooltip={{
+                      children: (
+                        <>
+                          <span>{item.title}</span>
+                          <Separator />
+                          {item.items.map((subItem) => (
+                            <SidebarMenuButton
+                              key={subItem.title}
+                              isActive={subItem.url === pathname}
+                              asChild
+                              className="group-data-[collapsible=icon]:!size-auto"
+                            >
+                              <Link
+                                href={subItem.url}
+                                onMouseEnter={() => {
+                                  router.prefetch(item.url, {
+                                    kind: PrefetchKind.FULL,
+                                  });
+                                }}
+                              >
+                                {subItem.icon && <subItem.icon />}
+                                <span>{subItem.title}</span>
+                              </Link>
+                            </SidebarMenuButton>
+                          ))}
+                        </>
+                      ),
+                      className: "w-56",
+                    }}
+                  >
                     {item.icon && <item.icon />}
                     <span>{item.title}</span>
                     <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
@@ -68,17 +108,20 @@ export function NavMain({
                   asChild
                   isActive={item.url === pathname}
                 >
-                  <Link
-                    href={item.url}
+                  <a
                     onMouseEnter={() => {
                       router.prefetch(item.url, {
                         kind: PrefetchKind.FULL,
                       });
                     }}
+                    onClick={() => {
+                      router.push(item.url);
+                    }}
+                    className="cursor-pointer"
                   >
                     {item.icon && <item.icon />}
                     <span>{item.title}</span>
-                  </Link>
+                  </a>
                 </SidebarMenuButton>
               )}
               <CollapsibleContent>

--- a/apps/web/components/navbar/nav-main.tsx
+++ b/apps/web/components/navbar/nav-main.tsx
@@ -17,7 +17,6 @@ import {
   SidebarMenuSubItem,
   useSidebar,
 } from "@repo/ui/sidebar";
-import { TooltipContent } from "@repo/ui/tooltip";
 import { ChevronRight, type LucideIcon } from "lucide-react";
 import { PrefetchKind } from "next/dist/client/components/router-reducer/router-reducer-types";
 import { usePathname, useRouter } from "next/navigation";
@@ -70,13 +69,18 @@ export function NavMain({
                     tooltip={{
                       children: (
                         <>
-                          <span>{item.title}</span>
-                          <Separator />
+                          <div className="px-2 py-1">
+                            <p className="text-sm text-sidebar-accent-foreground">
+                              {item.title}
+                            </p>
+                          </div>
+                          <Separator className="mb-1" />
                           {item.items.map((subItem) => (
                             <SidebarMenuButton
                               key={subItem.title}
                               isActive={subItem.url === pathname}
                               asChild
+                              size="sm"
                               className="group-data-[collapsible=icon]:!size-auto"
                             >
                               <Link
@@ -94,7 +98,7 @@ export function NavMain({
                           ))}
                         </>
                       ),
-                      className: "w-56",
+                      className: "p-1 min-w-32",
                     }}
                   >
                     {item.icon && <item.icon />}


### PR DESCRIPTION
This pull request includes several changes to the `NavMain` component in the `apps/web/components/navbar/nav-main.tsx` file, focusing on improving the sidebar navigation functionality and user experience. Additionally, there are minor import adjustments in related files.

Improvements to the sidebar navigation functionality:

* [`apps/web/components/navbar/nav-main.tsx`](diffhunk://#diff-1392a138ed0e7ac513d51281c8f2fb6de8743eb2e8c11e5bda4515a653eccfbcR18): Added `useSidebar` to manage the sidebar state and determine if the sidebar is open or if the user is on a mobile device. [[1]](diffhunk://#diff-1392a138ed0e7ac513d51281c8f2fb6de8743eb2e8c11e5bda4515a653eccfbcR18) [[2]](diffhunk://#diff-1392a138ed0e7ac513d51281c8f2fb6de8743eb2e8c11e5bda4515a653eccfbcR44)
* [`apps/web/components/navbar/nav-main.tsx`](diffhunk://#diff-1392a138ed0e7ac513d51281c8f2fb6de8743eb2e8c11e5bda4515a653eccfbcL59-R103): Enhanced `SidebarMenuButton` to display a tooltip with additional information and a separator when the sidebar is closed or in mobile view.
* [`apps/web/components/navbar/nav-main.tsx`](diffhunk://#diff-1392a138ed0e7ac513d51281c8f2fb6de8743eb2e8c11e5bda4515a653eccfbcL71-R128): Modified the main navigation links to use an anchor (`<a>`) element with an `onClick` handler to navigate, replacing the `Link` component for better control over navigation actions.

Minor import adjustments:

* [`apps/web/components/navbar/app-sidebar.tsx`](diffhunk://#diff-545c34bb3158879e8abce10713d63e9faed1805aa002e28640b23093994ba4ddL17): Removed an unused import for `useSession` from `next-auth/react`.
* [`apps/web/components/navbar/nav-main.tsx`](diffhunk://#diff-1392a138ed0e7ac513d51281c8f2fb6de8743eb2e8c11e5bda4515a653eccfbcR8): Added imports for `Separator` and `useSidebar` from `@repo/ui`. [[1]](diffhunk://#diff-1392a138ed0e7ac513d51281c8f2fb6de8743eb2e8c11e5bda4515a653eccfbcR8) [[2]](diffhunk://#diff-1392a138ed0e7ac513d51281c8f2fb6de8743eb2e8c11e5bda4515a653eccfbcR18)