### PR TITLE
chore: configure turbo to cache vercel outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^generate", "^build"],
-			"outputs": ["dist/**", ".next/**", "!.next/cache/**", "public/docs/**"]
+			"outputs": ["dist/**", ".next/**", "!.next/cache/**", ".vercel/**"]
 		},
 		"dev": {
 			"dependsOn": ["^generate"],


### PR DESCRIPTION
This pull request updates the `turbo.json` configuration file to refine the build process by adjusting the output paths.

* Configuration update:
  * [`turbo.json`](diffhunk://#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3L9-R9): Replaced the `public/docs/**` output path with `.vercel/**` in the `build` task to align with deployment requirements.