### PR TITLE
Fix/create package without spotify

### DIFF
--- a/apps/web/actions/user-package-action.ts
+++ b/apps/web/actions/user-package-action.ts
@@ -4,7 +4,7 @@ import { auth } from "@repo/auth";
 import { prisma } from "@repo/database";
 
 type Package = {
-  spotify_id: string;
+  spotify_id?: string;
   file_name: string;
   file_size: number;
 };
@@ -20,7 +20,7 @@ export const createPackageAction = async (pakge: Package) => {
   await prisma.package.create({
     data: {
       userId,
-      spotify_id: pakge.spotify_id,
+      spotify_id: pakge.spotify_id || session.user.id || "Unknown",
       fileName: pakge.file_name,
       fileSize: String(pakge.file_size),
     },


### PR DESCRIPTION
This pull request includes several changes to improve error handling, add new dependencies, and update the `Package` type definition. The most important changes include making the `spotify_id` field optional, adding error handling in the `FileUpload` component, and updating the `saveData` function to handle rate limit errors.

### Error Handling Improvements:

* [`apps/web/components/file-upload.tsx`](diffhunk://#diff-47e41e1eed0c69acf5bd3a6feaeec9cc2a539a4adf639d9913de1d120474b8c9L51-R60): Added error handling to `handleUpload` to display an error toast if the file processing response contains an error message.
* [`apps/web/services/file-processing.ts`](diffhunk://#diff-376612f0fe22674b896ab1a83283df35f96b6063740b5155ccab6423f5669078L47-R57): Added try-catch blocks to handle rate limit errors and other exceptions, returning error messages when exceptions occur. [[1]](diffhunk://#diff-376612f0fe22674b896ab1a83283df35f96b6063740b5155ccab6423f5669078L47-R57) [[2]](diffhunk://#diff-376612f0fe22674b896ab1a83283df35f96b6063740b5155ccab6423f5669078L81-R94) [[3]](diffhunk://#diff-376612f0fe22674b896ab1a83283df35f96b6063740b5155ccab6423f5669078R113)

### Dependency Updates:

* [`apps/web/components/file-upload.tsx`](diffhunk://#diff-47e41e1eed0c69acf5bd3a6feaeec9cc2a539a4adf639d9913de1d120474b8c9R7-R8): Imported `useRouter` from `next/navigation` and `toast` from `sonner` to handle navigation and display toast notifications. [[1]](diffhunk://#diff-47e41e1eed0c69acf5bd3a6feaeec9cc2a539a4adf639d9913de1d120474b8c9R7-R8) [[2]](diffhunk://#diff-47e41e1eed0c69acf5bd3a6feaeec9cc2a539a4adf639d9913de1d120474b8c9R21)

### Type Definition Updates:

* [`apps/web/actions/user-package-action.ts`](diffhunk://#diff-a15642db65d61c4bf417dac0575a7d6a8d540e9e2a3edf95d30fec48801604c3L7-R7): Made the `spotify_id` field in the `Package` type optional and provided a default value in `createPackageAction` if `spotify_id` is not present. [[1]](diffhunk://#diff-a15642db65d61c4bf417dac0575a7d6a8d540e9e2a3edf95d30fec48801604c3L7-R7) [[2]](diffhunk://#diff-a15642db65d61c4bf417dac0575a7d6a8d540e9e2a3edf95d30fec48801604c3L23-R23)