### PR TITLE
fix(cron): update authorization check and add logging for ranking updates

### DIFF
--- a/apps/web/app/api/cron/update-rankings/route.ts
+++ b/apps/web/app/api/cron/update-rankings/route.ts
@@ -6,12 +6,15 @@ export const runtime = "nodejs";
 export const maxDuration = 60;
 
 export async function GET(request: NextRequest) {
-	// const authHeader = request.headers.get('authorization');
-	// if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-	//   return new Response('Unauthorized', {
-	// 	status: 401,
-	//   });
-	// }
+	const authHeader = request.headers.get("authorization");
+	if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+		return new Response("Unauthorized", {
+			status: 401,
+		});
+	}
+
+	console.log("Updating rankings");
+
 	try {
 		const users = await prisma.user.findMany();
 

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,7 +2,7 @@
 	"crons": [
 		{
 			"path": "/api/cron/update-rankings",
-			"schedule": "0 0 * * 1"
+			"schedule": "0 2 * * 0"
 		}
 	]
 }


### PR DESCRIPTION
This pull request makes updates to the `update-rankings` cron job in the `apps/web` project, including changes to authentication logic, logging, and the cron schedule.

### Authentication and Logging Updates:
* [`apps/web/app/api/cron/update-rankings/route.ts`](diffhunk://#diff-30f57f2a52885956689d6a6774c4e7a958068bbc81ce8bc58862e1bdc23b5cdaL9-R17): Re-enabled and updated the authentication check for the `authorization` header to ensure only authorized requests can trigger the cron job. Added a log statement (`console.log`) to indicate when rankings are being updated.

### Cron Schedule Change:
* [`apps/web/vercel.json`](diffhunk://#diff-361f945cebcf11354b7400e3c2b5f31c66b73f5c3a5b3f428a0a0f78d3bc898bL5-R5): Updated the cron schedule for the `update-rankings` route to run at 2:00 AM every Sunday instead of midnight every Monday.