### PR TITLE
Feat/stats numbers page

### DIFF
--- a/apps/web/actions/get-numbers-stats-actions.ts
+++ b/apps/web/actions/get-numbers-stats-actions.ts
@@ -67,10 +67,16 @@ export const getNumbersStatsAction = async (minDate: Date, maxDate: Date) => {
     };
 
   const stats = calculateStats(tracks);
-  const trackDetails = await fetchTrackDetails(
-    tracks,
-    stats.mostFwdbtnTrack.spotifyId,
-  );
+  let trackDetails: SpotifyTrack[] = [];
+  try {
+    trackDetails = await fetchTrackDetails(
+      tracks,
+      stats.mostFwdbtnTrack.spotifyId,
+    );
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
 
   return formatResponse(stats, tracks, trackDetails);
 };

--- a/apps/web/app/(app)/stats/listening-habits/days-habit-chart.tsx
+++ b/apps/web/app/(app)/stats/listening-habits/days-habit-chart.tsx
@@ -62,6 +62,7 @@ export const DaysHabitChart = ({ initialData }: DaysHabitChartProps) => {
         margin={{
           left: 12,
           right: 12,
+          top: 12,
         }}
       >
         <CartesianGrid vertical={false} />

--- a/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
+++ b/apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx
@@ -136,7 +136,7 @@ export const NumbersStatsCards = ({ initialData }: NumbersStatsCardsProps) => {
 
       {/* First Track */}
       <Card className="p-6">
-        <h3 className="font-semibold mb-2">First Track of the Year</h3>
+        <h3 className="font-semibold mb-2">First Track you played</h3>
         <div>
           <ItemCard className="py-0">
             <ItemCardImage


### PR DESCRIPTION
This pull request includes several changes to improve error handling, UI consistency, and code formatting in the `apps/web` directory. The most important changes include adding error handling for fetching track details, updating chart margins, and modifying card titles for clarity.

Error handling improvements:

* [`apps/web/actions/get-numbers-stats-actions.ts`](diffhunk://#diff-61e864acfe614debcc15e7d1fc1937858e8a6c74704d9c4091294eabf0d0bba9L70-R79): Added a try-catch block around the `fetchTrackDetails` function to handle errors and return null if an error occurs.

UI consistency:

* [`apps/web/app/(app)/stats/listening-habits/days-habit-chart.tsx`](diffhunk://#diff-50ff0613f831a1349201cc86af9fd672403611903f93c32247f7d0f52e03868aR65): Added a top margin to the chart component for consistent spacing.
* [`apps/web/app/(app)/stats/numbers/numbers-stats-cards.tsx`](diffhunk://#diff-9237b98674b6f4efeeb89aef4e1db3b6d792b986aea3e59c79cd6091fcc462e4L139-R139): Updated the title of the first track card to "First Track you played" for better clarity.