### PR TITLE
Fix/update rankings cron job

### DIFF
--- a/apps/web/app/api/cron/update-rankings/route.ts
+++ b/apps/web/app/api/cron/update-rankings/route.ts
@@ -6,14 +6,12 @@ export const runtime = "nodejs";
 export const maxDuration = 60;
 
 export async function GET(request: NextRequest) {
-	const authHeader = request.headers.get("authorization");
-	if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-		return new Response("Unauthorized", {
-			status: 401,
-		});
-	}
-
-	console.log("Updating rankings");
+	// const authHeader = request.headers.get("authorization");
+	// if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+	// 	return new Response("Unauthorized", {
+	// 		status: 401,
+	// 	});
+	// }
 
 	try {
 		const users = await prisma.user.findMany();

--- a/apps/web/app/api/cron/update-rankings/route.ts
+++ b/apps/web/app/api/cron/update-rankings/route.ts
@@ -6,12 +6,12 @@ export const runtime = "nodejs";
 export const maxDuration = 60;
 
 export async function GET(request: NextRequest) {
-	// const authHeader = request.headers.get("authorization");
-	// if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-	// 	return new Response("Unauthorized", {
-	// 		status: 401,
-	// 	});
-	// }
+	const authHeader = request.headers.get("authorization");
+	if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+		return new Response("Unauthorized", {
+			status: 401,
+		});
+	}
 
 	try {
 		const users = await prisma.user.findMany();

--- a/apps/web/services/historical-rankings/index.ts
+++ b/apps/web/services/historical-rankings/index.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@repo/database";
-import { spotify } from "@repo/spotify";
+import { SpotifyAPI } from "@repo/spotify";
 import { getUserInfos } from "~/lib/utils";
 import { getTimeRangeStats } from "~/services/music-lists/get-top-data";
 
@@ -58,6 +58,13 @@ export async function updateHistoricalRankings(userId: string) {
 	const timeRanges = ["short_term", "medium_term", "long_term"] as const;
 	const allTrackRankings = [];
 	const allArtistRankings = [];
+
+	const spotify = new SpotifyAPI({
+		clientId: process.env.AUTH_SPOTIFY_ID || "missing",
+		clientSecret: process.env.AUTH_SPOTIFY_SECRET || "missing",
+		debug: true,
+		userId,
+	});
 
 	for (const timeRange of timeRanges) {
 		const topTracks = await spotify.me.top("tracks", timeRange);

--- a/packages/spotify/src/index.ts
+++ b/packages/spotify/src/index.ts
@@ -1,7 +1,9 @@
 import { SpotifyAPI } from "./lib/SpotifyAPI";
 
-export const spotify = new SpotifyAPI({
+const spotify = new SpotifyAPI({
 	clientId: process.env.AUTH_SPOTIFY_ID || "missing",
 	clientSecret: process.env.AUTH_SPOTIFY_SECRET || "missing",
 	debug: true,
 });
+
+export { spotify, SpotifyAPI };

--- a/packages/spotify/src/lib/http/AuthManager.ts
+++ b/packages/spotify/src/lib/http/AuthManager.ts
@@ -95,7 +95,9 @@ export class AuthManager {
 			return this.refreshPromise;
 		}
 
-		const session = await auth();
+		const session = this.config.userId
+			? { user: { id: this.config.userId } }
+			: await auth();
 
 		if (!session?.user?.id) {
 			throw new AuthError("No user session found");

--- a/packages/spotify/src/types/SpotifyConfig.ts
+++ b/packages/spotify/src/types/SpotifyConfig.ts
@@ -2,4 +2,5 @@ export interface SpotifyConfig {
 	clientId: string;
 	clientSecret: string;
 	debug?: boolean;
+	userId?: string;
 }


### PR DESCRIPTION
This pull request introduces changes to improve the handling of Spotify API interactions and refactors related code. Key updates include transitioning from a shared `spotify` instance to a per-user `SpotifyAPI` instance, adding user-specific configurations, and simplifying logging.

### Spotify API Refactor:
* [`apps/web/services/historical-rankings/index.ts`](diffhunk://#diff-0c8f5981bc8e66821d5415c9a0190cd5e4c1c32e1987e41820a01798395bea65R62-R68): Replaced the shared `spotify` instance with a new `SpotifyAPI` instance created per user, allowing user-specific configurations. (`[apps/web/services/historical-rankings/index.tsR62-R68](diffhunk://#diff-0c8f5981bc8e66821d5415c9a0190cd5e4c1c32e1987e41820a01798395bea65R62-R68)`)
* [`packages/spotify/src/index.ts`](diffhunk://#diff-4627f0e840fbbe70d626d6dfb12d56b24cb322f5a06029ea9bd32b3ef032a12aL3-R9): Updated the export structure to include both the `SpotifyAPI` class and the shared `spotify` instance, while ensuring the shared instance remains available for generic use. (`[packages/spotify/src/index.tsL3-R9](diffhunk://#diff-4627f0e840fbbe70d626d6dfb12d56b24cb322f5a06029ea9bd32b3ef032a12aL3-R9)`)

### User-Specific Configuration:
* [`packages/spotify/src/types/SpotifyConfig.ts`](diffhunk://#diff-f82126ddca325da981aa036c7ff27792efeb761204ff0a6b6ad22c8a77bb1f63R5): Added a new optional `userId` property to the `SpotifyConfig` interface to support user-specific API interactions. (`[packages/spotify/src/types/SpotifyConfig.tsR5](diffhunk://#diff-f82126ddca325da981aa036c7ff27792efeb761204ff0a6b6ad22c8a77bb1f63R5)`)
* [`packages/spotify/src/lib/http/AuthManager.ts`](diffhunk://#diff-038dfe6c50cb9a85fdcdbf209431685c1d239f00558fb0cc747e21483086147eL98-R100): Updated the `AuthManager` to use the `userId` from the configuration for session management, falling back to the default `auth()` method if `userId` is not provided. (`[packages/spotify/src/lib/http/AuthManager.tsL98-R100](diffhunk://#diff-038dfe6c50cb9a85fdcdbf209431685c1d239f00558fb0cc747e21483086147eL98-R100)`)

### Code Cleanup:
* [`apps/web/app/api/cron/update-rankings/route.ts`](diffhunk://#diff-30f57f2a52885956689d6a6774c4e7a958068bbc81ce8bc58862e1bdc23b5cdaL16-L17): Removed a redundant `console.log` statement to clean up logging in the rankings update process. (`[apps/web/app/api/cron/update-rankings/route.tsL16-L17](diffhunk://#diff-30f57f2a52885956689d6a6774c4e7a958068bbc81ce8bc58862e1bdc23b5cdaL16-L17)`)