### PR TITLE
fix: simplify date formatting in time listened chart tooltip

### DIFF
--- a/apps/web/app/(app)/stats/activity/time-listened-chart.tsx
+++ b/apps/web/app/(app)/stats/activity/time-listened-chart.tsx
@@ -11,7 +11,6 @@ import {
 import { ChartConfig, ChartContainer, ChartTooltip } from "@repo/ui/chart";
 import { NumberFlow } from "@repo/ui/number";
 import { Skeleton } from "@repo/ui/skeleton";
-import { format } from "date-fns";
 import { TrendingDown, TrendingUp } from "lucide-react";
 import {
   Bar,
@@ -155,9 +154,7 @@ const CustomTooltip = ({ payload, chartData }: CustomTooltipProps) => {
 
   return (
     <div className="flex flex-col gap-1 p-2 bg-background shadow-lg rounded-md">
-      <div className="font-medium">
-        {format(new Date(currentData.month), "MMMM yyyy")}
-      </div>
+      <div className="font-medium">{currentData.month}</div>
       <div className="flex items-center gap-1">
         <div
           className="size-2.5 shrink-0 rounded-[2px] bg-[--color-bg]"


### PR DESCRIPTION
This pull request includes changes to the `apps/web/app/(app)/stats/activity/time-listened-chart.tsx` file, focusing on simplifying the code and removing unnecessary dependencies.

Code simplification:

* [`apps/web/app/(app)/stats/activity/time-listened-chart.tsx`](diffhunk://#diff-9b3900a631176cb750d0ab2c9f0d263c62f95df996e6e0f99069249fee4ca60eL14): Removed the import of the `format` function from `date-fns` as it is no longer needed.
* [`apps/web/app/(app)/stats/activity/time-listened-chart.tsx`](diffhunk://#diff-9b3900a631176cb750d0ab2c9f0d263c62f95df996e6e0f99069249fee4ca60eL158-R157): Simplified the `CustomTooltip` component by directly using `currentData.month` instead of formatting it with `date-fns`.