### PR TITLE
feat!: enable semantic-release beta for v3

### DIFF
--- a/.agents/skills/improve/SKILL.md
+++ b/.agents/skills/improve/SKILL.md
@@ -9,13 +9,13 @@ metadata:
 
 # Improve
 
-You are a **senior advisor, not an implementer**. Your job is to deeply understand a codebase, find the highest-value improvement opportunities, and write implementation plans good enough that a *different, less capable model with zero context from this session* can execute, test, and maintain them.
+You are a **senior advisor, not an implementer**. Your job is to deeply understand a codebase, find the highest-value improvement opportunities, and write implementation plans good enough that a _different, less capable model with zero context from this session_ can execute, test, and maintain them.
 
 The economics of this skill: an expensive, high-ceiling model does the part where intelligence compounds (understanding, judging, specifying). Cheaper models do the execution. The plan is the product — its quality determines whether the executor succeeds.
 
 ## Hard Rules
 
-1. **Never modify source code yourself.** No edits, no fixes, no "quick wins while you're in there." The ONLY files you may create or modify live under `plans/` in the repo root — or under `advisor-plans/` when `plans/` already exists for an unrelated purpose (create the chosen directory if absent). The `execute` variant dispatches a *separate executor subagent* that edits code in an isolated git worktree — you review its diff and render a verdict; you still never edit code directly, and you never merge, push, or commit to the user's branch.
+1. **Never modify source code yourself.** No edits, no fixes, no "quick wins while you're in there." The ONLY files you may create or modify live under `plans/` in the repo root — or under `advisor-plans/` when `plans/` already exists for an unrelated purpose (create the chosen directory if absent). The `execute` variant dispatches a _separate executor subagent_ that edits code in an isolated git worktree — you review its diff and render a verdict; you still never edit code directly, and you never merge, push, or commit to the user's branch.
 2. **Never run commands that mutate the user's working tree** — no installs, no builds that write artifacts outside standard ignored dirs, no git commits, no formatters. Read, search, and run read-only analysis only (e.g. `tsc --noEmit`, lint in check mode, `npm audit` / `pnpm audit`, test suite if cheap and side-effect free). Two scoped exceptions: verification commands inside an executor's disposable worktree during `execute` review, and `gh issue create` under an explicit `--issues` flag.
 3. **Every plan must be fully self-contained.** The executor has not seen this conversation, this codebase survey, or any other plan. If a plan references "the pattern discussed above," it is broken.
 4. **Never reproduce secret values.** If the audit finds credentials, tokens, or `.env` contents, findings and plans reference the `file:line` and credential type only, and recommend rotation. The value itself must never appear in anything you write.
@@ -30,7 +30,7 @@ Map the territory before judging it:
 
 - Read `README`, `CLAUDE.md`/`AGENTS.md`, `CONTRIBUTING`, root config files (`package.json`, `pyproject.toml`, `go.mod`, etc.), CI config, and the directory structure.
 - Identify: language(s), framework(s), package manager, **how to build / test / lint / typecheck** (exact commands — these go into every plan as verification gates), test coverage shape, deployment target.
-- Note repo conventions: code style, naming, folder layout, error-handling and state-management patterns. Plans must tell the executor to *match* these, with examples.
+- Note repo conventions: code style, naming, folder layout, error-handling and state-management patterns. Plans must tell the executor to _match_ these, with examples.
 - **Ingest intent & design docs where present** — they record decided tradeoffs and product direction the code itself can't tell you. Glob for ADRs (`docs/adr/`, `docs/adrs/`, `docs/decisions/`), PRDs / specs, `CONTEXT.md` (shared domain vocabulary), `DESIGN.md` (design-system spec), and `PRODUCT.md` (product brief). Strictly additive: read what exists, no-op when absent. Carry what you learn forward — into Vet (a tradeoff recorded in an ADR is by-design, not a finding), Direction (ground suggestions in stated product intent), and the plans themselves (match the documented vocabulary and design system). Reading these docs lets `/improve` compose with repos that already maintain them.
 - Check git signal where useful (`git log --oneline -30`, churn hotspots) for what's actively evolving vs. frozen.
 
@@ -51,15 +51,15 @@ For repos of any real size, fan out with parallel read-only subagents (in Claude
 
 Audit depth follows the **effort level** (default `standard`; the user sets it with a `quick` / `deep` keyword anywhere in the invocation):
 
-| | `quick` | `standard` (default) | `deep` |
-|---|---|---|---|
-| Coverage | Recon hotspots only — highest-churn, highest-criticality code | Hotspot-weighted, key packages | Whole repo, every package |
-| Subagents | 0–1 (sweep directly when feasible) | ≤4 concurrent | ≤8 concurrent, one per category |
-| Breadth | "medium" | "very thorough" for correctness + security, "medium" rest | "very thorough" everywhere |
-| Categories | correctness, security, tests | all nine | all nine |
-| Findings | top ~6, HIGH-confidence only | full table | full table incl. LOW-confidence "investigate" items |
+|            | `quick`                                                       | `standard` (default)                                      | `deep`                                              |
+| ---------- | ------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------- |
+| Coverage   | Recon hotspots only — highest-churn, highest-criticality code | Hotspot-weighted, key packages                            | Whole repo, every package                           |
+| Subagents  | 0–1 (sweep directly when feasible)                            | ≤4 concurrent                                             | ≤8 concurrent, one per category                     |
+| Breadth    | "medium"                                                      | "very thorough" for correctness + security, "medium" rest | "very thorough" everywhere                          |
+| Categories | correctness, security, tests                                  | all nine                                                  | all nine                                            |
+| Findings   | top ~6, HIGH-confidence only                                  | full table                                                | full table incl. LOW-confidence "investigate" items |
 
-Whatever the level, say in the final report what was *not* audited. On a large monorepo even `deep` scopes subagents to packages, not the root.
+Whatever the level, say in the final report what was _not_ audited. On a large monorepo even `deep` scopes subagents to packages, not the root.
 
 Every finding needs: evidence (`file:line` references), impact, effort estimate (S/M/L), risk of the fix itself, and confidence. No vibes-only findings.
 

--- a/.agents/skills/improve/references/audit-playbook.md
+++ b/.agents/skills/improve/references/audit-playbook.md
@@ -25,7 +25,7 @@ Review only what is directly supported by code evidence. Keep findings framed as
 
 **Handling rule:** never copy a secret value into a finding or plan — those files get committed. Reference the `file:line` and credential type only ("Stripe live key at `config.ts:12`"), and the fix sketch always includes rotation, not just removal (a committed secret is burned even after deletion).
 
-**By-design is not a finding:** standard platform conventions are intentional behavior — honoring `https_proxy`/`NO_PROXY`, reading `~/.netrc`, an explicitly local dev tool shelling out to configured package managers. A tradeoff explicitly recorded in an ADR or decision doc is likewise settled, not a finding. Flag these only when the *implementation* adds risk beyond the convention or the documented decision itself — and note that a **stale ADR is itself a finding**: if the code has drifted from what the decision doc says, report the decision drift (the doc or the code is wrong; either way the team should know), don't use the doc to suppress it.
+**By-design is not a finding:** standard platform conventions are intentional behavior — honoring `https_proxy`/`NO_PROXY`, reading `~/.netrc`, an explicitly local dev tool shelling out to configured package managers. A tradeoff explicitly recorded in an ADR or decision doc is likewise settled, not a finding. Flag these only when the _implementation_ adds risk beyond the convention or the documented decision itself — and note that a **stale ADR is itself a finding**: if the code has drifted from what the decision doc says, report the decision drift (the doc or the code is wrong; either way the team should know), don't use the doc to suppress it.
 
 - Credential hygiene: hardcoded keys/tokens/passwords, credentials in committed `.env` files, credentials logged or persisted in event/history stores. Findings should name only the credential type and location, then recommend removal, rotation, and a safer configuration path.
 - Data crossing into interpreters or privileged APIs: SQL or shell operations assembled from request data (SQL/command injection), HTML sinks fed by user-controlled content (XSS), dynamic execution APIs used with runtime input, or filesystem paths derived from request data (path traversal). Describe the safer API or validation boundary; do not provide runnable examples.
@@ -42,14 +42,14 @@ Look for the algorithmic and architectural wins, not micro-optimizations.
 - N+1 patterns: query/fetch per item inside loops or per list-row rendering; missing batching or dataloader.
 - Wrong complexity: nested scans over the same collection, repeated `find`/`filter` inside hot loops where a Map keyed lookup belongs.
 - Caching gaps: identical expensive computations or fetches repeated per request/render; missing memoization at clear function boundaries; no HTTP/data-layer caching on stable data.
-- Payload size: over-fetching (select *, full objects where IDs suffice), missing pagination on unbounded lists, large JSON shipped to clients.
+- Payload size: over-fetching (select \*, full objects where IDs suffice), missing pagination on unbounded lists, large JSON shipped to clients.
 - Frontend (if applicable): bundle composition (heavyweight deps for trivial use), missing code-splitting on rarely-hit routes, unoptimized images/fonts, client-side fetching for data available at render time, render waterfalls. For React/Next.js, defer to the repo's framework conventions and any installed best-practices guidelines.
 - Backend: synchronous work that belongs in a queue, missing indexes implied by query patterns (flag for verification — don't claim without schema evidence), connection-per-request patterns where pooling exists.
 - Build/CI: slow CI from missing caching, redundant pipeline steps, test suites that could parallelize.
 
 ## 4. Test Coverage
 
-The goal is not a percentage — it's *which untested code is dangerous*.
+The goal is not a percentage — it's _which untested code is dangerous_.
 
 - Map the critical paths (money, auth, data mutation, the feature the repo exists for) and check which have zero or trivial coverage.
 - Modules with high churn (git log) + no tests = top refactor risk; flag as "characterization tests first" candidates.
@@ -101,7 +101,7 @@ Forward-looking: not what's broken, but what this codebase wants to become. **Gr
 - **The adjacent possible**: capabilities the existing architecture makes disproportionately cheap — a plugin system one interface away, a public API one route file from the existing service layer, an integration the data model already supports.
 - **Friction worth productizing**: things users of this project evidently do by hand around it (visible in docs, examples, issues) that the project could absorb.
 
-Direction findings use the standard format with two adaptations: **Impact** is product/user value (who wants this and why now), and **Confidence** reflects how grounded the evidence is — not certainty that it's the right call. Strategy belongs to the maintainer; the advisor's job is grounded options with honest trade-offs. Effort estimates here are coarser; say so. Plans for selected direction findings are usually a *design/spike plan* (investigate, prototype, define the API, list open questions) rather than a build-everything plan — scope them that way.
+Direction findings use the standard format with two adaptations: **Impact** is product/user value (who wants this and why now), and **Confidence** reflects how grounded the evidence is — not certainty that it's the right call. Strategy belongs to the maintainer; the advisor's job is grounded options with honest trade-offs. Effort estimates here are coarser; say so. Plans for selected direction findings are usually a _design/spike plan_ (investigate, prototype, define the API, list open questions) rather than a build-everything plan — scope them that way.
 
 ---
 
@@ -114,7 +114,7 @@ Every finding, from every category and every subagent, comes back in this shape:
 
 - **Evidence**: `path/file.ts:123` — one-sentence description of what's there. (Repeat per location; 2–5 strongest locations, note "and ~N similar sites" if widespread.)
 - **Impact**: What goes wrong / what's being paid because of this. Concrete: "every order-list render issues 1+N queries", not "suboptimal".
-- **Effort**: S (hours) / M (a day-ish) / L (multi-day) — for the *fix*, including tests.
+- **Effort**: S (hours) / M (a day-ish) / L (multi-day) — for the _fix_, including tests.
 - **Risk**: What the fix could break; LOW/MED/HIGH plus one line why.
 - **Confidence**: HIGH (read the code, certain) / MED (strong signal, needs verification) / LOW (smell, needs investigation). LOW-confidence findings may be reported but get an "investigate" plan, not a "fix" plan.
 - **Fix sketch**: 1–3 sentences. Not the plan — just enough to judge effort honestly.

--- a/.agents/skills/improve/references/closing-the-loop.md
+++ b/.agents/skills/improve/references/closing-the-loop.md
@@ -2,7 +2,7 @@
 
 The advisor's job doesn't end at the plan. This file covers the three follow-through flows: dispatching an executor and reviewing its work (`execute`), keeping the plan backlog alive (`reconcile`), and publishing plans where work gets picked up (`--issues`).
 
-The founding rule survives unchanged: **the advisor never edits source code.** In `execute`, a *separate executor subagent* edits code in an isolated git worktree; the advisor dispatches, reviews, and renders a verdict — like a tech lead who doesn't push commits to your branch.
+The founding rule survives unchanged: **the advisor never edits source code.** In `execute`, a _separate executor subagent_ edits code in an isolated git worktree; the advisor dispatches, reviews, and renders a verdict — like a tech lead who doesn't push commits to your branch.
 
 ---
 
@@ -58,13 +58,13 @@ Review like a tech lead reviewing a PR against the spec — never fix anything y
 
 ### Verdict
 
-**Documented deviations are judged on merit, not reflex-blocked.** "Do not improvise" exists to stop silent drift; an executor that hits a real obstacle (e.g. the plan's approach breaks existing test mocks), adapts minimally, and explains it in NOTES has done the right thing. Approve it if the adaptation serves the plan's intent and stays in scope; treat *undocumented* deviations as review failures.
+**Documented deviations are judged on merit, not reflex-blocked.** "Do not improvise" exists to stop silent drift; an executor that hits a real obstacle (e.g. the plan's approach breaks existing test mocks), adapts minimally, and explains it in NOTES has done the right thing. Approve it if the adaptation serves the plan's intent and stays in scope; treat _undocumented_ deviations as review failures.
 
-| Verdict | When | Action |
-|---|---|---|
-| **APPROVE** | Criteria pass, scope clean, quality holds | Update index status to DONE. Present to the user: diff summary, worktree path and branch, anything from NOTES. **Merging is the user's decision — never merge, push, or commit to their branch.** |
-| **REVISE** | Fixable gaps | SendMessage to the same executor with specific, actionable feedback ("criterion 3 fails: X; the error handling in `api.ts:90` swallows the error — use the Result pattern per the plan"). **Max 2 revision rounds**, then BLOCK. |
-| **BLOCK** | STOP condition hit, scope violated unrecoverably, or revisions exhausted | Mark BLOCKED in the index with the reason. Refine or rewrite the plan with what was learned. Tell the user what happened and what changed in the plan. |
+| Verdict     | When                                                                     | Action                                                                                                                                                                                                                           |
+| ----------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **APPROVE** | Criteria pass, scope clean, quality holds                                | Update index status to DONE. Present to the user: diff summary, worktree path and branch, anything from NOTES. **Merging is the user's decision — never merge, push, or commit to their branch.**                                |
+| **REVISE**  | Fixable gaps                                                             | SendMessage to the same executor with specific, actionable feedback ("criterion 3 fails: X; the error handling in `api.ts:90` swallows the error — use the Result pattern per the plan"). **Max 2 revision rounds**, then BLOCK. |
+| **BLOCK**   | STOP condition hit, scope violated unrecoverably, or revisions exhausted | Mark BLOCKED in the index with the reason. Refine or rewrite the plan with what was learned. Tell the user what happened and what changed in the plan.                                                                           |
 
 Running verification commands inside the executor's worktree is fine — it's isolated and disposable. The no-mutating-commands rule protects the user's working tree, not the worktree.
 

--- a/.agents/skills/improve/references/plan-template.md
+++ b/.agents/skills/improve/references/plan-template.md
@@ -5,7 +5,7 @@ Every plan is written for an executor model that has **zero context**: it has no
 Three properties make a plan executable by a weaker model:
 
 1. **Self-contained context** — everything needed is in the file: paths, code excerpts, conventions, commands.
-2. **Verification gates** — every step ends with a command and its expected result. The executor never has to *judge* whether it succeeded.
+2. **Verification gates** — every step ends with a command and its expected result. The executor never has to _judge_ whether it succeeded.
 3. **Hard boundaries and escape hatches** — explicit out-of-scope list, and "STOP and report" conditions instead of letting the model improvise when reality doesn't match the plan.
 
 File naming: `plans/NNN-short-slug.md`, numbered in recommended execution order.
@@ -34,7 +34,7 @@ File naming: `plans/NNN-short-slug.md`, numbered in recommended execution order.
 - **Priority**: P1 | P2 | P3
 - **Effort**: S | M | L
 - **Risk**: LOW | MED | HIGH
-- **Depends on**: plans/NNN-*.md (or "none")
+- **Depends on**: plans/NNN-\*.md (or "none")
 - **Category**: bug | security | perf | tests | tech-debt | migration | dx | docs | direction
 - **Planned at**: commit `<short SHA>`, <YYYY-MM-DD>
 - **Issue**: <GitHub issue URL — only when published via `--issues`; omit otherwise>
@@ -64,12 +64,12 @@ The facts the executor needs, inlined — never "as discussed" or "see audit":
 
 ## Commands you will need
 
-| Purpose   | Command                  | Expected on success |
-|-----------|--------------------------|---------------------|
-| Install   | `pnpm install`           | exit 0              |
-| Typecheck | `pnpm typecheck`         | exit 0, no errors   |
-| Tests     | `pnpm test -- <filter>`  | all pass            |
-| Lint      | `pnpm lint`              | exit 0              |
+| Purpose   | Command                 | Expected on success |
+| --------- | ----------------------- | ------------------- |
+| Install   | `pnpm install`          | exit 0              |
+| Typecheck | `pnpm typecheck`        | exit 0, no errors   |
+| Tests     | `pnpm test -- <filter>` | all pass            |
+| Lint      | `pnpm lint`             | exit 0              |
 
 (Exact commands from this repo — verified during recon, not guessed.)
 
@@ -85,10 +85,12 @@ executor's environment. Skip the section otherwise.)
 ## Scope
 
 **In scope** (the only files you should modify):
+
 - `src/orders/api.ts`
 - `src/orders/api.test.ts` (create)
 
 **Out of scope** (do NOT touch, even though they look related):
+
 - `src/orders/legacy-api.ts` — deprecated path, scheduled for deletion;
   changing it wastes effort and risks the v1 clients still pinned to it.
 - Any change to the public response shape — clients depend on it.
@@ -171,7 +173,7 @@ honor its STOP conditions, and update your row when done.
 ## Execution order & status
 
 | Plan | Title | Priority | Effort | Depends on | Status |
-|------|-------|----------|--------|------------|--------|
+| ---- | ----- | -------- | ------ | ---------- | ------ |
 | 001  | ...   | P1       | S      | —          | TODO   |
 | 002  | ...   | P1       | M      | 001        | TODO   |
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": [
+    "master",
     {
       "name": "v3",
       "prerelease": "beta",

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -30,11 +30,11 @@ That is the valid form of “v3.0 beta 01”: SemVer requires the patch segment
 
 While `v3` is configured as a beta channel:
 
-| Commit type | Effect |
-| --- | --- |
-| `BREAKING CHANGE` / `!` | major → starts next line (use once to leave `2.x` for `3.0.0-beta.1`) |
-| `feat:`, `fix:`, `chore:`, … | patch → increments `beta.N` on the current `3.0.0` line |
-| `deploy:` (compose pin) | no release |
+| Commit type                  | Effect                                                                |
+| ---------------------------- | --------------------------------------------------------------------- |
+| `BREAKING CHANGE` / `!`      | major → starts next line (use once to leave `2.x` for `3.0.0-beta.1`) |
+| `feat:`, `fix:`, `chore:`, … | patch → increments `beta.N` on the current `3.0.0` line               |
+| `deploy:` (compose pin)      | no release                                                            |
 
 After the first `3.0.0-beta.1`, everyday merges only bump `beta.N` (features do
 not become `3.1.0-beta.1` during this phase).
@@ -80,17 +80,17 @@ not required as GitHub Actions variables.
    that has `read:packages`.
 5. **Environment variables** for the stack (required unless noted):
 
-| Variable | Required | Notes |
-| --- | --- | --- |
-| `API_URL` | yes | Public API base URL for the web service |
-| `BUCKET_URL` | yes | Public DuckDB / CDN base URL for the web service |
-| `DATABASE_URL` | yes | Postgres connection string |
-| `S3_ENDPOINT` | yes | R2 / S3-compatible endpoint |
-| `S3_BUCKET` | yes | Bucket name |
-| `AWS_ACCESS_KEY_ID` | yes | Object storage access key |
-| `AWS_SECRET_ACCESS_KEY` | yes | Object storage secret |
-| `DEEZER_PROXY_URLS` | yes | Comma-separated proxy URLs |
-| `DEEZER_PROXY_SECRET` | yes | Proxy shared secret |
+| Variable                | Required | Notes                                            |
+| ----------------------- | -------- | ------------------------------------------------ |
+| `API_URL`               | yes      | Public API base URL for the web service          |
+| `BUCKET_URL`            | yes      | Public DuckDB / CDN base URL for the web service |
+| `DATABASE_URL`          | yes      | Postgres connection string                       |
+| `S3_ENDPOINT`           | yes      | R2 / S3-compatible endpoint                      |
+| `S3_BUCKET`             | yes      | Bucket name                                      |
+| `AWS_ACCESS_KEY_ID`     | yes      | Object storage access key                        |
+| `AWS_SECRET_ACCESS_KEY` | yes      | Object storage secret                            |
+| `DEEZER_PROXY_URLS`     | yes      | Comma-separated proxy URLs                       |
+| `DEEZER_PROXY_SECRET`   | yes      | Proxy shared secret                              |
 
 6. Deploy the stack. After the next successful release, wait one poll interval and
    confirm both services show image tags equal to the latest beta tag (for

--- a/apps/web/src/components/upload/steps/stats-step.tsx
+++ b/apps/web/src/components/upload/steps/stats-step.tsx
@@ -41,7 +41,7 @@ function formatListeningTime(totalMinutes: number): string {
 
 export function StatsStep({ uploadId, uploadCompleted, onBack, canBack = true }: StatsStepProps) {
   const { config } = useRouteContext({ from: "/app/$packageId/package" });
-  
+
   const statsQuery = useQuery({
     queryKey: ["upload-stats", uploadId],
     enabled: Boolean(uploadId) && uploadCompleted,

--- a/apps/web/src/lib/public-config.ts
+++ b/apps/web/src/lib/public-config.ts
@@ -7,6 +7,6 @@ export const getPublicConfig = createServerFn({ method: "GET" }).handler(() => {
   if (!apiUrl || !bucketUrl) {
     throw new Error("API_URL and BUCKET_URL must be set");
   }
-  
+
   return { apiUrl, bucketUrl };
 });

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -2,10 +2,10 @@ import { TooltipProvider } from "@harmony/ui/components/tooltip";
 import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
 import { HeadContent, Outlet, Scripts, createRootRouteWithContext } from "@tanstack/react-router";
 
+import { getPublicConfig } from "@/lib/public-config";
 import { queryClient } from "@/lib/query-client";
 
 import appCss from "../index.css?url";
-import { getPublicConfig } from "@/lib/public-config";
 
 export interface RouterAppContext {
   queryClient: QueryClient;

--- a/apps/web/src/routes/app/$packageId/package.tsx
+++ b/apps/web/src/routes/app/$packageId/package.tsx
@@ -68,7 +68,7 @@ const periodQuery = query.packages.period.queryOptions();
 
 export const Route = createFileRoute("/app/$packageId/package")({
   ssr: false,
-  loader: async ({ context: { queryClient, config }, parentMatchPromise, params  }) => {
+  loader: async ({ context: { queryClient, config }, parentMatchPromise, params }) => {
     await parentMatchPromise;
     await Promise.all([
       queryClient.ensureQueryData(packageQuery(config.apiUrl, params.packageId)),


### PR DESCRIPTION
BREAKING CHANGE: start of the Harmony v3 beta line. Require master as stable release branch so v3 can publish v3.0.0-beta.N.