### PR TITLE
feat: artists-page

### DIFF
--- a/apps/api/.adonisjs/client/registry/index.ts
+++ b/apps/api/.adonisjs/client/registry/index.ts
@@ -84,6 +84,12 @@ const routes = {
     tokens: [{"old":"/api/v1/package/:id/tracks/:trackId","type":0,"val":"api","end":""},{"old":"/api/v1/package/:id/tracks/:trackId","type":0,"val":"v1","end":""},{"old":"/api/v1/package/:id/tracks/:trackId","type":0,"val":"package","end":""},{"old":"/api/v1/package/:id/tracks/:trackId","type":1,"val":"id","end":""},{"old":"/api/v1/package/:id/tracks/:trackId","type":0,"val":"tracks","end":""},{"old":"/api/v1/package/:id/tracks/:trackId","type":1,"val":"trackId","end":""}],
     types: placeholder as Registry['package.tracks.get']['types'],
   },
+  'package.albums.top': {
+    methods: ["GET","HEAD"],
+    pattern: '/api/v1/package/:id/albums',
+    tokens: [{"old":"/api/v1/package/:id/albums","type":0,"val":"api","end":""},{"old":"/api/v1/package/:id/albums","type":0,"val":"v1","end":""},{"old":"/api/v1/package/:id/albums","type":0,"val":"package","end":""},{"old":"/api/v1/package/:id/albums","type":1,"val":"id","end":""},{"old":"/api/v1/package/:id/albums","type":0,"val":"albums","end":""}],
+    types: placeholder as Registry['package.albums.top']['types'],
+  },
   'package.package.destroy': {
     methods: ["DELETE"],
     pattern: '/api/v1/package/:id',

--- a/apps/api/.adonisjs/client/registry/schema.d.ts
+++ b/apps/api/.adonisjs/client/registry/schema.d.ts
@@ -146,8 +146,19 @@ export interface Registry {
       body: {}
       paramsTuple: [ParamValue, ParamValue]
       params: { id: ParamValue; trackId: ParamValue }
-      query: ExtractQueryForGet<InferInput<(typeof import('#validators/instant_range_query').trackParamsValidator)>|InferInput<(typeof import('#validators/instant_range_query').instantRangeQueryValidator)>>
+      query: ExtractQueryForGet<InferInput<(typeof import('#validators/instant_range_query').trackParamsValidator)>>
       response: ExtractResponse<Awaited<ReturnType<import('#controllers/tracks_controller').default['get']>>>
+    }
+  }
+  'package.albums.top': {
+    methods: ["GET","HEAD"]
+    pattern: '/api/v1/package/:id/albums'
+    types: {
+      body: {}
+      paramsTuple: [ParamValue]
+      params: { id: ParamValue }
+      query: ExtractQueryForGet<InferInput<(typeof import('#validators/instant_range_query').instantRangeQueryValidator)>>
+      response: ExtractResponse<Awaited<ReturnType<import('#controllers/albums_controller').default['top']>>>
     }
   }
   'package.package.destroy': {

--- a/apps/api/.adonisjs/client/registry/tree.d.ts
+++ b/apps/api/.adonisjs/client/registry/tree.d.ts
@@ -35,5 +35,8 @@ export interface ApiDefinition {
       top: typeof routes['package.tracks.top']
       get: typeof routes['package.tracks.get']
     }
+    albums: {
+      top: typeof routes['package.albums.top']
+    }
   }
 }

--- a/apps/api/.adonisjs/server/controllers.ts
+++ b/apps/api/.adonisjs/server/controllers.ts
@@ -5,6 +5,7 @@
 
 export const controllers = {
   AccessToken: () => import('#controllers/access_token_controller'),
+  Albums: () => import('#controllers/albums_controller'),
   NewAccount: () => import('#controllers/new_account_controller'),
   Package: () => import('#controllers/package_controller'),
   Profile: () => import('#controllers/profile_controller'),

--- a/apps/api/.adonisjs/server/routes.d.ts
+++ b/apps/api/.adonisjs/server/routes.d.ts
@@ -17,6 +17,7 @@ export type ScannedRoutes = {
     'package.package.stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'package.tracks.top': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'package.tracks.get': { paramsTuple: [ParamValue,ParamValue]; params: {'id': ParamValue,'trackId': ParamValue} }
+    'package.albums.top': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'package.package.destroy': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
   }
   GET: {
@@ -27,6 +28,7 @@ export type ScannedRoutes = {
     'package.package.stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'package.tracks.top': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'package.tracks.get': { paramsTuple: [ParamValue,ParamValue]; params: {'id': ParamValue,'trackId': ParamValue} }
+    'package.albums.top': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
   }
   HEAD: {
     'event_stream': { paramsTuple?: []; params?: {} }
@@ -36,6 +38,7 @@ export type ScannedRoutes = {
     'package.package.stats': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'package.tracks.top': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'package.tracks.get': { paramsTuple: [ParamValue,ParamValue]; params: {'id': ParamValue,'trackId': ParamValue} }
+    'package.albums.top': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
   }
   POST: {
     'subscribe': { paramsTuple?: []; params?: {} }

--- a/apps/api/app/controllers/albums_controller.ts
+++ b/apps/api/app/controllers/albums_controller.ts
@@ -1,0 +1,15 @@
+import AlbumService from '#services/album_service'
+import { instantRangeQueryValidator } from '#validators/instant_range_query'
+import { inject } from '@adonisjs/core'
+import { type HttpContext } from '@adonisjs/core/http'
+
+@inject()
+export default class AlbumsController {
+  constructor(private readonly albumService: AlbumService) {}
+
+  async top({ request, pkg, instantRange }: HttpContext) {
+    await request.validateUsing(instantRangeQueryValidator)
+    const albums = await this.albumService.getTopAlbums(pkg.id, instantRange)
+    return { packageId: pkg.publicId, albums }
+  }
+}

--- a/apps/api/app/controllers/tracks_controller.ts
+++ b/apps/api/app/controllers/tracks_controller.ts
@@ -1,5 +1,5 @@
 import TrackService from '#services/track_service'
-import { trackParamsValidator } from '#validators/instant_range_query'
+import { instantRangeQueryValidator, trackParamsValidator } from '#validators/instant_range_query'
 import { inject } from '@adonisjs/core'
 import { type HttpContext } from '@adonisjs/core/http'
 
@@ -7,7 +7,8 @@ import { type HttpContext } from '@adonisjs/core/http'
 export default class TracksController {
   constructor(private readonly trackService: TrackService) {}
 
-  async top({ pkg, instantRange }: HttpContext) {
+  async top({ request, pkg, instantRange }: HttpContext) {
+    await request.validateUsing(instantRangeQueryValidator)
     const tracks = await this.trackService.getTopTracks(pkg.id, instantRange)
     return { packageId: pkg.publicId, tracks }
   }

--- a/apps/api/app/dtos/album_dtos.ts
+++ b/apps/api/app/dtos/album_dtos.ts
@@ -1,0 +1,13 @@
+export interface TopAlbumDto {
+  id: number
+  name: string
+  description: string
+  image: string | null
+  streams: number
+  playtime: number
+}
+
+export interface TopAlbumsResponseDto {
+  packageId: string
+  albums: TopAlbumDto[]
+}

--- a/apps/api/app/services/album_service.ts
+++ b/apps/api/app/services/album_service.ts
@@ -1,0 +1,45 @@
+import type { TopAlbumDto } from '#dtos/album_dtos'
+import { msToMinutes } from '#lib/time_utils'
+import { type InstantRange } from '#services/interaction_timestamp_range'
+import Album from '#models/album'
+import db from '@adonisjs/lucid/services/db'
+
+export default class AlbumService {
+  async getTopAlbums(packageId: number, range: InstantRange): Promise<TopAlbumDto[]> {
+    const query = Album.query()
+      .select([
+        'albums.*',
+        db.raw('coalesce(sum(interactions.ms_played), 0)::bigint as listening_ms'),
+        db.raw('count(interactions.*)::int as streams'),
+        db.raw(
+          "coalesce(string_agg(distinct artists.name, ', ' order by artists.name), '') as artist_names"
+        ),
+      ])
+      .join('tracks', 'albums.id', 'tracks.album_id')
+      .join('interactions', 'interactions.track_id', 'tracks.id')
+      .leftJoin('album_artists', 'album_artists.album_id', 'albums.id')
+      .leftJoin('artists', 'artists.id', 'album_artists.artist_id')
+      .where('interactions.package_id', packageId)
+      .groupBy('albums.id')
+      .orderByRaw('sum(interactions.ms_played) desc')
+      .limit(50)
+
+    if (range.from) {
+      query.where('interactions.timestamp', '>=', range.from.toJSDate())
+    }
+    if (range.to) {
+      query.where('interactions.timestamp', '<=', range.to.toJSDate())
+    }
+
+    const albums = await query
+
+    return albums.map((album) => ({
+      id: album.id,
+      name: album.name,
+      description: String(album.$extras.artist_names ?? ''),
+      image: album.image,
+      streams: Number(album.$extras.streams ?? 0),
+      playtime: msToMinutes(Number(album.$extras.listening_ms ?? 0)),
+    }))
+  }
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -50,7 +50,10 @@ router
         router.get('/:id', [controllers.Package, 'show'])
         router.get('/:id/stats', [controllers.Package, 'stats'])
         router.get('/:id/tracks', [controllers.Tracks, 'top']).use(middleware.bindInstantRange())
-        router.get('/:id/tracks/:trackId', [controllers.Tracks, 'get']).use(middleware.bindInstantRange())
+        router
+          .get('/:id/tracks/:trackId', [controllers.Tracks, 'get'])
+          .use(middleware.bindInstantRange())
+        router.get('/:id/albums', [controllers.Albums, 'top']).use(middleware.bindInstantRange())
         router.delete('/:id', [controllers.Package, 'destroy'])
       })
       .prefix('package')

--- a/apps/web/src/components/catalog/catalog-grid.tsx
+++ b/apps/web/src/components/catalog/catalog-grid.tsx
@@ -1,0 +1,85 @@
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@harmony/ui/components/empty'
+import { GridViewIcon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useNavigate } from '@tanstack/react-router'
+import { FormattedMetric } from '../format/formatted-metric'
+import { CatalogImage } from './catalog-image'
+import type { Catalog } from './catalog'
+
+const getRankClassName = (rank: number) => {
+  switch (rank) {
+    case 1:
+      return 'bg-amber-500/20 text-amber-300 ring-1 ring-amber-400/40'
+    case 2:
+      return 'bg-slate-400/20 text-slate-200 ring-1 ring-slate-300/35'
+    case 3:
+      return 'bg-orange-700/25 text-orange-200 ring-1 ring-orange-400/35'
+    default:
+      return 'bg-muted/60 text-muted-foreground ring-1 ring-muted/80'
+  }
+}
+
+type CatalogGridProps = {
+  catalog: Array<Catalog> | undefined
+  empty?: string
+  loading?: boolean
+}
+
+export const CatalogGrid = ({
+  catalog,
+  empty = 'No items yet.',
+  loading = false,
+}: CatalogGridProps) => {
+  const navigate = useNavigate()
+
+  if (!loading && (!catalog || catalog.length <= 0)) {
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <HugeiconsIcon icon={GridViewIcon} />
+          </EmptyMedia>
+          <EmptyTitle>{empty}</EmptyTitle>
+          <EmptyDescription>Try adjusting your date range or filters.</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-2 xs:grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 px-4 py-2">
+      {catalog?.map((item, index) => (
+        <article
+          key={item.id}
+          onClick={() => navigate({ to: '.', search: { details: item.id }, resetScroll: false })}
+          className="flex flex-col gap-2 p-2 rounded-lg hover:bg-card transition-colors duration-100 cursor-pointer"
+        >
+          <div className="relative aspect-square">
+            <CatalogImage image={item.image} alt={item.name} className="size-full [&_svg]:size-5" />
+            <div className="absolute top-1.5 right-1.5 flex items-center justify-center">
+              <span
+                className={`inline-flex h-5 min-w-5 items-center justify-center rounded-md text-xs font-medium ${getRankClassName(index + 1)}`}
+              >
+                {index + 1}
+              </span>
+            </div>
+          </div>
+          <div>
+            <h3 className="text-sm font-medium line-clamp-2">{item.name}</h3>
+            <p className="text-xs text-muted-foreground line-clamp-1">{item.description}</p>
+            <div className="mt-1.5 flex items-center justify-between gap-1">
+              <FormattedMetric value={item.streams} size="sm" />
+              <FormattedMetric value={item.playtime} unit="min" size="sm" />
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/catalog/catalog-table.tsx
+++ b/apps/web/src/components/catalog/catalog-table.tsx
@@ -49,14 +49,14 @@ export const CatalogTable = ({
   }
 
   return (
-    <Table>
+    <Table className="pb-2">
       <TableHeader className="bg-muted/50">
         <TableRow className="hover:bg-transparent">
           <TableHead className="w-[35.5px] h-8 pl-4 text-xs text-center font-medium text-muted-foreground">
             #
           </TableHead>
           <TableHead className="h-8 text-xs font-medium text-muted-foreground">Title</TableHead>
-          <TableHead className="h-8 w-28 text-right text-xs font-medium tabular-nums text-muted-foreground">
+          <TableHead className="h-8 w-16 text-right text-xs font-medium tabular-nums text-muted-foreground">
             Streams
           </TableHead>
           <TableHead className="h-8 w-28 pr-4 text-right text-xs font-medium tabular-nums text-muted-foreground">
@@ -81,7 +81,7 @@ export const CatalogTable = ({
           catalog?.map((item, index) => (
             <TableRow
               key={item.id}
-              onClick={() => navigate({ to: '.', search: { track: item.id }, resetScroll: false })}
+              onClick={() => navigate({ to: '.', search: { details: item.id }, resetScroll: false })}
             >
               <TableCell className="pl-4 text-center tabular-nums">
                 <span
@@ -90,7 +90,7 @@ export const CatalogTable = ({
                   {index + 1}
                 </span>
               </TableCell>
-              <TableCell>
+              <TableCell className="max-w-0">
                 <div className="flex min-w-0 items-center gap-3">
                   <CatalogImage image={item.image} alt={item.name} />
                   <div className="min-w-0">

--- a/apps/web/src/components/catalog/layout/catalog-date-range-tabs.tsx
+++ b/apps/web/src/components/catalog/layout/catalog-date-range-tabs.tsx
@@ -1,0 +1,26 @@
+import { Tabs, TabsList, TabsTrigger } from '@harmony/ui/components/tabs'
+import { DateRangeFilter } from '@/components/toolbar/date-range-filter'
+import { type DateRangeMode, useDateRangeStore } from '@/lib/store'
+
+export function CatalogDateRangeTabs() {
+  const mode = useDateRangeStore((s) => s.mode)
+  const setMode = useDateRangeStore((s) => s.setMode)
+
+  return (
+    <div className="shrink-0 border-b border-border px-4">
+      <div className="flex gap-3 items-center justify-between">
+        <Tabs value={mode} onValueChange={(value) => setMode(value as DateRangeMode)}>
+          <TabsList variant="line" className="gap-4">
+            <TabsTrigger value="month">Month</TabsTrigger>
+            <TabsTrigger value="year">Years</TabsTrigger>
+            <TabsTrigger value="custom">Custom</TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        <div className="flex shrink-0 justify-end pb-1">
+          <DateRangeFilter />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/catalog/layout/catalog-page-header.tsx
+++ b/apps/web/src/components/catalog/layout/catalog-page-header.tsx
@@ -1,0 +1,19 @@
+import type { PropsWithChildren } from 'react'
+
+type CatalogPageHeaderProps = PropsWithChildren<{
+  title: string
+  description: string
+}>
+
+export function CatalogPageHeader({ title, description, children }: CatalogPageHeaderProps) {
+  return (
+    <div className="flex shrink-0 items-center justify-between gap-2 p-4 pb-2">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <div className="flex items-center gap-1">{children}</div>
+    </div>
+  )
+}

--- a/apps/web/src/components/catalog/layout/catalog-page-shell.tsx
+++ b/apps/web/src/components/catalog/layout/catalog-page-shell.tsx
@@ -1,0 +1,61 @@
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '@harmony/ui/components/resizable'
+import { useDefaultLayout } from 'react-resizable-panels'
+import type { PropsWithChildren } from 'react'
+import { cookieStorage } from '@/lib/resizable-panels'
+
+type CatalogPageShellRootProps = PropsWithChildren<{
+  hasDetails: boolean
+}>
+
+export function CatalogPageShellRoot({ hasDetails, children }: CatalogPageShellRootProps) {
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: 'global-layout',
+    panelIds: hasDetails ? ['list-panel', 'details-panel'] : ['list-panel'],
+    storage: cookieStorage,
+  })
+
+  return (
+    <ResizablePanelGroup
+      orientation="horizontal"
+      className="min-h-0 w-full h-svh!"
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+    >
+      {children}
+    </ResizablePanelGroup>
+  )
+}
+
+type CatalogPageShellListProps = PropsWithChildren<{}>
+
+export function CatalogPageShellList({ children }: CatalogPageShellListProps) {
+  return (
+    <ResizablePanel id="list-panel" className="flex min-h-0 min-w-0 flex-col overflow-hidden!">
+      {children}
+    </ResizablePanel>
+  )
+}
+
+type CatalogPageShellDetailsProps = PropsWithChildren<{
+  open: boolean
+}>
+
+export function CatalogPageShellDetails({ open, children }: CatalogPageShellDetailsProps) {
+  if (!open) {
+    return null
+  }
+
+  return (
+    <>
+      <ResizableHandle />
+      <ResizablePanel id="details-panel" defaultSize={300} minSize={300} maxSize={500}>
+        {children}
+      </ResizablePanel>
+    </>
+  )
+}
+

--- a/apps/web/src/components/catalog/layout/catalog-route-search.ts
+++ b/apps/web/src/components/catalog/layout/catalog-route-search.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const catalogSearchSchema = z.object({
+  details: z.number().optional(),
+})

--- a/apps/web/src/components/catalog/layout/catalog-scroll-area.tsx
+++ b/apps/web/src/components/catalog/layout/catalog-scroll-area.tsx
@@ -1,0 +1,7 @@
+import type { PropsWithChildren } from 'react'
+
+type CatalogScrollAreaProps = PropsWithChildren<{}>
+
+export function CatalogScrollArea({ children }: CatalogScrollAreaProps) {
+  return <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">{children}</div>
+}

--- a/apps/web/src/components/catalog/layout/index.ts
+++ b/apps/web/src/components/catalog/layout/index.ts
@@ -1,0 +1,5 @@
+export { catalogSearchSchema } from './catalog-route-search'
+export { CatalogDateRangeTabs } from './catalog-date-range-tabs'
+export { CatalogPageHeader } from './catalog-page-header'
+export { CatalogPageShellRoot, CatalogPageShellList, CatalogPageShellDetails } from './catalog-page-shell'
+export { CatalogScrollArea } from './catalog-scroll-area'

--- a/apps/web/src/components/layout/sidebar/nav.config.tsx
+++ b/apps/web/src/components/layout/sidebar/nav.config.tsx
@@ -60,13 +60,8 @@ export const navConfig = {
     },
     {
       title: 'Albums',
-      url: '#',
+      url: '/albums',
       icon: <HugeiconsIcon icon={Vynil01Icon} className="text-muted-foreground" />,
-      badge: (
-        <Badge variant="outline" className="ms-auto">
-          Soon
-        </Badge>
-      ),
     },
   ],
   insights: [

--- a/apps/web/src/components/toolbar/view-mode-menu.tsx
+++ b/apps/web/src/components/toolbar/view-mode-menu.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@harmony/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@harmony/ui/components/dropdown-menu'
+import { LayoutGridIcon, Menu01Icon, SlidersHorizontalIcon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { type ViewMode, useUserPreferencesStore } from '@/lib/store'
+
+export function ViewModeMenu() {
+  const viewMode = useUserPreferencesStore((s) => s.viewMode)
+  const setViewMode = useUserPreferencesStore((s) => s.setViewMode)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">
+          <HugeiconsIcon icon={SlidersHorizontalIcon} className="size-4" />
+          Display
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-28">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>View Mode</DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={viewMode}
+            onValueChange={(next) => setViewMode(next as ViewMode)}
+          >
+            <DropdownMenuRadioItem value="grid">
+              <HugeiconsIcon icon={LayoutGridIcon} className="size-4" />
+              Grid
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="list">
+              <HugeiconsIcon icon={Menu01Icon} className="size-4" />
+              List
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -1,7 +1,42 @@
 import { useMemo } from 'react'
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { type StateStorage, createJSONStorage, persist } from 'zustand/middleware'
 import { useShallow } from 'zustand/react/shallow'
+
+const COOKIE_MAX_AGE_ONE_YEAR = 60 * 60 * 24 * 30 // 30 days
+
+export const zustandCookieStorage: StateStorage = {
+  getItem(name: string) {
+    const match = document.cookie.split('; ').find((c) => c.startsWith(`${name}=`))
+    return match ? decodeURIComponent(match.split('=').slice(1).join('=')) : null
+  },
+  setItem(name: string, value: string) {
+    document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${COOKIE_MAX_AGE_ONE_YEAR}`
+  },
+  removeItem(name: string) {
+    document.cookie = `${name}=; path=/; max-age=0`
+  },
+}
+
+export type ViewMode = 'grid' | 'list'
+
+type UserPreferencesState = {
+  viewMode: ViewMode
+  setViewMode: (mode: ViewMode) => void
+}
+
+export const useUserPreferencesStore = create<UserPreferencesState>()(
+  persist(
+    (set) => ({
+      viewMode: 'grid',
+      setViewMode: (viewMode) => set({ viewMode }),
+    }),
+    {
+      name: 'harmony:user-preferences',
+      storage: createJSONStorage(() => zustandCookieStorage),
+    }
+  )
+)
 
 export type DateRangeMode = 'month' | 'year' | 'custom'
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as AppPackageIdRouteImport } from './routes/app/$packageId'
 import { Route as AppPackageIdIndexRouteImport } from './routes/app/$packageId/index'
 import { Route as AppPackageIdTracksRouteImport } from './routes/app/$packageId/tracks'
 import { Route as AppPackageIdPackageRouteImport } from './routes/app/$packageId/package'
+import { Route as AppPackageIdAlbumsRouteImport } from './routes/app/$packageId/albums'
 
 const UploadRoute = UploadRouteImport.update({
   id: '/upload',
@@ -46,11 +47,17 @@ const AppPackageIdPackageRoute = AppPackageIdPackageRouteImport.update({
   path: '/package',
   getParentRoute: () => AppPackageIdRoute,
 } as any)
+const AppPackageIdAlbumsRoute = AppPackageIdAlbumsRouteImport.update({
+  id: '/albums',
+  path: '/albums',
+  getParentRoute: () => AppPackageIdRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/upload': typeof UploadRoute
   '/app/$packageId': typeof AppPackageIdRouteWithChildren
+  '/app/$packageId/albums': typeof AppPackageIdAlbumsRoute
   '/app/$packageId/package': typeof AppPackageIdPackageRoute
   '/app/$packageId/tracks': typeof AppPackageIdTracksRoute
   '/app/$packageId/': typeof AppPackageIdIndexRoute
@@ -58,6 +65,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/upload': typeof UploadRoute
+  '/app/$packageId/albums': typeof AppPackageIdAlbumsRoute
   '/app/$packageId/package': typeof AppPackageIdPackageRoute
   '/app/$packageId/tracks': typeof AppPackageIdTracksRoute
   '/app/$packageId': typeof AppPackageIdIndexRoute
@@ -67,6 +75,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/upload': typeof UploadRoute
   '/app/$packageId': typeof AppPackageIdRouteWithChildren
+  '/app/$packageId/albums': typeof AppPackageIdAlbumsRoute
   '/app/$packageId/package': typeof AppPackageIdPackageRoute
   '/app/$packageId/tracks': typeof AppPackageIdTracksRoute
   '/app/$packageId/': typeof AppPackageIdIndexRoute
@@ -77,6 +86,7 @@ export interface FileRouteTypes {
     | '/'
     | '/upload'
     | '/app/$packageId'
+    | '/app/$packageId/albums'
     | '/app/$packageId/package'
     | '/app/$packageId/tracks'
     | '/app/$packageId/'
@@ -84,6 +94,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/upload'
+    | '/app/$packageId/albums'
     | '/app/$packageId/package'
     | '/app/$packageId/tracks'
     | '/app/$packageId'
@@ -92,6 +103,7 @@ export interface FileRouteTypes {
     | '/'
     | '/upload'
     | '/app/$packageId'
+    | '/app/$packageId/albums'
     | '/app/$packageId/package'
     | '/app/$packageId/tracks'
     | '/app/$packageId/'
@@ -147,16 +159,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppPackageIdPackageRouteImport
       parentRoute: typeof AppPackageIdRoute
     }
+    '/app/$packageId/albums': {
+      id: '/app/$packageId/albums'
+      path: '/albums'
+      fullPath: '/app/$packageId/albums'
+      preLoaderRoute: typeof AppPackageIdAlbumsRouteImport
+      parentRoute: typeof AppPackageIdRoute
+    }
   }
 }
 
 interface AppPackageIdRouteChildren {
+  AppPackageIdAlbumsRoute: typeof AppPackageIdAlbumsRoute
   AppPackageIdPackageRoute: typeof AppPackageIdPackageRoute
   AppPackageIdTracksRoute: typeof AppPackageIdTracksRoute
   AppPackageIdIndexRoute: typeof AppPackageIdIndexRoute
 }
 
 const AppPackageIdRouteChildren: AppPackageIdRouteChildren = {
+  AppPackageIdAlbumsRoute: AppPackageIdAlbumsRoute,
   AppPackageIdPackageRoute: AppPackageIdPackageRoute,
   AppPackageIdTracksRoute: AppPackageIdTracksRoute,
   AppPackageIdIndexRoute: AppPackageIdIndexRoute,

--- a/apps/web/src/routes/app/$packageId/albums.tsx
+++ b/apps/web/src/routes/app/$packageId/albums.tsx
@@ -1,0 +1,61 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { Button } from '@harmony/ui/components/button'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { FilterIcon } from '@hugeicons/core-free-icons'
+import { useInstantRangeQuery, useUserPreferencesStore } from '@/lib/store'
+import { api } from '@/lib/api'
+import { CatalogGrid } from '@/components/catalog/catalog-grid'
+import { CatalogTable } from '@/components/catalog/catalog-table'
+import { ViewModeMenu } from '@/components/toolbar/view-mode-menu'
+import {
+  CatalogDateRangeTabs,
+  CatalogPageHeader,
+  CatalogPageShellList,
+  CatalogPageShellRoot,
+  CatalogScrollArea,
+  catalogSearchSchema,
+} from '@/components/catalog/layout'
+
+export const Route = createFileRoute('/app/$packageId/albums')({
+  validateSearch: catalogSearchSchema,
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const { pkg } = Route.useRouteContext()
+  const { details } = Route.useSearch()
+  const instantQuery = useInstantRangeQuery()
+  const viewMode = useUserPreferencesStore((s) => s.viewMode)
+
+  const { data, isLoading } = useQuery(
+    api.package.albums.top.queryOptions({ params: { id: pkg.id }, query: instantQuery })
+  )
+
+  return (
+    <CatalogPageShellRoot hasDetails={!!details}>
+      <CatalogPageShellList>
+        <CatalogPageHeader
+          title="Albums"
+          description="A ranked view of the albums you've spent the most time with"
+        >
+          <ViewModeMenu />
+          <Button variant="secondary">
+            <HugeiconsIcon icon={FilterIcon} className="size-4" />
+            Filters
+          </Button>
+        </CatalogPageHeader>
+
+        <CatalogDateRangeTabs />
+
+        <CatalogScrollArea>
+          {viewMode === 'grid' ? (
+            <CatalogGrid catalog={data?.albums} empty="No albums yet." loading={isLoading} />
+          ) : (
+            <CatalogTable catalog={data?.albums} empty="No albums yet." loading={isLoading} />
+          )}
+        </CatalogScrollArea>
+      </CatalogPageShellList>
+    </CatalogPageShellRoot>
+  )
+}

--- a/apps/web/src/routes/app/$packageId/tracks.tsx
+++ b/apps/web/src/routes/app/$packageId/tracks.tsx
@@ -1,123 +1,79 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useQuery } from '@tanstack/react-query'
+import { skipToken, useQuery } from '@tanstack/react-query'
 
-import { Tabs, TabsList, TabsTrigger } from '@harmony/ui/components/tabs'
 import { Button } from '@harmony/ui/components/button'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { FilterIcon, SlidersHorizontalIcon } from '@hugeicons/core-free-icons'
-import { z } from 'zod'
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from '@harmony/ui/components/resizable'
-import { useDefaultLayout } from 'react-resizable-panels'
-import type { DateRangeMode } from '@/lib/store'
-import { useDateRangeStore, useInstantRangeQuery } from '@/lib/store'
+import { useInstantRangeQuery } from '@/lib/store'
 import { api } from '@/lib/api'
 import { CatalogTable } from '@/components/catalog/catalog-table'
-import { DateRangeFilter } from '@/components/toolbar/date-range-filter'
 import { CatalogDetailsPanel } from '@/components/catalog/details/catalog-details-panel'
-import { cookieStorage } from '@/lib/resizable-panels'
-
-const trackSearchSchema = z.object({
-  track: z.number().optional(),
-})
+import {
+  CatalogDateRangeTabs,
+  CatalogPageHeader,
+  CatalogPageShellDetails,
+  CatalogPageShellList,
+  CatalogPageShellRoot,
+  CatalogScrollArea,
+  catalogSearchSchema,
+} from '@/components/catalog/layout'
 
 export const Route = createFileRoute('/app/$packageId/tracks')({
-  validateSearch: trackSearchSchema,
-  loader: ({ context }) => {
-    const { queryClient, pkg } = context
-    void queryClient.prefetchQuery(api.package.tracks.top.queryOptions({ params: { id: pkg.id } }))
-  },
+  validateSearch: catalogSearchSchema,
   component: RouteComponent,
 })
 
 function RouteComponent() {
   const { pkg } = Route.useRouteContext()
-  const { track } = Route.useSearch()
-  const mode = useDateRangeStore((s) => s.mode)
-  const setMode = useDateRangeStore((s) => s.setMode)
+  const { details } = Route.useSearch()
   const instantQuery = useInstantRangeQuery()
   const navigate = useNavigate()
-
-  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: 'tracks-layout',
-    panelIds: track ? ['tracks-panel', 'track-details-panel'] : ['tracks-panel'],
-    storage: cookieStorage,
-  })
 
   const { data, isLoading } = useQuery(
     api.package.tracks.top.queryOptions({ params: { id: pkg.id }, query: instantQuery })
   )
 
-  const { data: trackDetails, isLoading: isTrackDetailsLoading } = useQuery(
-    api.package.tracks.get.queryOptions(
-      { params: { id: pkg.id, trackId: track! }, query: instantQuery },
-      { enabled: !!track }
-    )
-  )
+  const trackDetailsQuery =
+    details === undefined
+      ? api.package.tracks.get.queryOptions(skipToken)
+      : api.package.tracks.get.queryOptions({
+          params: { id: pkg.id, trackId: details },
+          query: { ...instantQuery, trackId: details },
+        })
+
+  const { data: trackDetails, isLoading: isTrackDetailsLoading } = useQuery(trackDetailsQuery)
 
   return (
-    <ResizablePanelGroup
-      orientation="horizontal"
-      className="min-h-0 w-full h-svh!"
-      defaultLayout={defaultLayout}
-      onLayoutChanged={onLayoutChanged}
-    >
-      <ResizablePanel id="tracks-panel" className="flex min-h-0 min-w-0 flex-col overflow-hidden!">
-        <div className="flex shrink-0 items-center justify-between gap-2 p-4 pb-2">
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Tracks</h1>
-            <p className="text-sm text-muted-foreground">
-              Discover your most listened to tracks based on your listening history
-            </p>
-          </div>
+    <CatalogPageShellRoot hasDetails={!!details}>
+      <CatalogPageShellList>
+        <CatalogPageHeader
+          title="Tracks"
+          description="See which songs you keep coming back to"
+        >
+          <Button variant="outline">
+            <HugeiconsIcon icon={SlidersHorizontalIcon} className="size-4" />
+            Display
+          </Button>
+          <Button variant="secondary">
+            <HugeiconsIcon icon={FilterIcon} className="size-4" />
+            Filters
+          </Button>
+        </CatalogPageHeader>
 
-          <div className="flex items-center gap-1">
-            <Button variant="outline">
-              <HugeiconsIcon icon={SlidersHorizontalIcon} className="size-4" />
-              Display
-            </Button>
-            <Button variant="secondary">
-              <HugeiconsIcon icon={FilterIcon} className="size-4" />
-              Filters
-            </Button>
-          </div>
-        </div>
+        <CatalogDateRangeTabs />
 
-        <div className="shrink-0 border-b border-border px-4">
-          <div className="flex gap-3 pt-4 items-center justify-between">
-            <Tabs value={mode} onValueChange={(value) => setMode(value as DateRangeMode)}>
-              <TabsList variant="line" className="gap-4">
-                <TabsTrigger value="month">Month</TabsTrigger>
-                <TabsTrigger value="year">Years</TabsTrigger>
-                <TabsTrigger value="custom">Custom</TabsTrigger>
-              </TabsList>
-            </Tabs>
-
-            <div className="flex shrink-0 justify-end pb-1">
-              <DateRangeFilter />
-            </div>
-          </div>
-        </div>
-
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain py-2">
+        <CatalogScrollArea>
           <CatalogTable catalog={data?.tracks} empty="No tracks yet." loading={isLoading} />
-        </div>
-      </ResizablePanel>
-      {(trackDetails || isTrackDetailsLoading) && (
-        <>
-          <ResizableHandle />
-          <ResizablePanel id="track-details-panel" defaultSize={300} minSize={300} maxSize={500}>
-            <CatalogDetailsPanel
-              close={() => navigate({ to: '.', search: { track: undefined }, resetScroll: false })}
-              details={trackDetails?.details}
-              isLoading={isTrackDetailsLoading}
-            />
-          </ResizablePanel>
-        </>
-      )}
-    </ResizablePanelGroup>
+        </CatalogScrollArea>
+      </CatalogPageShellList>
+
+      <CatalogPageShellDetails open={!!(trackDetails || isTrackDetailsLoading)}>
+        <CatalogDetailsPanel
+          close={() => navigate({ to: '.', search: { details: undefined }, resetScroll: false })}
+          details={trackDetails?.details}
+          isLoading={isTrackDetailsLoading}
+        />
+      </CatalogPageShellDetails>
+    </CatalogPageShellRoot>
   )
 }


### PR DESCRIPTION
This pull request introduces a new "Albums" feature to the API and web application, allowing users to view top albums for a package, similar to the existing tracks functionality. It adds backend API endpoints, a service layer, DTOs, and integrates the feature into the web frontend with new components, navigation updates, and view mode persistence.

**Albums API and Service Layer:**

- Added a new `AlbumsController` with a `top` endpoint to fetch top albums for a package, including validation and response formatting.
- Implemented `AlbumService` with a `getTopAlbums` method that queries and aggregates album data (streams, playtime, artist names) within a given date range.
- Defined DTOs for top albums and the albums response in `album_dtos.ts`.
- Registered the new albums route in the API client registry and AdonisJS routes, exposing `/api/v1/package/:id/albums` and binding date range middleware. [[1]](diffhunk://#diff-0ef7a27b158243e5ca712fc2279ca4934a23126cc346cefa8ffba1ad2e888c71R87-R92) [[2]](diffhunk://#diff-b885164dbe6fbc90b3f5666daece62d5e57985cfc276e5b55216cf8739695763L53-R56)
- Registered the `AlbumsController` in the controllers registry.

**Frontend Integration and Navigation:**

- Added a new "Albums" entry to the sidebar navigation, linking to `/albums` and removing the "Soon" badge.
- Integrated the albums route into the web app's route tree.

**Catalog UI Components and Layout:**

- Introduced a reusable `CatalogGrid` component for displaying albums/tracks in a grid with ranking, images, and metrics.
- Improved `CatalogTable` with better cell layout and navigation logic for details. [[1]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081L52-R59) [[2]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081L84-R84) [[3]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081L93-R93)
- Added new layout components for catalog pages: date range tabs, page header, scroll area, and a resizable shell for list/details views, enhancing modularity and UX. [[1]](diffhunk://#diff-c475c39ce7dfaaa065f55ea19218246a0287abadf95e596dbdad3962e2c98fd6R1-R26) [[2]](diffhunk://#diff-61998d5870a6fb0cc6bedc340db0e0e45347a004b342b48616db547ac6c49b26R1-R19) [[3]](diffhunk://#diff-506990b5cdeba55a9138abe4c596834b7535e27f1243156677f99c7f889fcce1R1-R61) [[4]](diffhunk://#diff-07d2d6ffa0fb8bf81aaa5c31f96765b838fc64652bcd92aceb49e92f7d54fdccR1-R7) [[5]](diffhunk://#diff-63fdae843e1be0ddc725f70cc442aff585f82945dfb4561c7143065c7e9755ecR1-R5) [[6]](diffhunk://#diff-f4f9025db935b311a880b13134082ff550e6c120bd9f863e7a8fd313a4c9ff1bR1-R5)

**User Preferences and View Modes:**

- Added a persistent user preference store for catalog view mode (grid/list), using cookies for storage, and a `ViewModeMenu` UI for switching modes. [[1]](diffhunk://#diff-61981a7f7497057d6cad64f1f0e4939ebf1841a6b22c890dacd343b4d6de0914L3-R40) [[2]](diffhunk://#diff-3a2c840e6ef8ba1d7592b6d2b558d1f9eb8952e731539491b2ca8821cbdbe341R1-R47)

**Tracks Endpoint Consistency:**

- Updated the tracks controller to validate instant range queries for the top tracks endpoint, matching the new albums endpoint behavior.

These changes collectively add a robust albums feature to both the backend and frontend, improve catalog browsing UX, and lay groundwork for further catalog enhancements.