### PR TITLE
fix: typeerror serialize bigint remove cache chart data

### DIFF
--- a/apps/web/app/(app)/stats/listening-habits/get-charts-data.ts
+++ b/apps/web/app/(app)/stats/listening-habits/get-charts-data.ts
@@ -1,7 +1,6 @@
 "server-only";
 
 import { prisma } from "@repo/database";
-import { unstable_cache as cache } from "next/cache";
 
 import { getMonthRangeAction } from "~/actions/month-range-actions";
 
@@ -193,21 +192,19 @@ export const getDaysHabit = async (userId: string | undefined) => {
   }));
 };
 
-const getTracks = cache(
-  async (userId: string, dateStart: Date, dateEnd: Date) => {
-    return prisma.track.findMany({
-      where: {
-        userId,
-        timestamp: {
-          gte: dateStart,
-          lt: dateEnd,
-        },
+const getTracks = async (userId: string, dateStart: Date, dateEnd: Date) => {
+  return prisma.track.findMany({
+    where: {
+      userId,
+      timestamp: {
+        gte: dateStart,
+        lt: dateEnd,
       },
-      select: {
-        timestamp: true,
-        msPlayed: true,
-        platform: true,
-      },
-    });
-  },
-);
+    },
+    select: {
+      timestamp: true,
+      msPlayed: true,
+      platform: true,
+    },
+  });
+};


### PR DESCRIPTION
This pull request focuses on simplifying the caching mechanism in the `get-charts-data.ts` file. The most important changes involve removing the use of the `unstable_cache` function and refactoring the `getTracks` function to be a regular asynchronous function.

Codebase simplification:

* [`apps/web/app/(app)/stats/listening-habits/get-charts-data.ts`](diffhunk://#diff-215fa842df702501e2e0a88950508acb379250c4cb5d62bbecef2630a281fb34L4): Removed the import of `unstable_cache` from `next/cache`.
* [`apps/web/app/(app)/stats/listening-habits/get-charts-data.ts`](diffhunk://#diff-215fa842df702501e2e0a88950508acb379250c4cb5d62bbecef2630a281fb34L196-R195): Refactored the `getTracks` function to be a regular asynchronous function instead of using the `cache` function. [[1]](diffhunk://#diff-215fa842df702501e2e0a88950508acb379250c4cb5d62bbecef2630a281fb34L196-R195) [[2]](diffhunk://#diff-215fa842df702501e2e0a88950508acb379250c4cb5d62bbecef2630a281fb34L212-R210)