### PR TITLE
feat: add studio app with basic configuration and dependencies

### DIFF
--- a/apps/studio/.gitignore
+++ b/apps/studio/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+# Keep environment variables out of version control
+.env

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "studio",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "dotenv -e ../../.env -- prisma studio --schema ../../packages/database/prisma/schema.prisma --port 3005",
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "devDependencies": {
+    "prisma": "6.1.0"
+  }
+}

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@repo/typescript-config/nextjs.json",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
         "node": ">=18"
       }
     },
+    "apps/studio": {
+      "version": "0.0.0",
+      "devDependencies": {
+        "prisma": "6.1.0"
+      }
+    },
     "apps/web": {
       "version": "1.0.0",
       "dependencies": {
@@ -2615,53 +2621,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.0.1.tgz",
-      "integrity": "sha512-jQylgSOf7ibTVxqBacnAlVGvek6fQxJIYCQOeX2KexsfypNzXjJQSS2o5s+Mjj2Np93iSOQUaw6TvPj8syhG4w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.1.0.tgz",
+      "integrity": "sha512-0himsvcM4DGBTtvXkd2Tggv6sl2JyUYLzEGXXleFY+7Kp6rZeSS3hiTW9mwtUlXrwYbJP6pwlVNB7jYElrjWUg==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.0.1.tgz",
-      "integrity": "sha512-4hxzI+YQIR2uuDyVsDooFZGu5AtixbvM2psp+iayDZ4hRrAHo/YwgA17N23UWq7G6gRu18NvuNMb48qjP3DPQw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.1.0.tgz",
+      "integrity": "sha512-GnYJbCiep3Vyr1P/415ReYrgJUjP79fBNc1wCo7NP6Eia0CzL2Ot9vK7Infczv3oK7JLrCcawOSAxFxNFsAERQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.0.1",
-        "@prisma/engines-version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
-        "@prisma/fetch-engine": "6.0.1",
-        "@prisma/get-platform": "6.0.1"
+        "@prisma/debug": "6.1.0",
+        "@prisma/engines-version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+        "@prisma/fetch-engine": "6.1.0",
+        "@prisma/get-platform": "6.1.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e.tgz",
-      "integrity": "sha512-JmIds0Q2/vsOmnuTJYxY4LE+sajqjYKhLtdOT6y4imojqv5d/aeVEfbBGC74t8Be1uSp0OP8lxIj2OqoKbLsfQ==",
+      "version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959.tgz",
+      "integrity": "sha512-PdJqmYM2Fd8K0weOOtQThWylwjsDlTig+8Pcg47/jszMuLL9iLIaygC3cjWJLda69siRW4STlCTMSgOjZzvKPQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.0.1.tgz",
-      "integrity": "sha512-T36bWFVGeGYYSyYOj9d+O9G3sBC+pAyMC+jc45iSL63/Haq1GrYjQPgPMxrEj9m739taXrupoysRedQ+VyvM/Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.1.0.tgz",
+      "integrity": "sha512-asdFi7TvPlEZ8CzSZ/+Du5wZ27q6OJbRSXh+S8ISZguu+S9KtS/gP7NeXceZyb1Jv1SM1S5YfiCv+STDsG6rrg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.0.1",
-        "@prisma/engines-version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
-        "@prisma/get-platform": "6.0.1"
+        "@prisma/debug": "6.1.0",
+        "@prisma/engines-version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+        "@prisma/get-platform": "6.1.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.0.1.tgz",
-      "integrity": "sha512-zspC9vlxAqx4E6epMPMLLBMED2VD8axDe8sPnquZ8GOsn6tiacWK0oxrGK4UAHYzYUVuMVUApJbdXB2dFpLhvg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.1.0.tgz",
+      "integrity": "sha512-ia8bNjboBoHkmKGGaWtqtlgQOhCi7+f85aOkPJKgNwWvYrT6l78KgojLekE8zMhVk0R9lWcifV0Pf8l3/15V0Q==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.0.1"
+        "@prisma/debug": "6.1.0"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -11976,14 +11982,14 @@
       "license": "MIT"
     },
     "node_modules/prisma": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.0.1.tgz",
-      "integrity": "sha512-CaMNFHkf+DDq8zq3X/JJsQ4Koy7dyWwwtOKibkT/Am9j/tDxcfbg7+lB1Dzhx18G/+RQCMgjPYB61bhRqteNBQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.1.0.tgz",
+      "integrity": "sha512-aFI3Yi+ApUxkwCJJwyQSwpyzUX7YX3ihzuHNHOyv4GJg3X5tQsmRaJEnZ+ZyfHpMtnyahhmXVfbTZ+lS8ZtfKw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "6.0.1"
+        "@prisma/engines": "6.1.0"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -13320,6 +13326,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/studio": {
+      "resolved": "apps/studio",
+      "link": true
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",


### PR DESCRIPTION
This pull request includes the initial setup for the `studio` application. The most important changes include adding necessary files to `.gitignore`, defining the `package.json` with scripts and dependencies, and setting up the TypeScript configuration.

Initial setup for `studio` application:

* [`apps/studio/.gitignore`](diffhunk://#diff-ae6d05dfa2e9b9ebbde6c4d731b62b27d79458541bd4b46a835802a07a16d12cR1-R3): Added `node_modules` and `.env` to keep environment variables and dependencies out of version control.
* [`apps/studio/package.json`](diffhunk://#diff-14a87cb8301b0736bd6722d3ad7b33f96f0da057b76a9aa6d98537b2a5ff69ceR1-R12): Created `package.json` with scripts for development, cleaning, and type checking, and added `prisma` as a development dependency.
* [`apps/studio/tsconfig.json`](diffhunk://#diff-0744ab4ecab6b901a9ca7ece581e69b438b9ac8392b1494f0767b2c26514f768R1-R5): Added TypeScript configuration extending the repository's Next.js TypeScript configuration and including TypeScript files while excluding `node_modules`.