### PR TITLE
fix: Platform Usage chart wrong time range (#59)

### DIFF
--- a/apps/web/app/(app)/stats/activity/get-data.ts
+++ b/apps/web/app/(app)/stats/activity/get-data.ts
@@ -102,12 +102,15 @@ export const getMonthlyPlatformData = async (userId: string | undefined) => {
     const key = formatMonth(date);
     const platformKey = (
       Object.keys(PLATFORMS) as Array<keyof typeof PLATFORMS>
-    ).find((key) => PLATFORMS[key].includes(platform.platform));
+    ).find((key) =>
+      PLATFORMS[key].some((p) => platform.platform.toLowerCase().includes(p)),
+    );
 
     if (!platformKey) return;
 
     if (!data[key]) data[key] = {};
-    data[key][platformKey] = Number(platform.totalmsplayed);
+    data[key][platformKey] =
+      (data[key][platformKey] || 0) + Number(platform.totalmsplayed);
 
     const currentMsPlayed = platformsMap.get(platformKey) ?? 0;
     platformsMap.set(
@@ -117,8 +120,8 @@ export const getMonthlyPlatformData = async (userId: string | undefined) => {
   });
 
   const platformsLength = Array.from(platformsMap.values()).length;
-  const totalMsPlayed = platforms.reduce(
-    (acc, msPlayed) => acc + Number(msPlayed),
+  const totalMsPlayed = Array.from(platformsMap.values()).reduce(
+    (acc, msPlayed) => acc + msPlayed,
     0,
   );
 


### PR DESCRIPTION
This pull request includes changes to the `getMonthlyPlatformData` function in `apps/web/app/(app)/stats/activity/get-data.ts` to improve the handling of platform data aggregation. The most important changes include modifying the way platforms are matched and how the total milliseconds played are calculated.

Improvements to platform data aggregation:

* Modified the platform matching logic to use `some` and `toLowerCase` for more accurate matches.
* Changed the calculation of `data[key][platformKey]` to accumulate the total milliseconds played instead of overwriting it.
* Updated the calculation of `totalMsPlayed` to use `Array.from(platformsMap.values()).reduce` for more accurate aggregation.