### PR TITLE
fix: docker env handling and GHCR image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,5 +69,5 @@ jobs:
           push: true
           build-args: ${{ matrix.app.build_args }}
           tags: |
-            ghcr.io/${{ github.repository }}/${{ matrix.app.name }}:latest
-            ghcr.io/${{ github.repository }}/${{ matrix.app.name }}:${{ github.sha }}
+            ghcr.io/abgameur/harmony/${{ matrix.app.name }}:latest
+            ghcr.io/abgameur/harmony/${{ matrix.app.name }}:${{ github.sha }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   api:
-    image: ghcr.io/aBgAmeuR/Harmony/api:latest
+    image: ghcr.io/abgameur/harmony/api:latest
     container_name: harmony-api
     restart: always
     environment:
@@ -25,7 +25,7 @@ services:
       APP_ENV: ${API_APP_ENV:-production}
 
   web:
-    image: ghcr.io/aBgAmeuR/Harmony/web:latest
+    image: ghcr.io/abgameur/harmony/web:latest
     container_name: harmony-web
     restart: always
     environment:


### PR DESCRIPTION
This pull request updates image references in both the GitHub Actions workflow and the `docker-compose.yml` file to use the correct, consistently formatted container registry path. This ensures that images are pulled and pushed from the intended repository, preventing potential deployment issues due to incorrect image names.

Container image reference updates:

* Updated the `docker-compose.yml` file to reference the correct image path (`ghcr.io/abgameur/harmony/...`) for both the `api` and `web` services, fixing previous casing and spelling inconsistencies. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L5-R5) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L28-R28)
* Modified the GitHub Actions workflow (`.github/workflows/release.yml`) to push images to the corrected registry path (`ghcr.io/abgameur/harmony/...`) instead of using the repository variable, ensuring all images are tagged and stored in the intended location.