### PR TITLE
fix: duckdb vite config

### DIFF
--- a/apps/benchmark/vite.config.ts
+++ b/apps/benchmark/vite.config.ts
@@ -23,11 +23,4 @@ export default defineConfig({
   resolve: {
     tsconfigPaths: true,
   },
-  optimizeDeps: {
-    exclude: ["@duckdb/duckdb-wasm"],
-  },
-  ssr: {
-    // Keep the Node entry out of the SSR bundle; duckdb-wasm is browser-only.
-    external: ["@duckdb/duckdb-wasm"],
-  },
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -28,11 +28,4 @@ export default defineConfig({
   resolve: {
     tsconfigPaths: true,
   },
-  optimizeDeps: {
-    exclude: ["@duckdb/duckdb-wasm"],
-  },
-  ssr: {
-    // Keep the Node entry out of the SSR bundle; duckdb-wasm is browser-only.
-    external: ["@duckdb/duckdb-wasm"],
-  },
 });

--- a/packages/duckdb/src/duckdb.ts
+++ b/packages/duckdb/src/duckdb.ts
@@ -1,5 +1,4 @@
-import type { AsyncDuckDB, DuckDBBundles } from "@duckdb/duckdb-wasm";
-
+import * as duckdb from "@duckdb/duckdb-wasm";
 import eh_worker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
 import mvp_worker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
 import duckdb_wasm_eh from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
@@ -7,7 +6,7 @@ import duckdb_wasm from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
 
 import { DuckDBEnvironmentError, DuckDBFetchError, DuckDBPackageNotFoundError } from "./error";
 
-const MANUAL_BUNDLES: DuckDBBundles = {
+const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
   mvp: {
     mainModule: duckdb_wasm,
     mainWorker: mvp_worker,
@@ -18,8 +17,8 @@ const MANUAL_BUNDLES: DuckDBBundles = {
   },
 };
 
-let dbInstance: AsyncDuckDB | null = null;
-let initPromise: Promise<AsyncDuckDB> | null = null;
+let dbInstance: duckdb.AsyncDuckDB | null = null;
+let initPromise: Promise<duckdb.AsyncDuckDB> | null = null;
 
 export const getDuckDBInstance = async () => {
   if (typeof window === "undefined") {
@@ -30,9 +29,6 @@ export const getDuckDBInstance = async () => {
   if (initPromise) return initPromise;
 
   initPromise = (async () => {
-    // Dynamic import keeps the Node entry (`duckdb-node.cjs`) out of the SSR
-    // module graph. Vite resolves the browser build for the client bundle.
-    const duckdb = await import("@duckdb/duckdb-wasm");
     const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
 
     const worker = new Worker(bundle.mainWorker!);
@@ -49,7 +45,7 @@ export const getDuckDBInstance = async () => {
 };
 
 export async function registerPackageDatabase(
-  dbInstance: AsyncDuckDB,
+  dbInstance: duckdb.AsyncDuckDB,
   packageId: string,
   url: string,
 ) {


### PR DESCRIPTION
This pull request refactors how `@duckdb/duckdb-wasm` is imported and simplifies Vite configuration for both the `benchmark` and `web` apps. The main changes involve switching from dynamic to static imports for DuckDB, updating type usage, and removing custom Vite dependency and SSR exclusions for DuckDB.

### DuckDB Import Refactor

* Changed from dynamic to static import for all DuckDB symbols in `packages/duckdb/src/duckdb.ts`, replacing type imports with a single namespace import (`import * as duckdb from "@duckdb/duckdb-wasm"`).
* Updated all references to DuckDB types and values (e.g., `AsyncDuckDB`, `DuckDBBundles`) to use the `duckdb.` namespace. [[1]](diffhunk://#diff-ddfc4c55e1399feb722a745c4d79586e0ec6c5f2012273f8896340e9d9878b14L21-R21) [[2]](diffhunk://#diff-ddfc4c55e1399feb722a745c4d79586e0ec6c5f2012273f8896340e9d9878b14L52-R48)
* Removed the dynamic import of `@duckdb/duckdb-wasm` inside the `getDuckDBInstance` function—DuckDB is now always statically imported.

### Vite Configuration Simplification

* Removed `optimizeDeps.exclude` and `ssr.external` for `@duckdb/duckdb-wasm` from both `apps/benchmark/vite.config.ts` and `apps/web/vite.config.ts`, as these are no longer necessary with static imports. [[1]](diffhunk://#diff-03fc16383b7f475036160f43ff6bea56b5d203d9fe45fafa3f2e844d03efb65aL26-L32) [[2]](diffhunk://#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786L31-L37)