### PR TITLE
feat: playtime sparklines tracks table

### DIFF
--- a/apps/web/src/components/catalog/catalog-table.tsx
+++ b/apps/web/src/components/catalog/catalog-table.tsx
@@ -1,4 +1,5 @@
-import { Icon, Loading03Icon } from "@harmony/icons";
+import { Icon, Loading03Icon, ViewIcon, ViewOffSlashIcon } from "@harmony/icons";
+import { Button } from "@harmony/ui/components/button";
 import { Card, CardContent } from "@harmony/ui/components/card";
 import {
   Table,
@@ -9,11 +10,14 @@ import {
   TableRow,
 } from "@harmony/ui/components/table";
 import { cn } from "@harmony/ui/lib/utils";
+import { useState } from "react";
 
 import type { Catalog } from "./catalog";
+import type { CatalogTrendPoint } from "./catalog-trend-sparkline";
 
 import { MetricCell } from "../format/metric-cell";
 import { CatalogImage } from "./catalog-image";
+import { CatalogTrendSparkline } from "./catalog-trend-sparkline";
 
 const getRankClassName = (rank: number) => {
   switch (rank) {
@@ -35,6 +39,7 @@ type CatalogTableProps = {
   selectedId?: number;
   onSelectItem?: (item: Catalog) => void;
   stickyHeader?: boolean;
+  trends?: Record<number, CatalogTrendPoint[]>;
 };
 
 export const CatalogTable = ({
@@ -44,7 +49,12 @@ export const CatalogTable = ({
   selectedId,
   onSelectItem,
   stickyHeader = false,
+  trends,
 }: CatalogTableProps) => {
+  const [showSparklines, setShowSparklines] = useState(true);
+  const showTrendColumn = trends !== undefined;
+  const columnCount = showTrendColumn ? 5 : 4;
+
   if (!loading && (!catalog || catalog.length <= 0)) {
     return (
       <Card size="sm">
@@ -59,9 +69,23 @@ export const CatalogTable = ({
     <div className={cn(stickyHeader && "[&_[data-slot=table-container]]:overflow-visible")}>
       <Table className="pb-2">
         <TableHeader className={cn(stickyHeader ? "bg-background!" : "bg-muted/50")}>
-          <TableRow className={cn("bg-background", stickyHeader && "sticky top-0 z-10")}>
+          <TableRow className={cn("bg-background!", stickyHeader && "sticky top-0 z-10")}>
             <TableHead className={cn(headClassName, "w-[35.5px] pl-4 text-center")}>#</TableHead>
             <TableHead className={cn(headClassName, "text-left")}>Title</TableHead>
+            {showTrendColumn && (
+              <TableHead className={cn(headClassName, "w-32")}>
+                <div className="flex items-center">
+                  <span>Trend</span>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={() => setShowSparklines((current) => !current)}
+                  >
+                    <Icon icon={showSparklines ? ViewIcon : ViewOffSlashIcon} />
+                  </Button>
+                </div>
+              </TableHead>
+            )}
             <TableHead className={cn(headClassName, "w-16 text-right tabular-nums")}>
               Streams
             </TableHead>
@@ -74,7 +98,7 @@ export const CatalogTable = ({
           {loading ? (
             <TableRow>
               <TableCell
-                colSpan={4}
+                colSpan={columnCount}
                 className="h-32 text-center align-middle text-sm text-muted-foreground"
               >
                 <div className="flex items-center justify-center gap-2">
@@ -86,6 +110,7 @@ export const CatalogTable = ({
           ) : (
             catalog?.map((item, index) => {
               const selected = selectedId === item.id;
+              const trend = trends?.[item.id];
 
               return (
                 <TableRow
@@ -110,6 +135,13 @@ export const CatalogTable = ({
                       </div>
                     </div>
                   </TableCell>
+                  {showTrendColumn ? (
+                    <TableCell className="py-1.5">
+                      {showSparklines && trend && trend.length > 0 ? (
+                        <CatalogTrendSparkline trend={trend} />
+                      ) : null}
+                    </TableCell>
+                  ) : null}
                   <TableCell className="py-1.5 text-right">
                     <MetricCell value={item.streams} />
                   </TableCell>

--- a/apps/web/src/components/catalog/catalog-trend-sparkline.tsx
+++ b/apps/web/src/components/catalog/catalog-trend-sparkline.tsx
@@ -1,0 +1,65 @@
+import { useId } from "react";
+
+export type CatalogTrendPoint = {
+  date: Date;
+  value: number;
+};
+
+type Point = { x: number; y: number };
+
+const W = 168;
+const H = 28;
+
+function paths(values: number[]) {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const pad = span * 0.12;
+  const y0 = min - pad;
+  const y1 = max + pad;
+  const last = values.length - 1;
+
+  const pts: Point[] = values.map((v, i) => ({
+    x: last === 0 ? W / 2 : (i / last) * W,
+    y: (1 - (v - y0) / (y1 - y0)) * H,
+  }));
+
+  let line = `M${pts[0]!.x} ${pts[0]!.y}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i]!;
+    const p1 = pts[i]!;
+    const p2 = pts[i + 1]!;
+    const p3 = pts[i + 2] ?? p2;
+    line += ` C${p1.x + (p2.x - p0.x) / 6} ${p1.y + (p2.y - p0.y) / 6}, ${p2.x - (p3.x - p1.x) / 6} ${p2.y - (p3.y - p1.y) / 6}, ${p2.x} ${p2.y}`;
+  }
+
+  const a = pts[0]!;
+  const b = pts[pts.length - 1]!;
+  return { line, area: `${line} L${b.x} ${H} L${a.x} ${H} Z` };
+}
+
+export function CatalogTrendSparkline({ trend }: { trend: CatalogTrendPoint[] }) {
+  const id = useId();
+  if (trend.length === 0) return null;
+
+  const { line, area } = paths(trend.map((p) => p.value));
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="h-7 w-full" preserveAspectRatio="none" aria-hidden>
+      <defs>
+        <linearGradient id={id} gradientUnits="userSpaceOnUse" x1={0} y1={0} x2={0} y2={H}>
+          <stop offset="0%" stopColor="var(--chart-2)" stopOpacity={0.4} />
+          <stop offset="100%" stopColor="var(--chart-4)" stopOpacity={0.1} />
+        </linearGradient>
+      </defs>
+      <path d={area} fill={`url(#${id})`} />
+      <path
+        d={line}
+        fill="none"
+        stroke="var(--chart-2)"
+        strokeWidth={2}
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/layout/header/header.tsx
+++ b/apps/web/src/components/layout/header/header.tsx
@@ -18,7 +18,7 @@ export function Header({ title, showArtistSelect = true }: HeaderProps) {
 
         {showArtistSelect && (
           <>
-            <span className="pb-0.5 text-muted-foreground pe-1">/</span>
+            <span className="pe-1 pb-0.5 text-muted-foreground">/</span>
             <ArtistsSelect />
           </>
         )}

--- a/apps/web/src/features/listening/queries/listening-filter.ts
+++ b/apps/web/src/features/listening/queries/listening-filter.ts
@@ -1,4 +1,5 @@
-import { interactionDateConditions, joinWhere, toSqlDate } from "@/lib/sql/date-range";
+import { interactionDateConditions, joinWhere } from "@/lib/sql/date-range";
+import { buildPeriodRange } from "@/lib/sql/period-range";
 
 export type ListeningRangeParams = {
   artistId?: number;
@@ -6,37 +7,16 @@ export type ListeningRangeParams = {
   to: Date;
 };
 
-export function calendarDaySpan(from: Date, to: Date): number {
-  const fromUtc = Date.UTC(from.getFullYear(), from.getMonth(), from.getDate());
-  const toUtc = Date.UTC(to.getFullYear(), to.getMonth(), to.getDate());
-  return (toUtc - fromUtc) / 86_400_000;
-}
+export { calendarDaySpan } from "@/lib/sql/period-range";
 
 export function buildListeningFilter({ artistId, from, to }: ListeningRangeParams) {
-  const fromSql = toSqlDate(from);
-  const toSql = toSqlDate(to);
-  const byDay = calendarDaySpan(from, to) < 31;
   const artistJoin = artistId ? "JOIN tracks t ON t.id = i.track_id" : "";
   const where = joinWhere([
     ...interactionDateConditions(from, to),
     ...(artistId ? [`t.artists @> ARRAY[${artistId}]`] : []),
   ]);
 
-  const periodRange = byDay
-    ? `
-    SELECT generate_series::DATE AS period
-    FROM generate_series(DATE '${fromSql}', DATE '${toSql}', INTERVAL 1 DAY)
-  `
-    : `
-    SELECT date_trunc('month', generate_series::DATE)::DATE AS period
-    FROM generate_series(
-      date_trunc('month', DATE '${fromSql}')::DATE,
-      date_trunc('month', DATE '${toSql}')::DATE,
-      INTERVAL 1 MONTH
-    )
-  `;
-
-  const periodExpr = byDay ? "CAST(i.ts AS DATE)" : "date_trunc('month', i.ts)::DATE";
+  const { byDay, fromSql, toSql, periodRange, periodExpr } = buildPeriodRange(from, to);
 
   return { artistJoin, where, byDay, fromSql, toSql, periodRange, periodExpr };
 }

--- a/apps/web/src/features/tracks/queries.ts
+++ b/apps/web/src/features/tracks/queries.ts
@@ -2,13 +2,14 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { toSqlDate } from "@/lib/sql/date-range";
 
-import { getTrackFn } from "./queries/get";
 import { trackBehavioralFn } from "./queries/behavioral";
 import { trackDevicesFn } from "./queries/devices";
+import { getTrackFn } from "./queries/get";
 import { trackHistoryFn } from "./queries/history";
 import { trackListeningFn } from "./queries/listening";
 import { trackOverviewFn } from "./queries/overview";
 import { topTracksFn } from "./queries/top";
+import { trackTrendsFn } from "./queries/trends";
 import { trackVsAverageFn } from "./queries/vs-average";
 
 type TrackRangeArgs = { trackId: number; from: Date; to: Date };
@@ -19,6 +20,14 @@ export const tracksQueries = {
       queryOptions({
         queryKey: ["tracks", "top", { artistId, from: toSqlDate(from), to: toSqlDate(to) }],
         queryFn: () => topTracksFn({ artistId, from, to }),
+      }),
+  },
+  trends: {
+    queryOptions: ({ trackIds, from, to }: { trackIds: number[]; from: Date; to: Date }) =>
+      queryOptions({
+        queryKey: ["tracks", "trends", { trackIds, from: toSqlDate(from), to: toSqlDate(to) }],
+        queryFn: () => trackTrendsFn({ trackIds, from, to }),
+        enabled: trackIds.length > 0,
       }),
   },
   get: {

--- a/apps/web/src/features/tracks/queries/devices.ts
+++ b/apps/web/src/features/tracks/queries/devices.ts
@@ -46,9 +46,7 @@ function toPrimaryDevices(rows: PlatformRow[]): DeviceShare[] {
   }
 
   const top = withPercent.slice(0, 2);
-  const othersPercentage = withPercent
-    .slice(2)
-    .reduce((sum, device) => sum + device.percentage, 0);
+  const othersPercentage = withPercent.slice(2).reduce((sum, device) => sum + device.percentage, 0);
 
   return [...top, { label: "Others", percentage: othersPercentage }];
 }

--- a/apps/web/src/features/tracks/queries/listening.ts
+++ b/apps/web/src/features/tracks/queries/listening.ts
@@ -44,10 +44,7 @@ function buildTrackPeriodFilter({ trackId, from, to }: TrackListeningParams) {
   const fromSql = toSqlDate(from);
   const toSql = toSqlDate(to);
   const byDay = calendarDaySpan(from, to) < 31;
-  const where = joinWhere([
-    ...interactionDateConditions(from, to),
-    `i.track_id = ${trackId}`,
-  ]);
+  const where = joinWhere([...interactionDateConditions(from, to), `i.track_id = ${trackId}`]);
 
   const periodRange = byDay
     ? `

--- a/apps/web/src/features/tracks/queries/trends.ts
+++ b/apps/web/src/features/tracks/queries/trends.ts
@@ -1,0 +1,79 @@
+import { db } from "@harmony/duckdb";
+
+import { interactionDateConditions, joinWhere } from "@/lib/sql/date-range";
+import { buildPeriodRange } from "@/lib/sql/period-range";
+
+export type TrackTrendPoint = {
+  date: Date;
+  value: number;
+};
+
+export type TrackTrends = Record<number, TrackTrendPoint[]>;
+
+type TrackTrendRow = {
+  track_id: number;
+  period: string | Date;
+  value: number;
+};
+
+type TrackTrendsParams = {
+  trackIds: number[];
+  from: Date;
+  to: Date;
+};
+
+export const trackTrendsFn = async ({
+  trackIds,
+  from,
+  to,
+}: TrackTrendsParams): Promise<TrackTrends> => {
+  if (trackIds.length === 0) {
+    return {};
+  }
+
+  const { periodRange, periodExpr } = buildPeriodRange(from, to);
+  const idsList = trackIds.join(", ");
+  const conditions = [...interactionDateConditions(from, to), `i.track_id IN (${idsList})`];
+
+  const rows = await db.query<TrackTrendRow>(`
+    WITH period_range AS (
+      ${periodRange}
+    ),
+    track_ids AS (
+      SELECT UNNEST([${idsList}])::BIGINT AS track_id
+    ),
+    stats AS (
+      SELECT
+        i.track_id,
+        ${periodExpr} AS period,
+        ROUND(SUM(i.ms_played) / 60000.0)::INTEGER AS value
+      FROM interactions i
+      ${joinWhere(conditions)}
+      GROUP BY i.track_id, ${periodExpr}
+    )
+    SELECT
+      t.track_id,
+      p.period,
+      COALESCE(s.value, 0)::INTEGER AS value
+    FROM track_ids t
+    CROSS JOIN period_range p
+    LEFT JOIN stats s ON s.track_id = t.track_id AND s.period = p.period
+    ORDER BY t.track_id, p.period
+  `);
+
+  const trends: TrackTrends = {};
+  for (const id of trackIds) {
+    trends[id] = [];
+  }
+
+  for (const row of rows) {
+    const points = trends[row.track_id];
+    if (!points) continue;
+    points.push({
+      date: row.period instanceof Date ? row.period : new Date(row.period),
+      value: row.value,
+    });
+  }
+
+  return trends;
+};

--- a/apps/web/src/lib/sql/period-range.ts
+++ b/apps/web/src/lib/sql/period-range.ts
@@ -1,0 +1,31 @@
+import { toSqlDate } from "./date-range";
+
+export function calendarDaySpan(from: Date, to: Date): number {
+  const fromUtc = Date.UTC(from.getFullYear(), from.getMonth(), from.getDate());
+  const toUtc = Date.UTC(to.getFullYear(), to.getMonth(), to.getDate());
+  return (toUtc - fromUtc) / 86_400_000;
+}
+
+export function buildPeriodRange(from: Date, to: Date) {
+  const fromSql = toSqlDate(from);
+  const toSql = toSqlDate(to);
+  const byDay = calendarDaySpan(from, to) < 31;
+
+  const periodRange = byDay
+    ? `
+    SELECT generate_series::DATE AS period
+    FROM generate_series(DATE '${fromSql}', DATE '${toSql}', INTERVAL 1 DAY)
+  `
+    : `
+    SELECT date_trunc('month', generate_series::DATE)::DATE AS period
+    FROM generate_series(
+      date_trunc('month', DATE '${fromSql}')::DATE,
+      date_trunc('month', DATE '${toSql}')::DATE,
+      INTERVAL 1 MONTH
+    )
+  `;
+
+  const periodExpr = byDay ? "CAST(i.ts AS DATE)" : "date_trunc('month', i.ts)::DATE";
+
+  return { byDay, fromSql, toSql, periodRange, periodExpr };
+}

--- a/apps/web/src/routes/app/$packageId/listening.tsx
+++ b/apps/web/src/routes/app/$packageId/listening.tsx
@@ -2,19 +2,19 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { Header } from "@/components/layout/header/header";
 import { ActiveDaysWidget } from "@/features/listening/widgets/active-days-widget";
+import { GenresWidget } from "@/features/listening/widgets/genres-widget";
+import { ListeningStyleWidget } from "@/features/listening/widgets/listening-style-widget";
 import { ListeningTimeWidget } from "@/features/listening/widgets/listening-time-widget";
 import { MonthlyActivityWidget } from "@/features/listening/widgets/monthly-activity-widget";
+import { PeakHoursWidget } from "@/features/listening/widgets/peak-hours-widget";
+import { PlatformsWidget } from "@/features/listening/widgets/platforms-widget";
+import { ReleaseYearWidget } from "@/features/listening/widgets/release-year-widget";
 import { TotalStreamsWidget } from "@/features/listening/widgets/total-streams-widget";
+import { TrackEngagementWidget } from "@/features/listening/widgets/track-engagement-widget";
 import { UniqueTracksWidget } from "@/features/listening/widgets/unique-tracks-widget";
 import { query } from "@/lib/query";
 import { useArtistStore } from "@/lib/stores/artist-store";
 import { buildInstantRangeQuery, useDateRangeStore } from "@/lib/stores/date-range-store";
-import { PeakHoursWidget } from "@/features/listening/widgets/peak-hours-widget";
-import { PlatformsWidget } from "@/features/listening/widgets/platforms-widget";
-import { ListeningStyleWidget } from "@/features/listening/widgets/listening-style-widget";
-import { TrackEngagementWidget } from "@/features/listening/widgets/track-engagement-widget";
-import { ReleaseYearWidget } from "@/features/listening/widgets/release-year-widget";
-import { GenresWidget } from "@/features/listening/widgets/genres-widget";
 
 export const Route = createFileRoute("/app/$packageId/listening")({
   ssr: false,
@@ -52,23 +52,23 @@ function RouteComponent() {
             {/* <DaysOfWeekWidget /> */}
           </div>
         </div>
-        
-          {/* <WhenYouListenWidget /> */}
 
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <PeakHoursWidget />
-            <PlatformsWidget />
-          </div>
+        {/* <WhenYouListenWidget /> */}
 
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_2fr]">
-            <ListeningStyleWidget />
-            <TrackEngagementWidget />
-          </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <PeakHoursWidget />
+          <PlatformsWidget />
+        </div>
 
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <ReleaseYearWidget />
-            <GenresWidget />
-          </div>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_2fr]">
+          <ListeningStyleWidget />
+          <TrackEngagementWidget />
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <ReleaseYearWidget />
+          <GenresWidget />
+        </div>
       </main>
     </div>
   );

--- a/apps/web/src/routes/app/$packageId/tracks.tsx
+++ b/apps/web/src/routes/app/$packageId/tracks.tsx
@@ -37,6 +37,8 @@ function RouteComponent() {
   const artistId = useArtistStore((s) => s.artist?.id);
   const { from, to } = useInstantRangeQuery();
   const { data, isLoading } = useQuery(query.tracks.top.queryOptions({ artistId, from, to }));
+  const trackIds = data?.map((track) => track.id) ?? [];
+  const { data: trends } = useQuery(query.tracks.trends.queryOptions({ trackIds, from, to }));
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   useEffect(() => {
@@ -77,6 +79,7 @@ function RouteComponent() {
               selectedId={selectedId ?? undefined}
               onSelectItem={handleSelectItem}
               stickyHeader
+              trends={trends ?? {}}
             />
           </ScrollArea>
         </ResizablePanel>


### PR DESCRIPTION
This pull request introduces a new "trend" (sparkline) column to the catalog table, enabling users to visualize track trends over time. It also refactors how time period ranges are calculated and adds a new backend query for fetching track trend data. The changes are grouped into frontend feature additions, backend/query enhancements, and code organization improvements.

**Frontend: Catalog Table Trend Visualization**

- Added an optional "Trend" column to the `CatalogTable` component, displaying a sparkline for each track if trend data is provided. Users can toggle the visibility of sparklines with a button in the column header. (`catalog-table.tsx`, `catalog-trend-sparkline.tsx`) [[1]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081L1-R2) [[2]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081R13-R20) [[3]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081R42) [[4]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081R52-R57) [[5]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081L62-R88) [[6]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081L77-R101) [[7]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081R113) [[8]](diffhunk://#diff-ba837be81a02639c98fa6e6bf5de060e17773dbe76376823d744bd65b0ae9081R138-R144) [[9]](diffhunk://#diff-c80b727826f0df641d4eaf51ab98d8fe6ccb4c5271d4bad52accc882256b1303R1-R65)

- Updated the `/app/$packageId/tracks` route to fetch and pass trend data to the catalog table, using a new query. (`tracks.tsx`) [[1]](diffhunk://#diff-43149824c33c8de0666399fc21e4c85d67e2c1bc86d3689d2f2c3fd4f1edceccR40-R41) [[2]](diffhunk://#diff-43149824c33c8de0666399fc21e4c85d67e2c1bc86d3689d2f2c3fd4f1edceccR82)

**Backend/Queries: Track Trends and Period Range Calculation**

- Added a new `trackTrendsFn` backend function and query for fetching per-track, per-period trend data (minutes played per day or month), and exposed it in the track queries API. (`queries/trends.ts`, `queries.ts`) [[1]](diffhunk://#diff-e162d7b8ed62bef8201b83fa58d483679d8cab48652f9cf74c94ed88cb71df42R1-R79) [[2]](diffhunk://#diff-78200459e377c6be8529b0609759f1bc50af8b0eecd90069f172dbc41878b4aeL5-R12) [[3]](diffhunk://#diff-78200459e377c6be8529b0609759f1bc50af8b0eecd90069f172dbc41878b4aeR25-R32)

- Refactored period range calculation logic into a shared utility (`buildPeriodRange` and `calendarDaySpan`), and updated related queries to use this utility for consistent day/month grouping. (`period-range.ts`, `listening-filter.ts`, `queries/listening.ts`) [[1]](diffhunk://#diff-dc7249d8dd21006580b46c24fc80a3727b64a6f34af086447fe6582ff6c63768R1-R31) [[2]](diffhunk://#diff-758432b52df7c7a00715931c08fd3898534eadf6ceb3ee2b8f5fd436ed8a1e67L1-R19) [[3]](diffhunk://#diff-7c1ab4a83655aec74e2c455b73f5ec4f09c855e5974a043e35eb59b2952e3721L47-R47)

**Code Organization & Cleanup**

- Minor import cleanups and code formatting in several files for improved readability and maintainability. [[1]](diffhunk://#diff-027087a8788d6a57d32503bc4511407af07f84b37e9882398956818a4675e569L21-R21) [[2]](diffhunk://#diff-55a9666deac4fbd5db7b6ade95d38dbf1d7c0a68b2241c5a2c605831f59a50dfL49-R49) [[3]](diffhunk://#diff-807a85131462721dfa61daa8b1fdc20f5fffc8d703535fb26d686fb285f6075bR5-L17)

These changes collectively add a new visual trend feature to the catalog table, improve backend support for trend data, and standardize time period handling across the codebase.