### PR TITLE
feat: add CA certificate support for database (#118)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@
 
 # DATABASE
 DATABASE_URL="mongodb+srv://username:password@cluster-url/harmony"
+DATABASE_CA_CERT="your-ca-certificate"
 
 # AUTHENTICATION
 AUTH_SECRET="your-secret"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           APP_MAINTENANCE: ${{ secrets.APP_MAINTENANCE }}
           DEMO_ID: ${{ secrets.DEMO_ID }}
           DOCS_URL: ${{ secrets.DOCS_URL }}
+          DATABASE_CA_CERT: ${{ secrets.DATABASE_CA_CERT }}
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Run e2e tests
@@ -47,3 +48,4 @@ jobs:
           APP_MAINTENANCE: ${{ secrets.APP_MAINTENANCE }}
           DEMO_ID: ${{ secrets.DEMO_ID }}
           DOCS_URL: ${{ secrets.DOCS_URL }}
+          DATABASE_CA_CERT: ${{ secrets.DATABASE_CA_CERT }}

--- a/apps/studio/drizzle.config.ts
+++ b/apps/studio/drizzle.config.ts
@@ -6,5 +6,9 @@ export default defineConfig({
 	dialect: "postgresql",
 	dbCredentials: {
 		url: process.env.DATABASE_URL!,
+		ssl: {
+			rejectUnauthorized: true,
+			ca: process.env.DATABASE_CA_CERT!,
+		},
 	},
 });


### PR DESCRIPTION
This pull request introduces support for specifying a custom CA certificate for database connections, enhancing security by allowing SSL verification. The changes ensure the CA certificate can be provided via environment variables and is properly passed to relevant workflows and configuration files.

**Database connection security enhancements:**

* Added `DATABASE_CA_CERT` environment variable to `.env.example` to allow specifying a CA certificate for database SSL connections.
* Updated `apps/studio/drizzle.config.ts` to use the `DATABASE_CA_CERT` value for SSL configuration, enabling certificate-based authentication and enforcing SSL verification.

**CI/CD workflow updates:**

* Modified `.github/workflows/ci.yml` to inject the `DATABASE_CA_CERT` secret into the CI jobs, ensuring it is available for secure database connections during automated tests and deployments. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR38) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR51)