### PR TITLE
docs: changelog for v2.5.0

### DIFF
--- a/apps/web/contents/changelog/v2.4.0.mdx
+++ b/apps/web/contents/changelog/v2.4.0.mdx
@@ -29,17 +29,14 @@ Quick presets like `Last Year` or `Custom` help you dive right into the stats th
       {
           Issue: "Chart Tooltip Time",
           Description: "Fixed invalid time value in 'Time Listened' chart tooltip",
-          Status: "Fixed",
       },
       {
           Issue: "Platform Usage Range",
           Description: "Incorrect time range in usage chart now corrected",
-          Status: "Fixed",
       },
       {
           Issue: "Stats Page Slowness",
           Description: "Query optimization improves responsiveness",
-          Status: "Fixed",
       },
   ]}
 />

--- a/apps/web/contents/changelog/v2.5.0.mdx
+++ b/apps/web/contents/changelog/v2.5.0.mdx
@@ -1,0 +1,50 @@
+---
+version: "2.5.0"
+date: "2025-08-06"
+type: "major"
+---
+
+Welcome to **Harmony v2.5** - our biggest release yet! This update focuses on shareability, discoverability, and an even smoother user experience.
+
+## Highlights
+
+- **Full Documentation Site** - Powered by Fumadocs, covering self-hosting, package import, computation methods, FAQ, and more. ([docs](https://harmony.antoinejosset.fr/docs))
+- **Forgotten Gems** - Rediscover tracks you once loved but haven’t played in a while, with a year selector for targeted nostalgia.
+- **Profile Sharing & Link Management** - Generate secure shareable links to your profile, set usage limits & expiration dates, and monitor them in real time.
+- **Comparisons Suite**  
+  - `/artist-vs-artist` - Pit two artists head-to-head.  
+  - `/year-over-year` - Compare listening trends between two calendar years.
+- **Universal User Settings Page** - Central hub for appearance, default date range, privacy, and more.
+- **View Mode Switcher** - Toggle between List and Grid layouts on every list.
+- **Persistent & Informative Sidebar** - Tooltips for single-route items and collapsed state remembered across refreshes.
+- **Drizzle ORM Migration** - Faster queries, smaller bundle size, and SQL-first type safety.
+
+## Bug Fixes
+
+<MdxTable
+  content={[
+      {
+          Issue: "Spotify Dev Whitelist",
+          Description: "Clear error message when account isn’t in Spotify developer whitelist",
+      },
+      {
+          Issue: "Historical Rankings Data",
+          Description: "Corrected gaps and malformed points in historical rankings charts",
+      },
+      {
+          Issue: "Sidebar State",
+          Description: "Collapsed/expanded state now persists between sessions",
+      },
+  ]}
+/>
+
+## Developer Updates
+
+- Swapped Prisma for **Drizzle ORM** across the codebase.
+- Added **@repo/database** migrations and schema generation.
+- Refactored **TurboRepo** pipeline for faster CI builds.
+- Introduced **vitest** tests in `packages/web-tests`.
+- Internal analytics improvements with detailed metrics.
+
+That's all for this release! Feedback and suggestions are always welcome.  
+Stay tuned for more refinements in v2.6!


### PR DESCRIPTION
This pull request introduces the changelog for the major `v2.5.0` release, detailing new features, bug fixes, and developer updates. It also makes a minor cleanup to the previous `v2.4.0` changelog entry by removing the redundant "Status" field from bug fix items.

Changelog additions for v2.5.0:

**Major Features & Improvements**
* Added a comprehensive documentation site powered by Fumadocs, covering setup, usage, and FAQs.
* Introduced Forgotten Gems and Comparisons Suite for enhanced music discovery and analysis.
* Enabled secure profile sharing with link management, usage limits, and expiration controls.
* Unified user settings page and improved sidebar persistence and tooltips for better usability.
* Migrated from Prisma to Drizzle ORM for improved performance and type safety.

**Bug Fixes**
* Improved error messaging for Spotify developer whitelist issues, fixed historical rankings chart data, and ensured sidebar state persists between sessions.

Changelog cleanup:

* Removed the unnecessary "Status" field from bug fix items in the `v2.4.0` changelog for clarity.