### PR TITLE
fix: convert values to numbers for monthly data and top platforms

### DIFF
--- a/apps/web/app/(app)/stats/activity/get-data.ts
+++ b/apps/web/app/(app)/stats/activity/get-data.ts
@@ -64,9 +64,9 @@ export const getMonthlyData = async (userId: string | undefined) => {
   return {
     data: Object.entries(data).map(([key, value]) => ({
       month: key,
-      value,
+      value: Number(value),
     })),
-    average: Math.round(average) || 0,
+    average: Number(Math.round(average)) || 0,
   };
 };
 

--- a/apps/web/app/(app)/stats/listening-habits/get-charts-data.ts
+++ b/apps/web/app/(app)/stats/listening-habits/get-charts-data.ts
@@ -106,7 +106,7 @@ export const getTopPlatforms = async (userId: string | undefined) => {
 
   return topPlatforms.map(([platform, msPlayed]) => ({
     platform,
-    msPlayed,
+    msPlayed: Number(msPlayed),
   }));
 };
 


### PR DESCRIPTION
This pull request includes changes to ensure numerical values are correctly cast to numbers in the statistics-related functions. The most important changes include modifications to the `getMonthlyData` and `getTopPlatforms` functions to ensure the returned data is consistently typed as numbers.

Type consistency improvements:

* [`apps/web/app/(app)/stats/activity/get-data.ts`](diffhunk://#diff-235f2867e3d656ce62806602ef1d80cf770b27b022cda43652b8a0086dcf1295L67-R69): Modified the `getMonthlyData` function to cast `value` and `average` to numbers.
* [`apps/web/app/(app)/stats/listening-habits/get-charts-data.ts`](diffhunk://#diff-215fa842df702501e2e0a88950508acb379250c4cb5d62bbecef2630a281fb34L109-R109): Modified the `getTopPlatforms` function to cast `msPlayed` to a number.