### PR TITLE
Feat/stats numbers page

### DIFF
--- a/apps/web/actions/get-numbers-session-stats-action.ts
+++ b/apps/web/actions/get-numbers-session-stats-action.ts
@@ -64,8 +64,10 @@ export const getNumbersSessionStatsAction = async (
     (sum, duration) => sum + duration,
     0,
   );
-  const longestSession = Math.max(...sessionDurations);
-  const averageSessionTime = totalDuration / totalSessions;
+  const longestSession = sessionDurations.length
+    ? Math.max(...sessionDurations)
+    : 0;
+  const averageSessionTime = totalSessions ? totalDuration / totalSessions : 0;
 
   return {
     averageSessionTime: Math.round(averageSessionTime),

--- a/apps/web/actions/get-numbers-session-stats-action.ts
+++ b/apps/web/actions/get-numbers-session-stats-action.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { auth } from "@repo/auth";
+import { prisma } from "@repo/database";
+
+export const getNumbersSessionStatsAction = async (
+  minDate: Date,
+  maxDate: Date,
+) => {
+  const session = await auth();
+
+  if (!session?.user.id) {
+    return null;
+  }
+
+  const tracks = await prisma.track.findMany({
+    where: {
+      userId: session.user.id,
+      timestamp: {
+        gte: minDate,
+        lt: maxDate,
+      },
+    },
+    select: {
+      timestamp: true,
+      msPlayed: true,
+    },
+    orderBy: [{ timestamp: "asc" }],
+  });
+
+  const sessionDurations: number[] = [];
+  let currentSessionStart: Date | null = null;
+  let currentSessionDuration = 0;
+
+  for (let i = 0; i < tracks.length; i++) {
+    const track = tracks[i];
+    const trackTime = track.timestamp;
+
+    if (!currentSessionStart) {
+      currentSessionStart = track.timestamp;
+      currentSessionDuration = Number(track.msPlayed) || 0;
+    } else {
+      const lastTimestamp = currentSessionStart;
+      const diff =
+        Math.abs(trackTime.getTime() - lastTimestamp.getTime()) / 60000;
+
+      if (diff > 30) {
+        sessionDurations.push(currentSessionDuration);
+        currentSessionStart = track.timestamp;
+        currentSessionDuration = Number(track.msPlayed) || 0;
+      } else {
+        currentSessionDuration += Number(track.msPlayed) || 0;
+        currentSessionStart = track.timestamp;
+      }
+    }
+
+    if (i === tracks.length - 1) {
+      sessionDurations.push(currentSessionDuration);
+    }
+  }
+
+  const totalSessions = sessionDurations.length;
+  const totalDuration = sessionDurations.reduce(
+    (sum, duration) => sum + duration,
+    0,
+  );
+  const longestSession = Math.max(...sessionDurations);
+  const averageSessionTime = totalDuration / totalSessions;
+
+  return {
+    averageSessionTime: Math.round(averageSessionTime),
+    longestSession,
+    totalSessions,
+  };
+};

--- a/apps/web/actions/get-numbers-stats-actions.ts
+++ b/apps/web/actions/get-numbers-stats-actions.ts
@@ -1,0 +1,138 @@
+"use server";
+
+import { auth } from "@repo/auth";
+import { prisma } from "@repo/database";
+import { spotify } from "@repo/spotify";
+import { format } from "light-date";
+
+export const getNumbersStatsAction = async (minDate: Date, maxDate: Date) => {
+  const session = await auth();
+
+  if (!session?.user.id) {
+    return null;
+  }
+
+  const tracks = await prisma.track.findMany({
+    where: {
+      userId: session.user.id,
+      timestamp: {
+        gte: minDate,
+        lt: maxDate,
+      },
+    },
+    select: {
+      timestamp: true,
+      msPlayed: true,
+      spotifyId: true,
+      artistIds: true,
+      offline: true,
+      reasonStart: true,
+    },
+    orderBy: [{ timestamp: "asc" }],
+  });
+
+  if (tracks.length === 0) {
+    return {
+      listeningTime: 0,
+      totalPlays: 0,
+      uniqueTracks: 0,
+      differentArtists: 0,
+      firstTrack: null,
+      mostPlayedDay: { day: "", totalPlayed: 0 },
+      mostStreamedDay: { day: "", totalTime: 0 },
+      onlineTrackPercent: 0,
+      mostFwdbtnTrack: { spotifyId: null, totalPlayed: 0 },
+    };
+  }
+
+  const listeningTime = tracks.reduce(
+    (sum, track) => sum + Number(track.msPlayed),
+    0,
+  );
+  const totalPlays = tracks.length;
+
+  const uniqueTracks = new Set(tracks.map((track) => track.spotifyId)).size;
+  const differentArtists = new Set(tracks.flatMap((track) => track.artistIds))
+    .size;
+
+  const firstTrack = tracks[0];
+
+  const dayStats: Record<string, { totalPlayed: number; totalTime: number }> =
+    {};
+  tracks.forEach((track) => {
+    const day = format(track.timestamp, "{dd}/{MM}/{yyyy}");
+    if (!dayStats[day]) {
+      dayStats[day] = { totalPlayed: 0, totalTime: 0 };
+    }
+    dayStats[day].totalPlayed += 1;
+    dayStats[day].totalTime += Number(track.msPlayed);
+  });
+
+  let mostPlayedDay = { day: "", totalPlayed: 0 };
+  let mostStreamedDay = { day: "", totalTime: 0 };
+
+  Object.entries(dayStats).forEach(([day, stats]) => {
+    if (stats.totalPlayed > mostPlayedDay.totalPlayed) {
+      mostPlayedDay = { day, totalPlayed: stats.totalPlayed };
+    }
+    if (stats.totalTime > mostStreamedDay.totalTime) {
+      mostStreamedDay = { day, totalTime: stats.totalTime };
+    }
+  });
+
+  const onlineTracks = tracks.filter((track) => track.offline === false).length;
+  const onlineTrackPercent = Math.round((onlineTracks / totalPlays) * 100);
+
+  const fwdbtnTracks = tracks.filter((track) => track.reasonStart === "fwdbtn");
+  const fwdbtnTrackCount: Record<string, number> = {};
+  fwdbtnTracks.forEach((track) => {
+    if (!fwdbtnTrackCount[track.spotifyId]) {
+      fwdbtnTrackCount[track.spotifyId] = 0;
+    }
+    fwdbtnTrackCount[track.spotifyId]++;
+  });
+
+  let mostFwdbtnTrack = { spotifyId: "", totalPlayed: 0 };
+  Object.entries(fwdbtnTrackCount).forEach(([spotifyId, totalPlayed]) => {
+    if (totalPlayed > mostFwdbtnTrack.totalPlayed) {
+      mostFwdbtnTrack = { spotifyId, totalPlayed };
+    }
+  });
+
+  // Get track details
+  const trackDetails = await spotify.tracks.list([
+    firstTrack.spotifyId,
+    mostFwdbtnTrack.spotifyId,
+  ]);
+
+  const firstTrackDetails = trackDetails.find(
+    (track) => track.id === firstTrack.spotifyId,
+  );
+  const mostFwdbtnTrackDetails = trackDetails.find(
+    (track) => track.id === mostFwdbtnTrack.spotifyId,
+  );
+
+  return {
+    listeningTime,
+    totalPlays,
+    uniqueTracks,
+    differentArtists,
+    firstTrack: {
+      timestamp: firstTrack.timestamp,
+      id: firstTrackDetails?.id,
+      name: firstTrackDetails?.name,
+      cover: firstTrackDetails?.album.images[0].url,
+      artists: firstTrackDetails?.artists.map((artist) => artist.name),
+    },
+    mostPlayedDay,
+    mostStreamedDay,
+    onlineTrackPercent,
+    mostFwdbtnTrack: {
+      totalPlayed: mostFwdbtnTrack.totalPlayed,
+      id: mostFwdbtnTrackDetails?.id,
+      name: mostFwdbtnTrackDetails?.name,
+      cover: mostFwdbtnTrackDetails?.album.images[0].url,
+      artists: mostFwdbtnTrackDetails?.artists.map((artist) => artist.name),
+    },
+  };
+};

--- a/apps/web/actions/get-numbers-stats-actions.ts
+++ b/apps/web/actions/get-numbers-stats-actions.ts
@@ -31,20 +31,6 @@ export const getNumbersStatsAction = async (minDate: Date, maxDate: Date) => {
     orderBy: [{ timestamp: "asc" }],
   });
 
-  if (tracks.length === 0) {
-    return {
-      listeningTime: 0,
-      totalPlays: 0,
-      uniqueTracks: 0,
-      differentArtists: 0,
-      firstTrack: null,
-      mostPlayedDay: { day: "", totalPlayed: 0 },
-      mostStreamedDay: { day: "", totalTime: 0 },
-      onlineTrackPercent: 0,
-      mostFwdbtnTrack: { spotifyId: null, totalPlayed: 0 },
-    };
-  }
-
   const listeningTime = tracks.reduce(
     (sum, track) => sum + Number(track.msPlayed),
     0,

--- a/apps/web/actions/get-numbers-stats-actions.ts
+++ b/apps/web/actions/get-numbers-stats-actions.ts
@@ -38,7 +38,33 @@ export const getNumbersStatsAction = async (minDate: Date, maxDate: Date) => {
 
   const tracks = await getTracks(userId, minDate, maxDate);
 
-  if (tracks.length === 0) return null;
+  if (tracks.length === 0)
+    return {
+      listeningTime: 0,
+      totalPlays: 0,
+      uniqueTracks: 0,
+      differentArtists: 0,
+      firstTrack: {
+        timestamp: null,
+        id: null,
+        name: null,
+        cover: null,
+        artists: null,
+      },
+      mostActiveDay: {
+        day: null,
+        totalTime: 0,
+        totalPlayed: 0,
+      },
+      onlineTrackPercent: 0,
+      mostFwdbtnTrack: {
+        totalPlayed: 0,
+        id: null,
+        name: null,
+        cover: null,
+        artists: null,
+      },
+    };
 
   const stats = calculateStats(tracks);
   const trackDetails = await fetchTrackDetails(

--- a/apps/web/actions/get-numbers-stats-actions.ts
+++ b/apps/web/actions/get-numbers-stats-actions.ts
@@ -3,22 +3,14 @@
 import { auth } from "@repo/auth";
 import { prisma } from "@repo/database";
 import { spotify } from "@repo/spotify";
+import { Track as SpotifyTrack } from "@repo/spotify/types";
 import { format } from "light-date";
 
-export const getNumbersStatsAction = async (minDate: Date, maxDate: Date) => {
-  const session = await auth();
-
-  if (!session?.user.id) {
-    return null;
-  }
-
-  const tracks = await prisma.track.findMany({
+const getTracks = async (userId: string, minDate: Date, maxDate: Date) =>
+  prisma.track.findMany({
     where: {
-      userId: session.user.id,
-      timestamp: {
-        gte: minDate,
-        lt: maxDate,
-      },
+      userId,
+      timestamp: { gte: minDate, lt: maxDate },
     },
     select: {
       timestamp: true,
@@ -28,93 +20,142 @@ export const getNumbersStatsAction = async (minDate: Date, maxDate: Date) => {
       offline: true,
       reasonStart: true,
     },
-    orderBy: [{ timestamp: "asc" }],
+    orderBy: { timestamp: "asc" },
   });
 
+type DayStats = {
+  totalPlayed: number;
+  totalTime: bigint;
+};
+
+type Track = Awaited<ReturnType<typeof getTracks>>[number];
+
+export const getNumbersStatsAction = async (minDate: Date, maxDate: Date) => {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+
+  const userId = session.user.id;
+
+  const tracks = await getTracks(userId, minDate, maxDate);
+
+  if (tracks.length === 0) return null;
+
+  const stats = calculateStats(tracks);
+  const trackDetails = await fetchTrackDetails(
+    tracks,
+    stats.mostFwdbtnTrack.spotifyId,
+  );
+
+  return formatResponse(stats, tracks, trackDetails);
+};
+
+const calculateStats = (tracks: Track[]) => {
   const listeningTime = tracks.reduce(
-    (sum, track) => sum + Number(track.msPlayed),
-    0,
+    (sum, track) => sum + track.msPlayed,
+    BigInt(0),
   );
   const totalPlays = tracks.length;
-
   const uniqueTracks = new Set(tracks.map((track) => track.spotifyId)).size;
   const differentArtists = new Set(tracks.flatMap((track) => track.artistIds))
     .size;
 
-  const firstTrack = tracks[0];
-
-  const dayStats: Record<string, { totalPlayed: number; totalTime: number }> =
-    {};
-  tracks.forEach((track) => {
-    const day = format(track.timestamp, "{dd}/{MM}/{yyyy}");
-    if (!dayStats[day]) {
-      dayStats[day] = { totalPlayed: 0, totalTime: 0 };
-    }
-    dayStats[day].totalPlayed += 1;
-    dayStats[day].totalTime += Number(track.msPlayed);
-  });
-
-  let mostPlayedDay = { day: "", totalPlayed: 0 };
-  let mostStreamedDay = { day: "", totalTime: 0 };
-
-  Object.entries(dayStats).forEach(([day, stats]) => {
-    if (stats.totalPlayed > mostPlayedDay.totalPlayed) {
-      mostPlayedDay = { day, totalPlayed: stats.totalPlayed };
-    }
-    if (stats.totalTime > mostStreamedDay.totalTime) {
-      mostStreamedDay = { day, totalTime: stats.totalTime };
-    }
-  });
+  const dayStats = aggregateDayStats(tracks);
+  const mostActiveDay = findMostActiveDay(dayStats);
 
   const onlineTracks = tracks.filter((track) => track.offline === false).length;
   const onlineTrackPercent = Math.round((onlineTracks / totalPlays) * 100);
 
   const fwdbtnTracks = tracks.filter((track) => track.reasonStart === "fwdbtn");
-  const fwdbtnTrackCount: Record<string, number> = {};
-  fwdbtnTracks.forEach((track) => {
-    if (!fwdbtnTrackCount[track.spotifyId]) {
-      fwdbtnTrackCount[track.spotifyId] = 0;
-    }
-    fwdbtnTrackCount[track.spotifyId]++;
-  });
-
-  let mostFwdbtnTrack = { spotifyId: "", totalPlayed: 0 };
-  Object.entries(fwdbtnTrackCount).forEach(([spotifyId, totalPlayed]) => {
-    if (totalPlayed > mostFwdbtnTrack.totalPlayed) {
-      mostFwdbtnTrack = { spotifyId, totalPlayed };
-    }
-  });
-
-  // Get track details
-  const trackDetails = await spotify.tracks.list([
-    firstTrack.spotifyId,
-    mostFwdbtnTrack.spotifyId,
-  ]);
-
-  const firstTrackDetails = trackDetails.find(
-    (track) => track.id === firstTrack.spotifyId,
-  );
-  const mostFwdbtnTrackDetails = trackDetails.find(
-    (track) => track.id === mostFwdbtnTrack.spotifyId,
-  );
+  const mostFwdbtnTrack = findMostFwdbtnTrack(fwdbtnTracks);
 
   return {
     listeningTime,
     totalPlays,
     uniqueTracks,
     differentArtists,
+    dayStats,
+    mostActiveDay,
+    onlineTrackPercent,
+    mostFwdbtnTrack,
+  };
+};
+
+const aggregateDayStats = (tracks: Track[]) => {
+  return tracks.reduce<Record<string, DayStats>>((stats, track) => {
+    const day = format(track.timestamp, "{MM}/{dd}/{yyyy}");
+    if (!stats[day]) stats[day] = { totalPlayed: 0, totalTime: BigInt(0) };
+    stats[day].totalPlayed += 1;
+    stats[day].totalTime += track.msPlayed;
+    return stats;
+  }, {});
+};
+
+const findMostActiveDay = (dayStats: Record<string, DayStats>) => {
+  return Object.entries(dayStats).reduce(
+    (max, [day, stats]) =>
+      stats.totalTime > max.totalTime
+        ? {
+            day,
+            totalTime: Number(stats.totalTime),
+            totalPlayed: stats.totalPlayed,
+          }
+        : max,
+    { day: "", totalTime: 0, totalPlayed: 0 },
+  );
+};
+
+const findMostFwdbtnTrack = (fwdbtnTracks: Track[]) => {
+  const fwdbtnTrackCount = fwdbtnTracks.reduce<Record<string, number>>(
+    (count, track) => {
+      count[track.spotifyId] = (count[track.spotifyId] || 0) + 1;
+      return count;
+    },
+    {},
+  );
+
+  return Object.entries(fwdbtnTrackCount).reduce(
+    (max, [spotifyId, totalPlayed]) =>
+      totalPlayed > max.totalPlayed ? { spotifyId, totalPlayed } : max,
+    { spotifyId: "", totalPlayed: 0 },
+  );
+};
+
+const fetchTrackDetails = async (
+  tracks: Track[],
+  mostFwdbtnTrackId: string,
+) => {
+  const trackIds = [tracks[0].spotifyId, mostFwdbtnTrackId];
+  return await spotify.tracks.list(trackIds);
+};
+
+const formatResponse = (
+  stats: ReturnType<typeof calculateStats>,
+  tracks: Track[],
+  trackDetails: SpotifyTrack[],
+) => {
+  const firstTrackDetails = trackDetails.find(
+    (track) => track.id === tracks[0].spotifyId,
+  );
+  const mostFwdbtnTrackDetails = trackDetails.find(
+    (track) => track.id === stats.mostFwdbtnTrack.spotifyId,
+  );
+
+  return {
+    listeningTime: Number(stats.listeningTime),
+    totalPlays: stats.totalPlays,
+    uniqueTracks: stats.uniqueTracks,
+    differentArtists: stats.differentArtists,
     firstTrack: {
-      timestamp: firstTrack.timestamp,
+      timestamp: tracks[0]?.timestamp,
       id: firstTrackDetails?.id,
       name: firstTrackDetails?.name,
       cover: firstTrackDetails?.album.images[0].url,
       artists: firstTrackDetails?.artists.map((artist) => artist.name),
     },
-    mostPlayedDay,
-    mostStreamedDay,
-    onlineTrackPercent,
+    mostActiveDay: stats.mostActiveDay,
+    onlineTrackPercent: stats.onlineTrackPercent,
     mostFwdbtnTrack: {
-      totalPlayed: mostFwdbtnTrack.totalPlayed,
+      totalPlayed: stats.mostFwdbtnTrack.totalPlayed,
       id: mostFwdbtnTrackDetails?.id,
       name: mostFwdbtnTrackDetails?.name,
       cover: mostFwdbtnTrackDetails?.album.images[0].url,

--- a/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
+++ b/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
@@ -1,15 +1,20 @@
 "use client";
 
-import React from "react";
-import { Avatar, AvatarFallback, AvatarImage } from "@repo/ui/avatar";
 import { Badge } from "@repo/ui/badge";
 import { Card } from "@repo/ui/card";
-import { NumberFlow } from "@repo/ui/number";
+import { NumberFlow, NumbersFlowDate } from "@repo/ui/number";
 import { Progress } from "@repo/ui/progress";
 import { useQuery } from "@tanstack/react-query";
 import { Calendar, Clock, FastForward, Users } from "lucide-react";
 
 import { getNumbersStatsAction } from "~/actions/get-numbers-stats-actions";
+import {
+  ItemCard,
+  ItemCardContent,
+  ItemCardImage,
+  ItemCardSubtitle,
+  ItemCardTitle,
+} from "~/components/item-card";
 import { addMonths } from "~/components/month-range-picker";
 import { useRankingTimeRange } from "~/lib/store";
 
@@ -51,16 +56,20 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
           <div>
             <p className="text-sm opacity-75">Total Listening Time</p>
             <h2 className="text-4xl font-bold mt-2">
-              <NumberFlow value={msToHours(data.listeningTime).toFixed(2)} />{" "}
-              hours
+              <NumberFlow
+                value={msToHours(data.listeningTime).toFixed(2)}
+                suffix=" hours"
+              />
             </h2>
           </div>
           <Clock className="size-8 opacity-75" />
         </div>
         <p className="mt-4 text-sm opacity-75">
-          That's about{" "}
-          <NumberFlow value={Math.round(msToHours(data.listeningTime) / 24)} />{" "}
-          days of non-stop music!
+          <NumberFlow
+            value={Math.round(msToHours(data.listeningTime) / 24)}
+            prefix="That's about "
+            suffix=" days of non-stop music!"
+          />
         </p>
       </Card>
 
@@ -69,16 +78,36 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
         <div className="flex justify-between mb-4">
           <div>
             <p className="text-sm text-muted-foreground">Total Plays</p>
-            <h3 className="text-2xl font-semibold">{data.totalPlays}</h3>
+            <h3 className="text-2xl font-semibold">
+              <NumberFlow
+                value={data.totalPlays}
+                format={{ notation: "standard" }}
+                locales="en-US"
+              />
+            </h3>
           </div>
           <div>
             <p className="text-sm text-muted-foreground">Unique Tracks</p>
-            <h3 className="text-2xl font-semibold">4,395</h3>
+            <h3 className="text-2xl font-semibold">
+              <NumberFlow
+                value={data.uniqueTracks}
+                format={{ notation: "standard" }}
+                locales="en-US"
+              />
+            </h3>
           </div>
         </div>
-        <Progress value={18} className="h-2" />
+        <Progress
+          value={(data.uniqueTracks / data.totalPlays) * 100}
+          className="h-2 [&>div]:duration-500 [&>div]:ease-in-out"
+        />
         <p className="text-sm text-muted-foreground mt-2">
-          18% of your plays were unique tracks
+          <NumberFlow
+            value={data.uniqueTracks / data.totalPlays}
+            format={{ style: "percent" }}
+            locales="en-US"
+            suffix=" of your plays were unique tracks"
+          />
         </p>
       </Card>
 
@@ -87,7 +116,13 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
         <Users className="size-12 text-indigo-500" />
         <div>
           <p className="text-sm text-muted-foreground">Different Artists</p>
-          <h3 className="text-3xl font-bold">1,431</h3>
+          <h3 className="text-3xl font-bold">
+            <NumberFlow
+              value={data.differentArtists}
+              format={{ notation: "standard" }}
+              locales="en-US"
+            />
+          </h3>
           <p className="text-sm text-muted-foreground mt-1">
             Explored in your musical journey
           </p>
@@ -97,21 +132,21 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
       {/* First Track */}
       <Card className="p-6">
         <h3 className="font-semibold mb-2">First Track of the Year</h3>
-        <div className="flex items-center space-x-4">
-          <Avatar className="size-16">
-            <AvatarImage
-              src="https://i.scdn.co/image/ab67616d0000b27398ea0e689c91f8fea726d9bb"
-              alt="Control by Playboi Carti"
+        <div>
+          <ItemCard className="py-0">
+            <ItemCardImage
+              src={data.firstTrack.cover || ""}
+              alt={data.firstTrack.name || ""}
             />
-            <AvatarFallback>PC</AvatarFallback>
-          </Avatar>
-          <div>
-            <p className="font-medium">Control</p>
-            <p className="text-sm text-muted-foreground">Playboi Carti</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Played on Jan 1, 2024 at 00:28
-            </p>
-          </div>
+            <ItemCardContent>
+              <ItemCardTitle>{data.firstTrack.name}</ItemCardTitle>
+              <ItemCardSubtitle>{data.firstTrack.artists}</ItemCardSubtitle>
+            </ItemCardContent>
+          </ItemCard>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Played on{" "}
+            <NumbersFlowDate value={data.firstTrack.timestamp} showTime />
+          </p>
         </div>
       </Card>
 
@@ -119,46 +154,77 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
       <Card className="p-6 bg-green-100 dark:bg-green-900">
         <Calendar className="size-8 mb-2 text-green-600 dark:text-green-400" />
         <h3 className="font-semibold">Most Active Day</h3>
-        <p className="text-2xl font-bold mt-1">April 28, 2024</p>
+        <p className="text-2xl font-bold mt-1">
+          <NumbersFlowDate value={new Date(data.mostActiveDay.day)} />
+        </p>
         <p className="text-sm text-muted-foreground mt-1">
-          You played 231 tracks
+          <NumberFlow
+            value={data.mostActiveDay.totalPlayed}
+            format={{ notation: "standard" }}
+            locales="en-US"
+            suffix=" tracks for "
+            prefix="You played "
+          />
+          <NumberFlow
+            value={msToHours(data.mostActiveDay.totalTime).toFixed(2)}
+            suffix=" hours"
+          />
         </p>
       </Card>
 
       {/* Online Track Percent */}
       <Card className="p-6 flex flex-col justify-between h-full">
-        <div>
-          <h3 className="font-semibold mb-2">Online Listening</h3>
-          <p className="text-4xl font-bold">
-            98<span className="text-2xl">%</span>
-          </p>
+        <div className="flex justify-between mb-4">
+          <div>
+            <p className="text-sm text-muted-foreground">Online Listening</p>
+            <h3 className="text-4xl font-semibold">
+              <NumberFlow
+                value={data.onlineTrackPercent / 100}
+                format={{ style: "percent" }}
+                locales="en-US"
+              />
+            </h3>
+          </div>
         </div>
-        <p className="text-sm text-muted-foreground mt-4">
-          You mostly listen to music while connected to the internet
+        <Progress
+          value={data.onlineTrackPercent}
+          className="h-2 [&>div]:duration-500 [&>div]:ease-in-out"
+        />
+        <p className="text-sm text-muted-foreground mt-2">
+          {data.onlineTrackPercent > 50
+            ? "You mostly listen to music while connected to the internet"
+            : "You mostly listen to music while offline"}
         </p>
       </Card>
 
       {/* Most Skipped Track */}
       <Card className="p-6 bg-red-100 dark:bg-red-900">
         <div className="flex justify-between items-start mb-4">
-          <h3 className="font-semibold">Most Skipped Track</h3>
+          <h3 className="font-semibold">Most Forwarded Track</h3>
           <FastForward className="size-5 text-red-500 dark:text-red-400" />
         </div>
         <div className="flex items-center space-x-3">
-          <Avatar className="size-12">
-            <AvatarImage
-              src="https://i.scdn.co/image/ab67616d0000b273ca15942c726ec9c39796435e"
-              alt="ALL RED by Playboi Carti"
+          <ItemCard className="py-0">
+            <ItemCardImage
+              src={data.mostFwdbtnTrack.cover || ""}
+              alt={data.mostFwdbtnTrack.name || ""}
             />
-            <AvatarFallback>PC</AvatarFallback>
-          </Avatar>
-          <div>
-            <p className="font-medium">ALL RED</p>
-            <p className="text-sm text-muted-foreground">Playboi Carti</p>
-          </div>
+            <ItemCardContent>
+              <ItemCardTitle>{data.mostFwdbtnTrack.name}</ItemCardTitle>
+              <ItemCardSubtitle>
+                {data.mostFwdbtnTrack.artists}
+              </ItemCardSubtitle>
+            </ItemCardContent>
+          </ItemCard>
         </div>
         <Badge className="mt-3" variant="outline">
-          Skipped 29 times
+          <NumberFlow
+            value={data.mostFwdbtnTrack.totalPlayed}
+            format={{ notation: "standard" }}
+            locales="en-US"
+            prefix="Forwarded "
+            suffix=" times"
+          />
         </Badge>
       </Card>
     </div>

--- a/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
+++ b/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@repo/ui/badge";
 import { Card } from "@repo/ui/card";
 import { NumberFlow, NumbersFlowDate } from "@repo/ui/number";
 import { Progress } from "@repo/ui/progress";
+import { Skeleton } from "@repo/ui/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import { Calendar, Clock, FastForward, Users } from "lucide-react";
 
@@ -135,8 +136,8 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
         <div>
           <ItemCard className="py-0">
             <ItemCardImage
-              src={data.firstTrack.cover || ""}
-              alt={data.firstTrack.name || ""}
+              src={data.firstTrack.cover}
+              alt={data.firstTrack.name}
             />
             <ItemCardContent>
               <ItemCardTitle>{data.firstTrack.name}</ItemCardTitle>
@@ -226,6 +227,128 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
             suffix=" times"
           />
         </Badge>
+      </Card>
+    </div>
+  );
+};
+
+export const NumbersStatsSkeleton = () => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <Card className="p-6 bg-gradient-to-br from-purple-500 to-indigo-600 text-white">
+        <div className="flex justify-between items-start">
+          <div>
+            <p className="text-sm opacity-75">Total Listening Time</p>
+            <h2 className="text-4xl font-bold mt-2">
+              <Skeleton className="w-40 h-10 mt-4" />
+            </h2>
+          </div>
+          <Clock className="size-8 opacity-75" />
+        </div>
+        <p className="mt-4 text-sm opacity-75">
+          <Skeleton className="w-56 h-5 mt-6" />
+        </p>
+      </Card>
+
+      <Card className="p-6">
+        <div className="flex justify-between mb-4">
+          <div>
+            <p className="text-sm text-muted-foreground">Total Plays</p>
+            <h3 className="text-2xl font-semibold">
+              <Skeleton className="w-20 h-8 mt-1" />
+            </h3>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Unique Tracks</p>
+            <h3 className="text-2xl font-semibold">
+              <Skeleton className="w-20 h-8 mt-1" />
+            </h3>
+          </div>
+        </div>
+        <Progress className="h-2" />
+        <p className="text-sm text-muted-foreground mt-2">
+          <Skeleton className="w-44 h-5 mt-2" />
+        </p>
+      </Card>
+
+      <Card className="p-6 flex items-center space-x-4">
+        <Users className="size-12 text-indigo-500" />
+        <div>
+          <p className="text-sm text-muted-foreground">Different Artists</p>
+          <h3 className="text-3xl font-bold">
+            <Skeleton className="w-20 h-7 mt-2" />
+          </h3>
+          <p className="text-sm text-muted-foreground mt-1">
+            <Skeleton className="w-36 h-5 mt-4" />
+          </p>
+        </div>
+      </Card>
+
+      <Card className="p-6">
+        <h3 className="font-semibold mb-2">First Track of the Year</h3>
+        <div>
+          <ItemCard className="py-0">
+            <ItemCardImage src="" alt="" />
+            <ItemCardContent>
+              <ItemCardTitle>
+                <Skeleton className="w-32 h-5 mt-1" />
+              </ItemCardTitle>
+              <ItemCardSubtitle>
+                <Skeleton className="w-20 h-4 mt-1" />
+              </ItemCardSubtitle>
+            </ItemCardContent>
+          </ItemCard>
+          <p className="mt-2 text-sm text-muted-foreground">
+            <Skeleton className="w-36 h-4 mt-1" />
+          </p>
+        </div>
+      </Card>
+
+      <Card className="p-6 bg-green-100 dark:bg-green-900">
+        <Calendar className="size-8 mb-2 text-green-600 dark:text-green-400" />
+        <h3 className="font-semibold">Most Active Day</h3>
+        <p className="text-2xl font-bold mt-1">
+          <Skeleton className="w-44 h-8 mt-2" />
+        </p>
+        <p className="text-sm text-muted-foreground mt-1">
+          <Skeleton className="w-52 h-5 mt-3" />
+        </p>
+      </Card>
+
+      <Card className="p-6 flex flex-col justify-between h-full">
+        <div className="flex justify-between mb-4">
+          <div>
+            <p className="text-sm text-muted-foreground">Online Listening</p>
+            <h3 className="text-4xl font-semibold">
+              <Skeleton className="w-24 h-10 mt-3" />
+            </h3>
+          </div>
+        </div>
+        <Progress className="h-2" />
+        <p className="text-sm text-muted-foreground mt-2">
+          <Skeleton className="w-64 h-5 mt-1" />
+        </p>
+      </Card>
+
+      <Card className="p-6 bg-red-100 dark:bg-red-900">
+        <div className="flex justify-between items-start mb-4">
+          <h3 className="font-semibold">Most Forwarded Track</h3>
+          <FastForward className="size-5 text-red-500 dark:text-red-400" />
+        </div>
+        <div className="flex items-center space-x-3">
+          <ItemCard className="py-0">
+            <ItemCardImage src="" alt="" />
+            <ItemCardContent>
+              <ItemCardTitle>
+                <Skeleton className="w-32 h-5 mt-1" />
+              </ItemCardTitle>
+              <ItemCardSubtitle>
+                <Skeleton className="w-20 h-4 mt-1" />
+              </ItemCardSubtitle>
+            </ItemCardContent>
+          </ItemCard>
+        </div>
+        <Skeleton className="w-32 h-6 mt-3" />
       </Card>
     </div>
   );

--- a/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
+++ b/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
@@ -104,7 +104,11 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
         />
         <p className="text-sm text-muted-foreground mt-2">
           <NumberFlow
-            value={data.uniqueTracks / data.totalPlays}
+            value={
+              data.uniqueTracks && data.totalPlays
+                ? data.uniqueTracks / data.totalPlays
+                : 0
+            }
             format={{ style: "percent" }}
             locales="en-US"
             suffix=" of your plays were unique tracks"
@@ -146,7 +150,11 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
           </ItemCard>
           <p className="mt-2 text-sm text-muted-foreground">
             Played on{" "}
-            <NumbersFlowDate value={data.firstTrack.timestamp} showTime />
+            {data.firstTrack.timestamp ? (
+              <NumbersFlowDate value={data.firstTrack.timestamp} showTime />
+            ) : (
+              "an unknown date"
+            )}
           </p>
         </div>
       </Card>
@@ -156,7 +164,11 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
         <Calendar className="size-8 mb-2 text-green-600 dark:text-green-400" />
         <h3 className="font-semibold">Most Active Day</h3>
         <p className="text-2xl font-bold mt-1">
-          <NumbersFlowDate value={new Date(data.mostActiveDay.day)} />
+          {data.mostActiveDay.day ? (
+            <NumbersFlowDate value={new Date(data.mostActiveDay.day)} />
+          ) : (
+            "No data available"
+          )}
         </p>
         <p className="text-sm text-muted-foreground mt-1">
           <NumberFlow

--- a/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
+++ b/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import React from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@repo/ui/avatar";
+import { Badge } from "@repo/ui/badge";
+import { Card } from "@repo/ui/card";
+import { NumberFlow } from "@repo/ui/number";
+import { Progress } from "@repo/ui/progress";
+import { useQuery } from "@tanstack/react-query";
+import { Calendar, Clock, FastForward, Users } from "lucide-react";
+
+import { getNumbersStatsAction } from "~/actions/get-numbers-stats-actions";
+import { addMonths } from "~/components/month-range-picker";
+import { useRankingTimeRange } from "~/lib/store";
+
+type InitialData = Awaited<ReturnType<typeof getNumbersStatsAction>>;
+
+type NumbersStatsCardsProps = {
+  initialData: InitialData;
+};
+
+const msToHours = (ms: number) => ms / 1000 / 60 / 60;
+
+const useNumbersStats = (
+  minDate: Date,
+  maxDate: Date,
+  initialData: InitialData,
+) =>
+  useQuery({
+    queryKey: ["numbersStats", minDate, maxDate],
+    queryFn: async () => await getNumbersStatsAction(minDate, maxDate),
+    initialData,
+  });
+
+export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
+  const dates = useRankingTimeRange((state) => state.dates);
+  const { data, isLoading, isError } = useNumbersStats(
+    new Date(dates.start),
+    addMonths(new Date(dates.end), 1),
+    initialData,
+  );
+
+  if (isLoading) return null;
+  if (isError || !data) return null;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {/* Listening Time */}
+      <Card className="p-6 bg-gradient-to-br from-purple-500 to-indigo-600 text-white">
+        <div className="flex justify-between items-start">
+          <div>
+            <p className="text-sm opacity-75">Total Listening Time</p>
+            <h2 className="text-4xl font-bold mt-2">
+              <NumberFlow value={msToHours(data.listeningTime).toFixed(2)} />{" "}
+              hours
+            </h2>
+          </div>
+          <Clock className="size-8 opacity-75" />
+        </div>
+        <p className="mt-4 text-sm opacity-75">
+          That's about{" "}
+          <NumberFlow value={Math.round(msToHours(data.listeningTime) / 24)} />{" "}
+          days of non-stop music!
+        </p>
+      </Card>
+
+      {/* Total Plays and Unique Tracks */}
+      <Card className="p-6">
+        <div className="flex justify-between mb-4">
+          <div>
+            <p className="text-sm text-muted-foreground">Total Plays</p>
+            <h3 className="text-2xl font-semibold">{data.totalPlays}</h3>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Unique Tracks</p>
+            <h3 className="text-2xl font-semibold">4,395</h3>
+          </div>
+        </div>
+        <Progress value={18} className="h-2" />
+        <p className="text-sm text-muted-foreground mt-2">
+          18% of your plays were unique tracks
+        </p>
+      </Card>
+
+      {/* Different Artists */}
+      <Card className="p-6 flex items-center space-x-4">
+        <Users className="size-12 text-indigo-500" />
+        <div>
+          <p className="text-sm text-muted-foreground">Different Artists</p>
+          <h3 className="text-3xl font-bold">1,431</h3>
+          <p className="text-sm text-muted-foreground mt-1">
+            Explored in your musical journey
+          </p>
+        </div>
+      </Card>
+
+      {/* First Track */}
+      <Card className="p-6">
+        <h3 className="font-semibold mb-2">First Track of the Year</h3>
+        <div className="flex items-center space-x-4">
+          <Avatar className="size-16">
+            <AvatarImage
+              src="https://i.scdn.co/image/ab67616d0000b27398ea0e689c91f8fea726d9bb"
+              alt="Control by Playboi Carti"
+            />
+            <AvatarFallback>PC</AvatarFallback>
+          </Avatar>
+          <div>
+            <p className="font-medium">Control</p>
+            <p className="text-sm text-muted-foreground">Playboi Carti</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Played on Jan 1, 2024 at 00:28
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      {/* Most Played Day */}
+      <Card className="p-6 bg-green-100 dark:bg-green-900">
+        <Calendar className="size-8 mb-2 text-green-600 dark:text-green-400" />
+        <h3 className="font-semibold">Most Active Day</h3>
+        <p className="text-2xl font-bold mt-1">April 28, 2024</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          You played 231 tracks
+        </p>
+      </Card>
+
+      {/* Online Track Percent */}
+      <Card className="p-6 flex flex-col justify-between h-full">
+        <div>
+          <h3 className="font-semibold mb-2">Online Listening</h3>
+          <p className="text-4xl font-bold">
+            98<span className="text-2xl">%</span>
+          </p>
+        </div>
+        <p className="text-sm text-muted-foreground mt-4">
+          You mostly listen to music while connected to the internet
+        </p>
+      </Card>
+
+      {/* Most Skipped Track */}
+      <Card className="p-6 bg-red-100 dark:bg-red-900">
+        <div className="flex justify-between items-start mb-4">
+          <h3 className="font-semibold">Most Skipped Track</h3>
+          <FastForward className="size-5 text-red-500 dark:text-red-400" />
+        </div>
+        <div className="flex items-center space-x-3">
+          <Avatar className="size-12">
+            <AvatarImage
+              src="https://i.scdn.co/image/ab67616d0000b273ca15942c726ec9c39796435e"
+              alt="ALL RED by Playboi Carti"
+            />
+            <AvatarFallback>PC</AvatarFallback>
+          </Avatar>
+          <div>
+            <p className="font-medium">ALL RED</p>
+            <p className="text-sm text-muted-foreground">Playboi Carti</p>
+          </div>
+        </div>
+        <Badge className="mt-3" variant="outline">
+          Skipped 29 times
+        </Badge>
+      </Card>
+    </div>
+  );
+};

--- a/apps/web/app/(app)/stats/numbers/numbers-stats-sessions-card.tsx
+++ b/apps/web/app/(app)/stats/numbers/numbers-stats-sessions-card.tsx
@@ -2,6 +2,7 @@
 
 import { Card } from "@repo/ui/card";
 import { NumberFlow } from "@repo/ui/number";
+import { Skeleton } from "@repo/ui/skeleton";
 import { useQuery } from "@tanstack/react-query";
 
 import { getNumbersSessionStatsAction } from "~/actions/get-numbers-session-stats-action";
@@ -88,6 +89,28 @@ export const NumbersStatsSessionCard = ({
               suffix=" minutes"
             />
           </p>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export const NumbersStatsSessionSkeleton = () => {
+  return (
+    <Card className="p-6 col-span-full">
+      <h3 className="font-semibold mb-4">Listening Sessions</h3>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+          <p className="text-sm text-muted-foreground">Total Sessions</p>
+          <Skeleton className="w-20 h-7 mt-1" />
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">Average Session</p>
+          <Skeleton className="w-36 h-7 mt-1" />
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">Longest Session</p>
+          <Skeleton className="w-48 h-7 mt-1" />
         </div>
       </div>
     </Card>

--- a/apps/web/app/(app)/stats/numbers/numbers-stats-sessions-card.tsx
+++ b/apps/web/app/(app)/stats/numbers/numbers-stats-sessions-card.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Card } from "@repo/ui/card";
+import { NumberFlow } from "@repo/ui/number";
+import { useQuery } from "@tanstack/react-query";
+
+import { getNumbersSessionStatsAction } from "~/actions/get-numbers-session-stats-action";
+import { addMonths } from "~/components/month-range-picker";
+import { useRankingTimeRange } from "~/lib/store";
+
+type InitialData = Awaited<ReturnType<typeof getNumbersSessionStatsAction>>;
+
+type NumbersStatsCardsProps = {
+  initialData: InitialData;
+};
+
+const getMsToHoursAndMinutes = (ms: number) => {
+  const hours = Math.floor(ms / 1000 / 60 / 60);
+  const minutes = Math.floor((ms / 1000 / 60) % 60);
+
+  return { hours, minutes };
+};
+
+const useNumbersSessionStats = (
+  minDate: Date,
+  maxDate: Date,
+  initialData: InitialData,
+) =>
+  useQuery({
+    queryKey: ["numbersSessionStats", minDate, maxDate],
+    queryFn: async () => await getNumbersSessionStatsAction(minDate, maxDate),
+    initialData,
+  });
+
+export const NumbersStatsSessionCard = ({
+  initialData,
+}: NumbersStatsCardsProps) => {
+  const dates = useRankingTimeRange((state) => state.dates);
+  const { data, isLoading, isError } = useNumbersSessionStats(
+    new Date(dates.start),
+    addMonths(new Date(dates.end), 1),
+    initialData,
+  );
+
+  if (isLoading) return null;
+  if (isError || !data) return null;
+
+  return (
+    <Card className="p-6 col-span-full">
+      <h3 className="font-semibold mb-4">Listening Sessions</h3>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+          <p className="text-sm text-muted-foreground">Total Sessions</p>
+          {/* <p className="text-2xl font-bold">1,447</p> */}
+          <p className="text-2xl font-bold">
+            <NumberFlow
+              value={data.totalSessions}
+              format={{ notation: "standard" }}
+              locales="en-US"
+            />
+          </p>
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">Average Session</p>
+          <p className="text-2xl font-bold">
+            <NumberFlow
+              value={Math.floor(data.averageSessionTime / 1000 / 60)}
+              format={{ notation: "standard" }}
+              locales="en-US"
+              suffix=" minutes"
+            />
+          </p>
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">Longest Session</p>
+          {/* <p className="text-2xl font-bold">6 hours 54 minutes</p> */}
+          <p className="text-2xl font-bold">
+            <NumberFlow
+              value={getMsToHoursAndMinutes(data.longestSession).hours}
+              format={{ notation: "standard" }}
+              locales="en-US"
+              suffix=" hours "
+            />
+            <NumberFlow
+              value={getMsToHoursAndMinutes(data.longestSession).minutes}
+              format={{ notation: "standard" }}
+              locales="en-US"
+              suffix=" minutes"
+            />
+          </p>
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/apps/web/app/(app)/stats/numbers/page.tsx
+++ b/apps/web/app/(app)/stats/numbers/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import { getNumbersSessionStatsAction } from "~/actions/get-numbers-session-stats-action";
 import { getNumbersStatsAction } from "~/actions/get-numbers-stats-actions";
 import { AppHeader } from "~/components/app-header";
@@ -5,22 +7,21 @@ import { SelectMonthRange } from "~/components/select-month-range";
 import { addMonths, getCookieRankingTimeRange } from "~/lib/utils-server";
 
 import { NumbersStatsCards } from "./numbers-stats-cards";
+import { NumbersStatsSessionCard } from "./numbers-stats-sessions-card";
 
-export default async function StatsNumbersPage() {
-  const dates = await getCookieRankingTimeRange();
-  const dataSession = await getNumbersSessionStatsAction(
-    dates.dateStart,
-    addMonths(dates.dateEnd, 1),
-  );
-
+export default function StatsNumbersPage() {
   return (
     <>
       <AppHeader items={["Package", "Stats", "Numbers"]}>
         <SelectMonthRange />
       </AppHeader>
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <pre>{JSON.stringify(dataSession, null, 2)}</pre>
-        <NumbersStatsCardsWrapper />
+        <Suspense fallback={null}>
+          <NumbersStatsCardsWrapper />
+        </Suspense>
+        <Suspense fallback={null}>
+          <NumbersStatsSessionCardsWrapper />
+        </Suspense>
       </div>
     </>
   );
@@ -34,4 +35,14 @@ const NumbersStatsCardsWrapper = async () => {
   );
 
   return <NumbersStatsCards initialData={initialData} />;
+};
+
+const NumbersStatsSessionCardsWrapper = async () => {
+  const dates = await getCookieRankingTimeRange();
+  const initialData = await getNumbersSessionStatsAction(
+    dates.dateStart,
+    addMonths(dates.dateEnd, 1),
+  );
+
+  return <NumbersStatsSessionCard initialData={initialData} />;
 };

--- a/apps/web/app/(app)/stats/numbers/page.tsx
+++ b/apps/web/app/(app)/stats/numbers/page.tsx
@@ -1,16 +1,25 @@
+import { getNumbersSessionStatsAction } from "~/actions/get-numbers-session-stats-action";
+import { getNumbersStatsAction } from "~/actions/get-numbers-stats-actions";
 import { AppHeader } from "~/components/app-header";
+import { addMonths, getCookieRankingTimeRange } from "~/lib/utils-server";
 
-export default function StatsNumbersPage() {
+export default async function StatsNumbersPage() {
+  const dates = await getCookieRankingTimeRange();
+  const dataSession = await getNumbersSessionStatsAction(
+    dates.dateStart,
+    addMonths(dates.dateEnd, 1),
+  );
+  const data = await getNumbersStatsAction(
+    dates.dateStart,
+    addMonths(dates.dateEnd, 1),
+  );
+
   return (
     <>
       <AppHeader items={["Package", "Stats", "Activity"]} />
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-          <div className="aspect-video rounded-xl bg-muted/50" />
-          <div className="aspect-video rounded-xl bg-muted/50" />
-          <div className="aspect-video rounded-xl bg-muted/50" />
-        </div>
-        <div className="min-h-screen flex-1 rounded-xl bg-muted/50 md:min-h-min" />
+        <pre>{JSON.stringify(dataSession, null, 2)}</pre>
+        <pre>{JSON.stringify(data, null, 2)}</pre>
       </div>
     </>
   );

--- a/apps/web/app/(app)/stats/numbers/page.tsx
+++ b/apps/web/app/(app)/stats/numbers/page.tsx
@@ -1,7 +1,10 @@
 import { getNumbersSessionStatsAction } from "~/actions/get-numbers-session-stats-action";
 import { getNumbersStatsAction } from "~/actions/get-numbers-stats-actions";
 import { AppHeader } from "~/components/app-header";
+import { SelectMonthRange } from "~/components/select-month-range";
 import { addMonths, getCookieRankingTimeRange } from "~/lib/utils-server";
+
+import { NumbersStatsCards } from "./numbers-stats-cards";
 
 export default async function StatsNumbersPage() {
   const dates = await getCookieRankingTimeRange();
@@ -9,18 +12,26 @@ export default async function StatsNumbersPage() {
     dates.dateStart,
     addMonths(dates.dateEnd, 1),
   );
-  const data = await getNumbersStatsAction(
-    dates.dateStart,
-    addMonths(dates.dateEnd, 1),
-  );
 
   return (
     <>
-      <AppHeader items={["Package", "Stats", "Activity"]} />
+      <AppHeader items={["Package", "Stats", "Numbers"]}>
+        <SelectMonthRange />
+      </AppHeader>
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
         <pre>{JSON.stringify(dataSession, null, 2)}</pre>
-        <pre>{JSON.stringify(data, null, 2)}</pre>
+        <NumbersStatsCardsWrapper />
       </div>
     </>
   );
 }
+
+const NumbersStatsCardsWrapper = async () => {
+  const dates = await getCookieRankingTimeRange();
+  const initialData = await getNumbersStatsAction(
+    dates.dateStart,
+    addMonths(dates.dateEnd, 1),
+  );
+
+  return <NumbersStatsCards initialData={initialData} />;
+};

--- a/apps/web/app/(app)/stats/numbers/page.tsx
+++ b/apps/web/app/(app)/stats/numbers/page.tsx
@@ -6,8 +6,11 @@ import { AppHeader } from "~/components/app-header";
 import { SelectMonthRange } from "~/components/select-month-range";
 import { addMonths, getCookieRankingTimeRange } from "~/lib/utils-server";
 
-import { NumbersStatsCards } from "./numbers-stats-cards";
-import { NumbersStatsSessionCard } from "./numbers-stats-sessions-card";
+import { NumbersStatsCards, NumbersStatsSkeleton } from "./numbers-stats-cards";
+import {
+  NumbersStatsSessionCard,
+  NumbersStatsSessionSkeleton,
+} from "./numbers-stats-sessions-card";
 
 export default function StatsNumbersPage() {
   return (
@@ -15,12 +18,12 @@ export default function StatsNumbersPage() {
       <AppHeader items={["Package", "Stats", "Numbers"]}>
         <SelectMonthRange />
       </AppHeader>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <Suspense fallback={null}>
-          <NumbersStatsCardsWrapper />
-        </Suspense>
-        <Suspense fallback={null}>
+      <div className="flex flex-1 flex-col gap-4 p-4 max-w-7xl w-full mx-auto">
+        <Suspense fallback={<NumbersStatsSessionSkeleton />}>
           <NumbersStatsSessionCardsWrapper />
+        </Suspense>
+        <Suspense fallback={<NumbersStatsSkeleton />}>
+          <NumbersStatsCardsWrapper />
         </Suspense>
       </div>
     </>

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { Suspense } from "react";
 import { Button } from "@repo/ui/button";
 import { AlertCircle } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
 
 import { Icons } from "~/components/icons";
 import { ThemeToggle } from "~/components/theme-toggle";

--- a/apps/web/components/item-card.tsx
+++ b/apps/web/components/item-card.tsx
@@ -41,8 +41,8 @@ ItemCardRank.displayName = "ItemCardRank";
 const ItemCardImage = React.forwardRef<
   HTMLDivElement,
   Omit<React.ComponentPropsWithoutRef<"div">, "children"> & {
-    src?: string;
-    alt?: string;
+    src?: string | null;
+    alt?: string | null;
     layout?: "grid" | "list";
   }
 >(({ className, src, alt, layout = "list", ...props }, ref) => (

--- a/apps/web/components/item-card.tsx
+++ b/apps/web/components/item-card.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Slot } from "@radix-ui/react-slot";
+import { Avatar, AvatarFallback, AvatarImage } from "@repo/ui/avatar";
 import { cn } from "@repo/ui/lib/utils";
 import { format } from "light-date";
-import { Clock, ExternalLink } from "lucide-react";
+import { Clock, ExternalLink, Music2 } from "lucide-react";
 import Image from "next/image";
 
 const ItemCard = React.forwardRef<
@@ -40,19 +41,26 @@ ItemCardRank.displayName = "ItemCardRank";
 const ItemCardImage = React.forwardRef<
   HTMLDivElement,
   Omit<React.ComponentPropsWithoutRef<"div">, "children"> & {
-    src: string;
-    alt: string;
+    src?: string;
+    alt?: string;
     layout?: "grid" | "list";
   }
 >(({ className, src, alt, layout = "list", ...props }, ref) => (
   <div ref={ref} {...props}>
-    <Image
-      src={src}
-      alt={alt}
-      width={layout === "grid" ? 200 : 64}
-      height={layout === "grid" ? 200 : 64}
-      className={cn("aspect-square rounded-md object-cover", className)}
-    />
+    <Avatar className={cn("rounded-md size-16", className)}>
+      <AvatarImage src={src!} asChild>
+        <Image
+          src={src!}
+          alt={alt!}
+          width={layout === "grid" ? 200 : 64}
+          height={layout === "grid" ? 200 : 64}
+          className={cn("aspect-square rounded-md object-cover")}
+        />
+      </AvatarImage>
+      <AvatarFallback className="rounded-md">
+        <Music2 />
+      </AvatarFallback>
+    </Avatar>
   </div>
 ));
 ItemCardImage.displayName = "ItemCardImage";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1746,6 +1746,45 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.0.tgz",
+      "integrity": "sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz",
@@ -9515,6 +9554,7 @@
         "@radix-ui/react-hover-card": "^1.1.2",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.2",
+        "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9562,6 +9562,7 @@
         "@radix-ui/react-tooltip": "^1.1.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "light-date": "^1.2.0",
         "lucide-react": "^0.454.0",
         "next-themes": "^0.4.3",
         "recharts": "^2.14.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,8 @@
     "sonner": "^1.7.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.1"
+    "vaul": "^1.1.1",
+    "light-date": "^1.2.0"
   },
   "exports": {
     "./globals.css": "./src/globals.css",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@number-flow/react": "^0.4.2",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",
@@ -28,6 +29,7 @@
     "@radix-ui/react-hover-card": "^1.1.2",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.2",
+    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
@@ -41,8 +43,7 @@
     "sonner": "^1.7.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.1",
-    "@number-flow/react": "^0.4.2"
+    "vaul": "^1.1.1"
   },
   "exports": {
     "./globals.css": "./src/globals.css",

--- a/packages/ui/src/components/ui/number.tsx
+++ b/packages/ui/src/components/ui/number.tsx
@@ -1,14 +1,63 @@
 import NumberFlowPrimitive from "@number-flow/react";
+import { format, localeFormat } from "light-date";
 
-type NumberFlowProps = {
+type NumberFlowProps = Omit<Parameters<typeof NumberFlowPrimitive>[0], 'value'> & {
   value: number | string;
 };
 
-export const NumberFlow = ({ value }: NumberFlowProps) => {
+export const NumberFlow = ({ value, ...props }: NumberFlowProps) => {
   return (
     <NumberFlowPrimitive
-      transformTiming={{ duration: 500, easing: "ease-out" }}
+      transformTiming={{ duration: 500, easing: "ease-in-out" }}
       value={Number(value)}
+      {...props}
     />
+  )
+}
+
+type NumbersFlowDateProps = {
+  value: Date;
+  showTime?: boolean;
+}
+
+export const NumbersFlowDate = ({ value, showTime }: NumbersFlowDateProps) => {
+  const month = localeFormat(value, "{MMMM}")
+  const day = format(value, "{dd}")
+  const year = format(value, "{yyyy}")
+  const hour = format(value, "{HH}")
+  const minute = format(value, "{mm}")
+
+  return (
+    <span>{month}
+      <NumberFlow
+        value={day}
+        format={{ notation: "standard" }}
+        locales="en-US"
+        prefix=" "
+        suffix=", "
+      />
+      <NumberFlow
+        value={year}
+        prefix=""
+        format={{ useGrouping: false }}
+        suffix={showTime ? " at " : ""}
+      />
+      {showTime && (
+        <>
+          <NumberFlow
+            value={hour}        
+            locales="en-US"
+            prefix=""
+            suffix=":"
+          />
+          <NumberFlow
+            value={minute}
+            format={{ notation: "standard" }}
+            locales="en-US"
+            prefix=""
+          />
+        </>
+      )}
+    </span>
   )
 }

--- a/packages/ui/src/components/ui/number.tsx
+++ b/packages/ui/src/components/ui/number.tsx
@@ -21,6 +21,7 @@ type NumbersFlowDateProps = {
 }
 
 export const NumbersFlowDate = ({ value, showTime }: NumbersFlowDateProps) => {
+
   const month = localeFormat(value, "{MMMM}")
   const day = format(value, "{dd}")
   const year = format(value, "{yyyy}")

--- a/packages/ui/src/components/ui/progress.tsx
+++ b/packages/ui/src/components/ui/progress.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+import { cn } from "../../lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/packages/ui/src/components/ui/progress.tsx
+++ b/packages/ui/src/components/ui/progress.tsx
@@ -17,7 +17,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="h-full w-full flex-1 bg-primary transition-al"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
This pull request introduces new functionalities for retrieving and displaying user statistics related to their music listening habits. The changes include new actions for fetching session and track statistics, as well as new components for displaying these statistics in the user interface.

### New Actions:
* [`apps/web/actions/get-numbers-session-stats-action.ts`](diffhunk://#diff-3d775e3faa99583b105b40de9700562f3ef13d6a581ad58efbb65a9e6beb3f4cR1-R77): Added a new action to fetch session statistics, including total sessions, average session time, and longest session.
* [`apps/web/actions/get-numbers-stats-actions.ts`](diffhunk://#diff-61e864acfe614debcc15e7d1fc1937858e8a6c74704d9c4091294eabf0d0bba9R1-R191): Added a new action to fetch detailed track statistics, such as listening time, total plays, unique tracks, and more.

### New Components:
* [`apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx`](diffhunk://#diff-9237b98674b6f4efeeb89aef4e1db3b6d792b986aea3e59c79cd6091fcc462e4R1-R367): Added a new component to display various statistics cards, including total listening time, total plays, unique tracks, different artists, first track of the year, most active day, online listening percentage, and most forwarded track.
* [`apps/web/app/(app)/stats/numbers/numbers-stats-sessions-card.tsx`](diffhunk://#diff-ea43c112f2afca54f81583692250a940cbf7ff51685547472e602ba45990d54cR1-R118): Added a new component to display session statistics, including total sessions, average session time, and longest session.