### PR TITLE
feat: preload user data after shareable link sign-in and demo

### DIFF
--- a/apps/web/app/(app)/profile/[token]/route.ts
+++ b/apps/web/app/(app)/profile/[token]/route.ts
@@ -1,12 +1,13 @@
 import { redirect } from "next/navigation";
 import { after } from "next/server";
 
-import { signInWithShareableLink } from "@repo/auth";
+import { getUser, signInWithShareableLink } from "@repo/auth";
 
 import {
 	getShareableLinkByToken,
 	incrementShareableLinkUsage,
 } from "~/features/shareable-links/data/shareable-links";
+import { preloadUserData } from "~/features/common/preload";
 
 export async function GET(
 	_request: Request,
@@ -22,7 +23,10 @@ export async function GET(
 	if (link.usageLimit !== 0 && link.usageCount >= link.usageLimit)
 		redirect("/error?error=LinkMaxUsage");
 
-	after(async () => await incrementShareableLinkUsage(token));
+	after(async () => {
+		await incrementShareableLinkUsage(token);
+		await preloadUserData(link.userId);
+	});
 
 	await signInWithShareableLink(token);
 }

--- a/apps/web/app/(auth)/signin-demo/route.ts
+++ b/apps/web/app/(auth)/signin-demo/route.ts
@@ -1,5 +1,11 @@
 import { signInDemo } from "@repo/auth";
+import { after } from "next/server";
+import { preloadUserData } from "~/features/common/preload";
 
 export async function GET() {
+	after(async () => {
+		await preloadUserData(process.env.DEMO_ID!);
+	});
+
 	return await signInDemo("/settings/about");
 }

--- a/apps/web/features/common/preload.ts
+++ b/apps/web/features/common/preload.ts
@@ -1,0 +1,65 @@
+"server-only";
+
+import { getUser, User } from "@repo/auth";
+import { getTopArtists } from "../stats/data/top-artists";
+import { getTopTracks } from "../stats/data/top-tracks";
+import { getTimeRangeData } from "../stats/data/time-range";
+import { getRankingAlbumsData } from "../rankings/data/ranking-albums";
+import { getRankingArtistsData } from "../rankings/data/ranking-artists";
+import { getRankingTracksData } from "../rankings/data/ranking-tracks";
+import { getStatsCardsData } from "../overview/data/stats-cards";
+import { getListeningPatternData } from "../overview/data/listening-pattern-chart";
+import { getListeningSessionData } from "../numbers/data/listening-session";
+import { getNumbersStatsData } from "../numbers/data/numbers-stats";
+import { getHoursHabitsData } from "../listening-habits/data/hours-habits";
+import { getDaysHabitsData } from "../listening-habits/data/days-habits";
+import { getSkippedHabitsData } from "../listening-habits/data/skipped-habits";
+import { getShuffleHabitsData } from "../listening-habits/data/shuffle-habits";
+import { getTopPlatformsData } from "../listening-habits/data/top-platforms";
+import { getForgottenGems } from "../forgotten-gems/data/forgotten-gems-service";
+import { getAvailableYears } from "../comparisons/year-over-year/data/available-years";
+import { getYearMetrics } from "../comparisons/year-over-year/data/year-metrics";
+import { getTimeEvolutionData } from "../activity/data/time-evolution";
+import { getPlatformUsageData } from "../activity/data/platform-usage";
+import { getTimeListenedData } from "../activity/data/time-listened";
+import { spotify } from "@repo/spotify";
+
+export const preloadUserData = async (userId: string) => {
+	const isDemo = true;
+
+	spotify.setUserId(userId);
+	await spotify.me.get();
+
+	await Promise.all([
+		// Stats
+		await getTopArtists(userId, isDemo),
+		await getTopTracks(userId, isDemo),
+		await getTimeRangeData(userId, isDemo),
+		// Rankings
+		await getRankingAlbumsData(userId, isDemo),
+		await getRankingArtistsData(userId, isDemo),
+		await getRankingTracksData(userId, isDemo),
+		// Overview
+		await getStatsCardsData(userId, isDemo),
+		await getListeningPatternData(userId, isDemo),
+		// Numbers
+		await getListeningSessionData(userId, isDemo),
+		await getNumbersStatsData(userId, isDemo),
+		// Listening Habits
+		await getHoursHabitsData(userId, isDemo),
+		await getDaysHabitsData(userId, isDemo),
+		await getSkippedHabitsData(userId, isDemo),
+		await getShuffleHabitsData(userId, isDemo),
+		await getTopPlatformsData(userId, isDemo),
+		// Forgotten Gems
+		await getForgottenGems(userId),
+		// Comparisons
+		await getAvailableYears(userId),
+		await getYearMetrics(userId, new Date().getFullYear()),
+		await getYearMetrics(userId, new Date().getFullYear() - 1),
+		// Activity
+		await getTimeEvolutionData(userId, isDemo),
+		await getPlatformUsageData(userId, isDemo),
+		await getTimeListenedData(userId, isDemo),
+	]);
+};

--- a/apps/web/features/comparisons/artist-vs-artist/components/comparison-content.tsx
+++ b/apps/web/features/comparisons/artist-vs-artist/components/comparison-content.tsx
@@ -12,8 +12,6 @@ const titles = { title1: "Top Tracks", title2: "Top Albums" };
 export const ComparisonArtistVsArtistContent = ({ children }: PropsWithChildren) => {
     const { metrics1, metrics2, isLoading, isError } = useArtistsData();
 
-    console.log(isLoading, metrics1, metrics2);
-
     if ((!metrics1 && !metrics2) || (!isLoading && !metrics1) || (!isLoading && !metrics2)) return (
         <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-4">
             <h2 className="font-bold text-2xl text-foreground">Compare Your Artists</h2>

--- a/apps/web/features/comparisons/artist-vs-artist/data/artist-metrics.ts
+++ b/apps/web/features/comparisons/artist-vs-artist/data/artist-metrics.ts
@@ -1,6 +1,11 @@
 "server-only";
 
 import {
+	unstable_cacheLife as cacheLife,
+	unstable_cacheTag as cacheTag,
+} from "next/cache";
+
+import {
 	and,
 	arrayOverlaps,
 	auth,
@@ -23,9 +28,9 @@ export async function getArtistMetrics(
 	artistId: string,
 	limit = 5,
 ): Promise<ComparisonMetrics | null> {
-	// "use cache";
-	// cacheLife("days");
-	// cacheTag(userId, `artist-metrics-${artistId}`);
+	"use cache";
+	cacheLife("days");
+	cacheTag(userId, `artist-metrics-${artistId}`);
 
 	if (!artistId) return null;
 

--- a/apps/web/features/comparisons/artist-vs-artist/data/top-artists.ts
+++ b/apps/web/features/comparisons/artist-vs-artist/data/top-artists.ts
@@ -1,8 +1,17 @@
 "server-only";
 
+import {
+	unstable_cacheLife as cacheLife,
+	unstable_cacheTag as cacheTag,
+} from "next/cache";
+
 import { spotify } from "@repo/spotify";
 
 export async function getTopArtists(userId: string) {
+	"use cache";
+	cacheLife("days");
+	cacheTag(userId, "top-artists-vs-artist");
+
 	spotify.setUserId(userId);
 	return await spotify.me.top("artists", "medium_term");
 }

--- a/apps/web/features/comparisons/year-over-year/actions/year-metrics-action.ts
+++ b/apps/web/features/comparisons/year-over-year/actions/year-metrics-action.ts
@@ -7,11 +7,5 @@ import { getYearMetrics } from "../data/year-metrics";
 export async function getYearMetricsAction(year: number) {
 	const { userId } = await getUser();
 
-	const time = performance.now();
-	const metrics = await getYearMetrics(userId, year);
-	const endTime = performance.now();
-
-	console.log(`getYearMetricsAction took ${endTime - time}ms for ${year}`);
-
-	return metrics;
+	return await getYearMetrics(userId, year);
 }


### PR DESCRIPTION
This pull request introduces improvements to user data preloading and caching throughout the authentication and profile flow, as well as some minor code cleanups. The main focus is on ensuring that comprehensive user data is preloaded after sign-in events (including demo sign-in and shareable link sign-in), and on optimizing data fetching with caching for artist comparison features.

**User Data Preloading Enhancements:**

* Added a new `preloadUserData` function in `features/common/preload.ts` that preloads a wide range of user-related data (stats, rankings, habits, activity, etc.) for a given user ID. This function is now invoked after sign-in via shareable link and demo sign-in, ensuring faster and smoother user experiences after authentication. [[1]](diffhunk://#diff-5615a7e5739431b87c2402e9b5134d20aab255fbee8e3f63a0e48118d3f2d0d7R1-R65) [apps/web/app/(app)/profile/[token]/route.tsL25-R29](diffhunk://#diff-f1484aa3a7daa057280a46b1abcdf6c7127a34d3e909b14c44c7f159f3889a6cL25-R29), [[2]](diffhunk://#diff-0d0b1e1a7e127b44b7001ffcfbb1d193c1cb5259516a773a776a684223eb75d1R2-R9)

**Caching Improvements for Artist Comparison:**

* Enabled and configured caching for `getArtistMetrics` and `getTopArtists` functions using Next.js cache utilities. This will reduce redundant data fetching and improve performance for artist comparison features. [[1]](diffhunk://#diff-6402368810b3792c374f73a2324742bcdcecb2d0e761b32ce56ebf46a7097ebeL26-R33) [[2]](diffhunk://#diff-bedd2c699129fb36b0f255d2a981c20df7b6781d7d7676e61796c7d65b326271R3-R14)

**Minor Code Cleanups:**

* Removed unnecessary console logging from `comparison-content.tsx` and `year-metrics-action.ts`, streamlining the code and eliminating extraneous output. [[1]](diffhunk://#diff-a57726c7697d38293232ba8a8d9157702de38ade6f0b5582c451d52ab8668273L15-L16) [[2]](diffhunk://#diff-b7e8315542e126167113e2e594c9518e43b82570c8ac122a29715a93c539ce6cL10-R10)

**Dependency Updates:**

* Updated imports in several files to support the new preloading and caching features, including adding `getUser` and cache utilities where needed. ([apps/web/app/(app)/profile/[token]/route.tsL4-R10](diffhunk://#diff-f1484aa3a7daa057280a46b1abcdf6c7127a34d3e909b14c44c7f159f3889a6cL4-R10), [[1]](diffhunk://#diff-6402368810b3792c374f73a2324742bcdcecb2d0e761b32ce56ebf46a7097ebeR3-R7) [[2]](diffhunk://#diff-bedd2c699129fb36b0f255d2a981c20df7b6781d7d7676e61796c7d65b326271R3-R14) [[3]](diffhunk://#diff-0d0b1e1a7e127b44b7001ffcfbb1d193c1cb5259516a773a776a684223eb75d1R2-R9)