### PR TITLE
chore: add DOCS_URL secret to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           AUTH_SPOTIFY_SECRET: ${{ secrets.AUTH_SPOTIFY_SECRET }}
           APP_MAINTENANCE: ${{ secrets.APP_MAINTENANCE }}
           DEMO_ID: ${{ secrets.DEMO_ID }}
+          DOCS_URL: ${{ secrets.DOCS_URL }}
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Run e2e tests
@@ -45,3 +46,4 @@ jobs:
           AUTH_SPOTIFY_SECRET: ${{ secrets.AUTH_SPOTIFY_SECRET }}
           APP_MAINTENANCE: ${{ secrets.APP_MAINTENANCE }}
           DEMO_ID: ${{ secrets.DEMO_ID }}
+          DOCS_URL: ${{ secrets.DOCS_URL }}


### PR DESCRIPTION
This pull request updates the CI workflow configuration to include a new secret for `DOCS_URL`. This change ensures that the `DOCS_URL` secret is available for use in the CI environment.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR37): Added `DOCS_URL` to the list of secrets in the `jobs:` section. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR37) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR49)