### PR TITLE
feat: implement loading state for demo button

### DIFF
--- a/apps/web/components/get-demo-btn.tsx
+++ b/apps/web/components/get-demo-btn.tsx
@@ -1,15 +1,21 @@
 "use client";
 
+import { useTransition } from "react";
 import { signIn } from "@repo/auth/actions";
 import { Button } from "@repo/ui/button";
+import { LoaderCircle } from "lucide-react";
 
 export const GetDemoBtn = () => {
-  const onClick = async () => {
-    await signIn("credentials", {
-      username: "demo",
-      password: "demo",
-      redirect: true,
-      redirectTo: "/settings/about",
+  const [isTransition, transition] = useTransition();
+
+  const onClick = () => {
+    transition(async () => {
+      await signIn("credentials", {
+        username: "demo",
+        password: "demo",
+        redirect: true,
+        redirectTo: "/settings/about",
+      });
     });
   };
 
@@ -19,7 +25,16 @@ export const GetDemoBtn = () => {
       variant="link"
       className="p-0 text-spotifygreen"
       data-testid="get-demo-btn"
+      disabled={isTransition}
     >
+      {isTransition ? (
+        <LoaderCircle
+          className="-ms-1 me-2 animate-spin"
+          size={16}
+          strokeWidth={2}
+          aria-hidden="true"
+        />
+      ) : null}
       Get a demo of Harmony
     </Button>
   );

--- a/packages/auth/src/auth.config.ts
+++ b/packages/auth/src/auth.config.ts
@@ -49,5 +49,9 @@ export default {
   },
   pages: {
     error: "/error",
+    signIn: "/",
+    signOut: "/",
+    newUser: "/",
+    verifyRequest: "/",
   },
 } satisfies NextAuthConfig;


### PR DESCRIPTION
This pull request includes changes to improve the user experience of the "Get Demo" button and update the authentication configuration. The most important changes are as follows:

Improvements to the "Get Demo" button:

* [`apps/web/components/get-demo-btn.tsx`](diffhunk://#diff-e942dad38b11b525f11a047f891c69953398f04d59a2061ec1f599cdb802d6f1R3-R19): Added `useTransition` hook to manage the button's state during the sign-in process, and included a `LoaderCircle` to indicate loading. [[1]](diffhunk://#diff-e942dad38b11b525f11a047f891c69953398f04d59a2061ec1f599cdb802d6f1R3-R19) [[2]](diffhunk://#diff-e942dad38b11b525f11a047f891c69953398f04d59a2061ec1f599cdb802d6f1R28-R37)

Updates to authentication configuration:

* [`packages/auth/src/auth.config.ts`](diffhunk://#diff-2df152787e3b7101ba9d386f4a93155572707095c72bffd924f0095977cb78f7R52-R55): Added routes for `signIn`, `signOut`, `newUser`, and `verifyRequest` pages in the authentication configuration.