### PR TITLE
feat: migrate to chart v3

### DIFF
--- a/apps/web/src/components/catalog/catalog-trend-sparkline.tsx
+++ b/apps/web/src/components/catalog/catalog-trend-sparkline.tsx
@@ -39,14 +39,25 @@ function paths(values: number[]) {
   return { line, area: `${line} L${b.x} ${H} L${a.x} ${H} Z` };
 }
 
-export function CatalogTrendSparkline({ trend, className }: { trend: CatalogTrendPoint[] | number[], className?: string }) {
+export function CatalogTrendSparkline({
+  trend,
+  className,
+}: {
+  trend: CatalogTrendPoint[] | number[];
+  className?: string;
+}) {
   const id = useId();
   if (trend.length === 0) return null;
 
-  const { line, area } = paths(trend.map((p) => typeof p === "number" ? p : p.value));
+  const { line, area } = paths(trend.map((p) => (typeof p === "number" ? p : p.value)));
 
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className={cn("h-7 w-full", className)} preserveAspectRatio="none" aria-hidden>
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className={cn("h-7 w-full", className)}
+      preserveAspectRatio="none"
+      aria-hidden
+    >
       <defs>
         <linearGradient id={id} gradientUnits="userSpaceOnUse" x1={0} y1={0} x2={0} y2={H}>
           <stop offset="0%" stopColor="var(--chart-2)" stopOpacity={0.4} />

--- a/apps/web/src/components/landing/hero-chart.tsx
+++ b/apps/web/src/components/landing/hero-chart.tsx
@@ -1,4 +1,4 @@
-import { Area, AreaChart } from "@harmony/charts/v2";
+import { AreaChart } from "@harmony/charts/v3";
 import { cn } from "@harmony/ui/lib/utils";
 
 import { HERO_CHART_DATA } from "./mock-data";
@@ -8,7 +8,7 @@ export function HeroChart() {
   return (
     <div className="relative size-full overflow-visible">
       <div aria-hidden className="pointer-events-none absolute inset-0 z-0 overflow-visible">
-        <div className="absolute top-1/2 left-1/2 h-[160%] w-[min(110%,52rem)] animate-glow-pulse rounded-full bg-[radial-gradient(ellipse_at_center,var(--primary)_0%,color-mix(in_oklab,var(--primary)_35%,transparent)_42%,transparent_72%)] blur-3xl motion-reduce:animate-none!" />
+        <div className="absolute top-1/2 left-1/2 h-[160%] w-[min(100%,52rem)] animate-glow-pulse rounded-full bg-[radial-gradient(ellipse_at_center,var(--primary)_0%,color-mix(in_oklab,var(--primary)_35%,transparent)_42%,transparent_72%)] blur-3xl motion-reduce:animate-none!" />
       </div>
       <div
         className={cn(
@@ -16,8 +16,20 @@ export function HeroChart() {
           "mask-radial-from-20% mask-radial-to-80% mask-circle mask-radial-farthest-side mask-radial-at-top",
         )}
       >
-        <AreaChart data={[...HERO_CHART_DATA]} xDataKey="i" className="z-10 !aspect-auto h-full">
-          <Area dataKey="value" fill="var(--chart-3)" fillPattern="dots" />
+        <AreaChart
+          data={[...HERO_CHART_DATA]}
+          xDataKey="i"
+          className="z-10 aspect-auto! h-full"
+          config={{
+            value: {
+              label: "Value",
+              colors: {
+                light: ["#1db954"],
+              },
+            },
+          }}
+        >
+          <AreaChart.Area dataKey="value" variant="dotted" strokeVariant="solid" strokeWidth={2} />
         </AreaChart>
       </div>
     </div>

--- a/apps/web/src/components/landing/landing-header.tsx
+++ b/apps/web/src/components/landing/landing-header.tsx
@@ -54,9 +54,7 @@ export function LandingHeader() {
         >
           GitHub
         </Button>
-        <Button variant="gradient">
-          Upload
-        </Button>
+        <Button variant="gradient">Upload</Button>
       </nav>
     </header>
   );

--- a/apps/web/src/components/landing/landing-how-it-works.tsx
+++ b/apps/web/src/components/landing/landing-how-it-works.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { Bar, BarChart, ChartTooltip, Grid, XAxis } from "@harmony/charts/v2";
+import { BarChart } from "@harmony/charts/v3";
 import { Alert02Icon, Cancel01Icon, Icon, Loading03Icon, Tick02Icon } from "@harmony/icons";
 import { Badge } from "@harmony/ui/components/badge";
 import { Checkbox } from "@harmony/ui/components/checkbox";
@@ -344,12 +344,24 @@ function InsightCard() {
 
       <div className="flex flex-col gap-1.5">
         <SectionLabel>Listening</SectionLabel>
-        <div className="rounded-lg border border-border bg-card px-2.5 pt-1.5 pb-1">
-          <BarChart className="aspect-7/2" data={LISTENING_DATA} xDataKey="name">
+        <div className="rounded-lg border border-border bg-card px-2 pt-1.5">
+          {/* <BarChart className="aspect-7/2" data={LISTENING_DATA} xDataKey="name">
             <Bar dataKey="value" fill="var(--chart-2)" />
             <Grid />
             <XAxis gap={2} />
             <ChartTooltip suffix="min" />
+          </BarChart> */}
+          <BarChart className="aspect-7/2" data={LISTENING_DATA} xDataKey="name" config={{
+            value: {
+              label: "Month",
+              colors: {
+                light: ["#1db954"],
+              },
+            }
+          }} barCategoryGap={2}>
+            <BarChart.Bar dataKey="value" />
+            <BarChart.XAxis />
+            <BarChart.Tooltip suffix="min" />
           </BarChart>
         </div>
       </div>

--- a/apps/web/src/components/layout/header/artists-select.tsx
+++ b/apps/web/src/components/layout/header/artists-select.tsx
@@ -53,7 +53,7 @@ export function ArtistsSelect() {
     >
       <ComboboxTrigger
         render={
-          <Button variant="ghost" className={cn("-ms-2! gap-1.5 text-sm", artist && "px-1!")} />
+          <Button variant="ghost" className={cn("-ms-2! gap-1 text-sm", artist && "px-1!")} />
         }
       >
         <ComboboxValue>

--- a/apps/web/src/components/layout/header/header.tsx
+++ b/apps/web/src/components/layout/header/header.tsx
@@ -1,9 +1,6 @@
-import { FilterIcon, Icon } from "@harmony/icons";
-import { Button } from "@harmony/ui/components/button";
-
+import { ArrowRightIcon, Icon } from "@harmony/icons";
 import { ArtistsSelect } from "./artists-select";
 import { DateRangeFilter } from "./date-range-filter";
-import { ViewModeToggle } from "./view-mode-toggle";
 
 type HeaderProps = {
   title: string;
@@ -18,17 +15,18 @@ export function Header({ title, showArtistSelect = true }: HeaderProps) {
 
         {showArtistSelect && (
           <>
-            <span className="pe-1 pb-0.5 text-muted-foreground">/</span>
+            {/* <span className="pe-1 pb-0.5 text-muted-foreground">/</span> */}
+            <Icon icon={ArrowRightIcon} className="text-muted-foreground size-4 pt-0.5" />
             <ArtistsSelect />
           </>
         )}
       </div>
       <div className="flex items-center gap-1">
-        <Button variant="ghost">
+        {/* <Button variant="ghost">
           <Icon icon={FilterIcon} />
           Filters
-        </Button>
-        <ViewModeToggle size="sm" />
+        </Button> */}
+        {/* <ViewModeToggle size="sm" /> */}
         <DateRangeFilter />
       </div>
     </header>

--- a/apps/web/src/features/listening/components/metric-card.tsx
+++ b/apps/web/src/features/listening/components/metric-card.tsx
@@ -29,7 +29,7 @@ export const MetricCard = ({ label, unit, query }: MetricCardProps) => {
 
   return (
     <Card size="xs">
-      <CardHeader className="px-3 pt-3">
+      <CardHeader className="gap-0 px-3 pt-3">
         <div className="flex flex-col">
           <CardTitle className="text-muted-foreground">{label}</CardTitle>
           <FormattedMetric size="lg" value={data?.value} unit={unit} />
@@ -40,7 +40,7 @@ export const MetricCard = ({ label, unit, query }: MetricCardProps) => {
           </Button>
         </CardAction>
       </CardHeader>
-      <CardContent style={{ marginBottom: "-5px" }}>
+      <CardContent>
         <MetricSparkline trend={data?.trend} />
       </CardContent>
     </Card>

--- a/apps/web/src/features/listening/components/metric-sparkline.tsx
+++ b/apps/web/src/features/listening/components/metric-sparkline.tsx
@@ -1,4 +1,4 @@
-import { SparklineChart, Area } from "@harmony/charts/v2";
+import { AreaChart } from "@harmony/charts/v3";
 
 import type { ListeningHabitTrendPoint } from "@/features/listening/types";
 
@@ -8,8 +8,33 @@ type MetricSparklineProps = {
 
 export function MetricSparkline({ trend = [] }: MetricSparklineProps) {
   return (
-    <SparklineChart data={trend} xDataKey="date" className="aspect-[6/1]">
-      <Area dataKey="value" />
-    </SparklineChart>
+    <AreaChart
+      data={trend}
+      config={{
+        value: {
+          label: "Listening Time",
+          colors: {
+            light: ["#1db954"],
+          },
+        },
+      }}
+      chartOptions={{
+        grid: {
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0,
+        },
+      }}
+      className="aspect-6/1 **:cursor-default!"
+    >
+      <AreaChart.Area
+        dataKey="value"
+        strokeVariant="solid"
+        variant="solid"
+        strokeWidth={2}
+        isClickable={false}
+      />
+    </AreaChart>
   );
 }

--- a/apps/web/src/features/listening/widgets/days-of-week-widget.tsx
+++ b/apps/web/src/features/listening/widgets/days-of-week-widget.tsx
@@ -1,4 +1,4 @@
-import { RadarArea, RadarChart, RadarGrid, RadarLabels } from "@harmony/charts";
+import { RadarChart } from "@harmony/charts/v3";
 import { Card, CardContent, CardHeader, CardTitle } from "@harmony/ui/components/card";
 import { useQuery } from "@tanstack/react-query";
 
@@ -10,24 +10,35 @@ export function DaysOfWeekWidget() {
   const metrics = data?.metrics ?? [];
   const series = data?.data ?? [];
 
+  const newData =
+    metrics.length && series.length
+      ? metrics.map((metric) => ({
+          label: metric.label,
+          value: series[0]?.values[metric.key] ?? 0,
+        }))
+      : [];
+
   return (
-    <Card size="xs" className="h-full">
+    <Card size="xs" className="h-full pb-0">
       <CardHeader className="px-3 pt-3">
         <CardTitle className="text-muted-foreground">Days of the Week</CardTitle>
       </CardHeader>
       <CardContent>
         <RadarChart
-          className="aspect-[4/3]"
-          data={series}
-          enterDurationMs={100}
-          margin={24}
-          metrics={metrics}
+          className="aspect-4/3"
+          data={newData}
+          config={{
+            value: {
+              label: "Time",
+              colors: {
+                light: ["#1db954"],
+              },
+            },
+          }}
         >
-          <RadarGrid showLabels={false} />
-          <RadarLabels fontSize={10} offset={16} />
-          {series.map((_, index) => (
-            <RadarArea index={index} key={index} showPoints={false} />
-          ))}
+          <RadarChart.PolarGrid />
+          <RadarChart.PolarAngleAxis dataKey="label" />
+          <RadarChart.Radar dataKey="value" variant="filled" />
         </RadarChart>
       </CardContent>
     </Card>

--- a/apps/web/src/features/listening/widgets/monthly-activity-widget.tsx
+++ b/apps/web/src/features/listening/widgets/monthly-activity-widget.tsx
@@ -1,4 +1,4 @@
-import { Bar, BarChart, ChartTooltip, Grid, XAxis } from "@harmony/charts/v2";
+import { BarChart } from "@harmony/charts/v3";
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@harmony/ui/components/card";
 import { useQuery } from "@tanstack/react-query";
 
@@ -14,7 +14,7 @@ export function MonthlyActivityWidget() {
   );
 
   return (
-    <Card size="sm">
+    <Card size="sm" className="pb-0.5">
       <CardHeader>
         <CardTitle>Monthly Activity</CardTitle>
         <CardAction>
@@ -25,11 +25,23 @@ export function MonthlyActivityWidget() {
         </CardAction>
       </CardHeader>
       <CardContent>
-        <BarChart className="aspect-[4/1]" data={data} xDataKey="name">
-          <Bar dataKey="value" fill="var(--chart-2)" />
-          <Grid />
-          <XAxis />
-          <ChartTooltip suffix="min" />
+        <BarChart
+          className="aspect-4/1"
+          data={data}
+          config={{
+            value: {
+              label: "Time",
+              colors: {
+                light: ["#1db954"],
+              },
+            },
+          }}
+          barCategoryGap={2}
+        >
+          <BarChart.Bar enableHoverHighlight  dataKey="value" />
+          <BarChart.XAxis dataKey="name" />
+          <BarChart.Tooltip suffix="min" />
+          <BarChart.Grid />
         </BarChart>
       </CardContent>
     </Card>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -34,8 +34,8 @@
     opacity: 0.22;
   }
   50% {
-    transform: translate(-50%, -50%) scale(1.05);
-    opacity: 0.3;
+    transform: translate(-50%, -50%) scale(1.02);
+    opacity: 0.24;
   }
 }
 

--- a/apps/web/src/routes/app/$packageId/listening.tsx
+++ b/apps/web/src/routes/app/$packageId/listening.tsx
@@ -2,19 +2,14 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { Header } from "@/components/layout/header/header";
 import { ActiveDaysWidget } from "@/features/listening/widgets/active-days-widget";
-import { GenresWidget } from "@/features/listening/widgets/genres-widget";
-import { ListeningStyleWidget } from "@/features/listening/widgets/listening-style-widget";
 import { ListeningTimeWidget } from "@/features/listening/widgets/listening-time-widget";
 import { MonthlyActivityWidget } from "@/features/listening/widgets/monthly-activity-widget";
-import { PeakHoursWidget } from "@/features/listening/widgets/peak-hours-widget";
-import { PlatformsWidget } from "@/features/listening/widgets/platforms-widget";
-import { ReleaseYearWidget } from "@/features/listening/widgets/release-year-widget";
 import { TotalStreamsWidget } from "@/features/listening/widgets/total-streams-widget";
-import { TrackEngagementWidget } from "@/features/listening/widgets/track-engagement-widget";
 import { UniqueTracksWidget } from "@/features/listening/widgets/unique-tracks-widget";
 import { query } from "@/lib/query";
 import { useArtistStore } from "@/lib/stores/artist-store";
 import { buildInstantRangeQuery, useDateRangeStore } from "@/lib/stores/date-range-store";
+import { DaysOfWeekWidget } from "@/features/listening/widgets/days-of-week-widget";
 
 export const Route = createFileRoute("/app/$packageId/listening")({
   ssr: false,
@@ -49,13 +44,13 @@ function RouteComponent() {
             <MonthlyActivityWidget />
           </div>
           <div className="col-span-2 h-full self-start lg:col-span-1 lg:col-start-4 lg:row-start-2">
-            {/* <DaysOfWeekWidget /> */}
+            <DaysOfWeekWidget />
           </div>
         </div>
 
         {/* <WhenYouListenWidget /> */}
 
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {/* <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <PeakHoursWidget />
           <PlatformsWidget />
         </div>
@@ -68,7 +63,7 @@ function RouteComponent() {
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <ReleaseYearWidget />
           <GenresWidget />
-        </div>
+        </div> */}
       </main>
     </div>
   );

--- a/packages/charts/components.json
+++ b/packages/charts/components.json
@@ -10,17 +10,18 @@
     "cssVariables": true
   },
   "iconLibrary": "hugeicons",
-  "aliases": {
-    "components": "@harmony/charts/components",
-    "utils": "@harmony/ui/lib/utils",
-    "hooks": "@harmony/ui/hooks",
-    "lib": "@harmony/ui/lib",
-    "ui": "@harmony/charts/components"
-  },
   "rtl": false,
   "menuColor": "default",
   "menuAccent": "subtle",
+  "aliases": {
+    "components": "@harmony/charts/components",
+    "utils": "@harmony/ui/lib/utils",
+    "ui": "@harmony/charts/components",
+    "lib": "@harmony/ui/lib",
+    "hooks": "@harmony/ui/hooks"
+  },
   "registries": {
-    "@bklit": "https://ui.bklit.com/r/{name}.json"
+    "@bklit": "https://ui.bklit.com/r/{name}.json",
+    "@evilcharts": "https://evilcharts.com/r/{name}.json"
   }
 }

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.tsx",
-    "./tests": "./src/tests.tsx",
-    "./v2": "./src/v2/index.ts"
+    "./v2": "./src/v2/index.ts",
+    "./v3": "./src/components/evilcharts/index.tsx"
   },
   "scripts": {
     "check-types": "tsc --noEmit"
@@ -26,6 +26,7 @@
     "@visx/shape": "4.0.1-alpha.0",
     "d3-array": "^3.2.4",
     "d3-shape": "^3.2.0",
+    "echarts": "^6.1.0",
     "motion": "^12.42.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/packages/charts/src/components/evilcharts/charts/echarts-area-chart.tsx
+++ b/packages/charts/src/components/evilcharts/charts/echarts-area-chart.tsx
@@ -1,0 +1,2355 @@
+"use client";
+
+import type { ComposeOption, ImagePatternObject } from "echarts/core";
+
+import {
+  Brush,
+  buildBrushDataZoom,
+  syncBrushOverlay,
+  type BrushGeometry,
+  type BrushOverlayElements,
+  type BrushProps,
+  type BrushRange,
+} from "@harmony/charts/components/evilcharts/ui/echarts-brush";
+import {
+  buildChartCss,
+  flattenColor,
+  getColorsCount,
+  resolveColors,
+  seriesPaint,
+  withAlpha,
+  type ChartConfig,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+import {
+  dotItemStyle,
+  dotStyle,
+  sampleGradient,
+  type DotVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-dot";
+import {
+  LegendOverlay,
+  type LegendVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-legend";
+import {
+  formatTooltipValue,
+  tooltipBaseOption,
+  tooltipIndicatorHtml,
+  tooltipRow,
+  tooltipShell,
+  type TooltipPosition,
+  type TooltipRoundness,
+  type TooltipVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-tooltip";
+import { LineChart, type LineSeriesOption } from "echarts/charts";
+import {
+  DataZoomComponent,
+  GridComponent,
+  TooltipComponent,
+  type DataZoomComponentOption,
+  type GridComponentOption,
+  type TooltipComponentOption,
+} from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { motion, useReducedMotion } from "motion/react";
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FC,
+  type ReactNode,
+} from "react";
+
+// Re-export the shared types that were previously declared inline here, so
+// existing consumers/examples keep importing them from the chart module.
+export type {
+  ChartConfig,
+  DotVariant,
+  LegendVariant,
+  TooltipPosition,
+  TooltipRoundness,
+  TooltipVariant,
+};
+
+// Modular registration keeps the bundle lean — only the pieces this chart needs.
+// `DataZoomComponent` bundles both the slider (brush footer) and inside (wheel/drag)
+// zoom. The brush's frame/handles/labels are raw zrender elements, not the
+// graphic component — see syncBrushOverlay.
+echarts.use([LineChart, GridComponent, TooltipComponent, DataZoomComponent, CanvasRenderer]);
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+// The exact option surface this chart uses — line series, grid, tooltip, and
+// dataZoom, plus the axis options they pull in as dependencies. Narrower than
+// echarts' full EChartsOption, so a misspelled key fails the compile instead of
+// silently reaching setOption.
+type EChartsOption = ComposeOption<
+  LineSeriesOption | GridComponentOption | TooltipComponentOption | DataZoomComponentOption
+>;
+
+// Single-entry views of the composed option's array-or-single fields — the
+// modular entry points don't export the axis option types directly.
+type ArrayItem<T> = T extends readonly (infer U)[] ? U : T;
+type XAxisOption = ArrayItem<NonNullable<EChartsOption["xAxis"]>>;
+type YAxisOption = ArrayItem<NonNullable<EChartsOption["yAxis"]>>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STROKE_WIDTH = 0.8; // default series stroke — <Area strokeWidth> overrides it
+const LOADING_ANIMATION_DURATION = 2000; // shimmer loop, in milliseconds
+const REVEAL_DURATION = 1000; // intro draw-in length, in milliseconds
+// NOTE: the intro draw-in runs ECharts' RAW default entrance animation. Custom
+// easing was tried and abandoned — ECharts hardcodes the line-entrance clip to
+// linear and ignores animationEasing at every level (verified empirically).
+const LOADING_DEFAULT_POINTS = 14;
+// Buffer line: the last segment's stroke renders as this dash while the rest of
+// the area stays solid, echoing the Recharts twin's 4px dash / 3px gap forecast
+// tail. Ported from the line-chart twin.
+const BUFFER_DASH: [number, number] = [4, 3];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Theme knobs — every neutral line in the chart draws from these. Base colors
+// come from the consumer's CSS tokens (resolved from the live DOM), so only the
+// opacity factors live here. Factors MULTIPLY the token's own alpha — a border
+// token that is already 10%-white stays subtle. Tune here, not in the builder.
+// ─────────────────────────────────────────────────────────────────────────────
+// Recharts draws its grid at border/50, but SVG dashes render pixel-crisp while
+// canvas at 2× DPR spreads a 1px line across device pixels — roughly halving
+// perceived intensity. Using the border token's full alpha lands both engines at
+// the same apparent brightness.
+const GRID_LINE_OPACITY = 1; // dashed y-axis split lines, × border alpha
+const AXIS_POINTER_OPACITY = 1; // tooltip cursor line, × border alpha
+// The skeleton is CLIPPED to a small sweeping window — only the wave section
+// inside it exists (stroke + fill), everything outside is fully transparent,
+// like a clip-path sliding across the chart.
+const LOADING_STROKE_OPACITY = 0.5; // outline inside the window, × foreground alpha
+const LOADING_SHIMMER_MAX_OPACITY = 0.03; // fill inside the window, × foreground alpha
+const LOADING_SHIMMER_BAND = 0.2; // window half-width, fraction of chart width
+const LOADING_SHIMMER_FEATHER = 0.2; // eased edge softening of the clip window
+const BRUSH_STROKE_OPACITY = 0.5; // mini-chart series stroke
+const BRUSH_FILL_OPACITY = 0.15; // mini-chart series fade, at the top stop
+const BRUSH_FILLER_OPACITY = 0; // selected-range wash — evil-brush draws none
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AreaVariant =
+  | "gradient"
+  | "gradient-reverse"
+  | "solid"
+  | "dotted"
+  | "lines"
+  | "hatched"
+  | "none"; // stroke only — no fill at all
+export type StrokeVariant = "solid" | "dashed" | "animated-dashed";
+export type StackType = "default" | "stacked" | "expanded";
+export type AreaAnimationType =
+  | "none"
+  | "left-to-right"
+  | "right-to-left"
+  | "center-out"
+  | "edges-in";
+export type CurveType =
+  | "linear"
+  | "smooth"
+  | "bump"
+  | "monotone"
+  | "monotoneX"
+  | "monotoneY"
+  | "natural"
+  | "step";
+// DotVariant, TooltipVariant, TooltipRoundness, LegendVariant, and ChartConfig
+// now live in the shared @/registry/ui/echarts/* modules and are imported +
+// re-exported at the top of this file.
+
+export interface EChartsAreaChartProps<TData extends Record<string, unknown>> {
+  data: TData[]; // rows rendered by the chart
+  config: ChartConfig; // series colors + labels
+  xDataKey?: keyof TData & string; // x category key — falls back to the <XAxis> dataKey / first free column
+  className?: string; // extra classes for the chart container
+  curveType?: CurveType; // default curve interpolation each <Area> inherits
+  stackType?: StackType; // how multiple areas combine
+  animation?: boolean; // master switch for the intro draw-in — false renders instantly
+  animationType?: AreaAnimationType; // default intro reveal (first <Area> overrides)
+  enableHoverHighlight?: boolean; // hovering a series dims the others, like a temporary selection
+  enableHoverReveal?: boolean; // hovering colors each area up to the pointer's x and mutes the rest
+  defaultSelectedDataKey?: string | null; // series selected on first render
+  selectedDataKey?: string | null; // controlled selection — overrides internal state when set
+  onSelectionChange?: (key: string | null) => void; // fires when the selected series changes
+  isLoading?: boolean; // shows the animated loading skeleton
+  loadingPoints?: number; // number of points in the loading skeleton
+  chartOptions?: Record<string, unknown>; // escape hatch merged over the built ECharts option
+  children?: ReactNode; // declarative config — <Area>, <XAxis>, <Grid>, <Tooltip>, <Legend>, <Brush>, …
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Composible parts — DECLARATIVE CONFIG. Every part renders `null`; the root
+// walks `children` by reference (child.type === Area, …) to collect its props.
+// Presence semantics mirror the Recharts twin: omit a child and that part does
+// not render. These are never mounted into the tree — they only carry props.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AreaProps {
+  dataKey: string; // series key — must exist on the data + config
+  variant?: AreaVariant; // fill style for this area only
+  strokeVariant?: StrokeVariant; // stroke style for this area
+  strokeWidth?: number; // stroke thickness in pixels for this area
+  curveType?: CurveType; // curve interpolation — falls back to the root curveType
+  animationType?: AreaAnimationType; // intro reveal — first area drives the wrapper wipe
+  connectNulls?: boolean; // join segments across null/missing values
+  isClickable?: boolean; // lets this area be selected by clicking it
+  enableBufferLine?: boolean; // renders this area's last segment as a dashed, fill-less buffer
+  children?: ReactNode; // optional <Dot> and <ActiveDot> config
+}
+
+/**
+ * A single area series. Declares its own fill/stroke/curve/clickability and,
+ * optionally, resting/active point markers via composed <Dot> / <ActiveDot>.
+ * Renders nothing — the root reads these props to build the ECharts series.
+ */
+const Area: FC<AreaProps> = () => null;
+
+export interface DotProps {
+  variant?: DotVariant; // visual style of the point marker
+}
+
+/** Declares the resting point marker for the enclosing <Area>. Renders nothing. */
+const Dot: FC<DotProps> = () => null;
+
+/** Declares the hovered/active point marker for the enclosing <Area>. Renders nothing. */
+const ActiveDot: FC<DotProps> = () => null;
+
+export interface XAxisProps {
+  dataKey?: string; // x category key — overrides the root xDataKey
+  // Category-axis values are always stringified, so the formatter sees a string —
+  // letting examples share `(value) => value.substring(0, 3)` with the Recharts twin.
+  tickFormatter?: (value: string, index: number) => string; // formats x tick labels
+  label?: string; // axis title, centered below the tick labels
+  hideDots?: boolean; // hides the tick dots beside this axis's labels
+}
+
+/** Presence shows the x-axis category labels. Renders nothing. */
+const XAxis: FC<XAxisProps> = () => null;
+
+export interface YAxisProps {
+  dataKey?: string; // reserved for parity with the Recharts twin
+  tickFormatter?: (value: number, index: number) => string; // formats y tick labels
+  label?: string; // axis title, rotated alongside the tick labels
+  hideDots?: boolean; // hides the tick dots beside this axis's labels
+}
+
+/** Presence shows the y value axis. Renders nothing. */
+const YAxis: FC<YAxisProps> = () => null;
+
+/** Presence shows the dashed horizontal split lines. Renders nothing. */
+const Grid: FC = () => null;
+
+export interface TooltipProps {
+  variant?: TooltipVariant; // visual style of the tooltip surface
+  roundness?: TooltipRoundness; // border-radius of the tooltip
+  cursor?: boolean; // whether the vertical cursor line follows the pointer
+  position?: TooltipPosition; // "variable" follows both axes (default); "fixed" pins the tooltip near the top and tracks the pointer's X
+  suffix?: string; // unit appended after each row's value (e.g. "min")
+}
+
+/** Presence enables the hover tooltip. Renders nothing. */
+const Tooltip: FC<TooltipProps> = () => null;
+
+export interface LegendProps {
+  variant?: LegendVariant; // visual style of the legend indicators
+  align?: "left" | "center" | "right"; // horizontal placement
+  verticalAlign?: "top" | "middle" | "bottom"; // vertical placement
+  isClickable?: boolean; // lets each entry toggle selection of its series
+}
+
+/** Presence enables the HTML legend overlay. Renders nothing. */
+const Legend: FC<LegendProps> = () => null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Children collection — walk the declarative config into plain objects the
+// option builder consumes. <Dot> / <ActiveDot> are read from each <Area>'s own
+// children; a missing dot child means that marker does not render.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AreaSeriesConfig = {
+  dataKey: string;
+  variant: AreaVariant;
+  strokeVariant: StrokeVariant;
+  strokeWidth: number;
+  curveType?: CurveType;
+  animationType?: AreaAnimationType;
+  connectNulls: boolean;
+  isClickable: boolean;
+  enableBufferLine: boolean;
+  dotVariant: DotVariant; // "none" when no <Dot> child is present
+  activeDotVariant: DotVariant; // "none" when no <ActiveDot> child is present
+};
+
+type XAxisSlot = {
+  present: boolean;
+  dataKey?: string;
+  tickFormatter?: (value: string, index: number) => string;
+  label?: string;
+  hideDots: boolean;
+};
+type YAxisSlot = {
+  present: boolean;
+  dataKey?: string;
+  tickFormatter?: (value: number, index: number) => string;
+  label?: string;
+  hideDots: boolean;
+};
+type TooltipSlot = {
+  present: boolean;
+  variant: TooltipVariant;
+  roundness: TooltipRoundness;
+  cursor: boolean;
+  position: TooltipPosition;
+  suffix?: string;
+};
+type LegendSlot = {
+  present: boolean;
+  variant: LegendVariant;
+  align: "left" | "center" | "right";
+  verticalAlign: "top" | "middle" | "bottom";
+  isClickable: boolean;
+};
+type BrushSlot = {
+  present: boolean; // a <Brush> child was passed — replaces the old showBrush prop
+  height?: number;
+  formatLabel?: (value: string, index: number) => string;
+  onChange?: (range: { startIndex: number; endIndex: number }) => void;
+};
+
+type CollectedConfig = {
+  areas: AreaSeriesConfig[];
+  xAxis: XAxisSlot;
+  yAxis: YAxisSlot;
+  showGrid: boolean;
+  tooltip: TooltipSlot;
+  legend: LegendSlot;
+  brush: BrushSlot;
+};
+
+function collectConfig(children: ReactNode): CollectedConfig {
+  const areas: AreaSeriesConfig[] = [];
+  let xAxis: XAxisSlot = { present: false, hideDots: false };
+  let yAxis: YAxisSlot = { present: false, hideDots: false };
+  let showGrid = false;
+  let tooltip: TooltipSlot = {
+    present: false,
+    variant: "default",
+    roundness: "lg",
+    cursor: true,
+    position: "variable",
+  };
+  let legend: LegendSlot = {
+    present: false,
+    variant: "rounded-square",
+    align: "right",
+    verticalAlign: "top",
+    isClickable: false,
+  };
+  let brush: BrushSlot = { present: false };
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const type = child.type;
+
+    if (type === Area) {
+      const props = child.props as AreaProps;
+      let dotVariant: DotVariant = "none";
+      let activeDotVariant: DotVariant = "none";
+      Children.forEach(props.children, (dotChild) => {
+        if (!isValidElement(dotChild)) return;
+        if (dotChild.type === Dot) {
+          dotVariant = (dotChild.props as DotProps).variant ?? "default";
+        } else if (dotChild.type === ActiveDot) {
+          activeDotVariant = (dotChild.props as DotProps).variant ?? "default";
+        }
+      });
+      areas.push({
+        dataKey: props.dataKey,
+        variant: props.variant ?? "gradient",
+        strokeVariant: props.strokeVariant ?? "dashed",
+        strokeWidth: props.strokeWidth ?? STROKE_WIDTH,
+        curveType: props.curveType,
+        animationType: props.animationType,
+        connectNulls: props.connectNulls ?? false,
+        isClickable: props.isClickable ?? false,
+        enableBufferLine: props.enableBufferLine ?? false,
+        dotVariant,
+        activeDotVariant,
+      });
+    } else if (type === XAxis) {
+      const props = child.props as XAxisProps;
+      xAxis = {
+        present: true,
+        dataKey: props.dataKey,
+        tickFormatter: props.tickFormatter,
+        label: props.label,
+        hideDots: props.hideDots ?? false,
+      };
+    } else if (type === YAxis) {
+      const props = child.props as YAxisProps;
+      yAxis = {
+        present: true,
+        dataKey: props.dataKey,
+        tickFormatter: props.tickFormatter,
+        label: props.label,
+        hideDots: props.hideDots ?? false,
+      };
+    } else if (type === Grid) {
+      showGrid = true;
+    } else if (type === Tooltip) {
+      const props = child.props as TooltipProps;
+      tooltip = {
+        present: true,
+        variant: props.variant ?? "default",
+        roundness: props.roundness ?? "lg",
+        cursor: props.cursor ?? true,
+        position: props.position ?? "variable",
+        suffix: props.suffix,
+      };
+    } else if (type === Legend) {
+      const props = child.props as LegendProps;
+      legend = {
+        present: true,
+        variant: props.variant ?? "rounded-square",
+        align: props.align ?? "right",
+        verticalAlign: props.verticalAlign ?? "top",
+        isClickable: props.isClickable ?? false,
+      };
+    } else if (type === Brush) {
+      const props = child.props as BrushProps;
+      brush = {
+        present: true,
+        height: props.height,
+        formatLabel: props.formatLabel,
+        onChange: props.onChange,
+      };
+    }
+  });
+
+  return { areas, xAxis, yAxis, showGrid, tooltip, legend, brush };
+}
+
+// Color plumbing (ChartConfig, getColorsCount, distributeColors, buildChartCss,
+// normalizeColor, withAlpha, ResolvedColors, resolveColors, seriesPaint) now
+// lives in @/registry/ui/echarts-chart and is imported at the top of this file.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fill paints — the ECharts analogue of the Recharts fill variants (§1.1).
+// The first three are alpha fades; the last three are tiling canvas patterns.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Tiling texture fills, tinted with the series' first color. Stripes are drawn
+// STRAIGHT (trivially seamless) and the pattern itself is rotated — zrender
+// applies pattern transforms the same way ECharts decals do. Baking a diagonal
+// into a square tile clips the stroke at the corners, which reads as periodic
+// gaps once tiled. Tiles render at devicePixelRatio and scale back down so the
+// texture stays crisp on retina canvases.
+function patternFill(
+  kind: "dotted" | "lines" | "hatched" | "stripe",
+  color: string,
+): ImagePatternObject | null {
+  if (typeof document === "undefined") return null;
+  const dpr = Math.max(window.devicePixelRatio || 1, 1);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+
+  const size = (width: number, height: number) => {
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+  };
+  const pattern = (rotation = 0): ImagePatternObject => ({
+    image: canvas,
+    repeat: "repeat",
+    rotation,
+    scaleX: 1 / dpr,
+    scaleY: 1 / dpr,
+  });
+
+  if (kind === "dotted") {
+    size(6, 6);
+    // Slightly larger dots at 0.7 — the vertical fade + areaStyle opacity temper
+    // them, so at the old 0.5/r0.6 they washed out (especially on shorter areas).
+    ctx.fillStyle = withAlpha(color, 0.7);
+    ctx.beginPath();
+    ctx.arc(3, 3, 0.85, 0, Math.PI * 2);
+    ctx.fill();
+    return pattern();
+  }
+
+  if (kind === "lines" || kind === "stripe") {
+    // Vertical 1px line every 5px, rotated 45° by the pattern transform.
+    size(5, 5);
+    ctx.strokeStyle = withAlpha(color, 0.3);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(2.5, -1);
+    ctx.lineTo(2.5, 6);
+    ctx.stroke();
+    return pattern(-Math.PI / 4);
+  }
+
+  // hatched: bold two-tone stripes leaning ~20°, echoing the Recharts
+  // gradient-edged stripe fill.
+  size(20, 20);
+  ctx.fillStyle = withAlpha(color, 0.06);
+  ctx.fillRect(0, 0, 10, 20);
+  ctx.fillStyle = withAlpha(color, 0.22);
+  ctx.fillRect(10, 0, 10, 20);
+  return pattern((20 * Math.PI) / 180);
+}
+
+// Canvas can't express "multi-stop color horizontally × alpha fade vertically"
+// as one gradient, so multi-color fills composite the two on an offscreen canvas
+// sized to the chart: paint the horizontal color run, then mask it with a
+// vertical alpha ramp via destination-in. Regenerated on resize (patterns anchor
+// to the renderer's origin at natural pixel size).
+function gradientFillTexture(
+  slots: string[],
+  width: number,
+  height: number,
+  reverse: boolean,
+): HTMLCanvasElement | null {
+  if (typeof document === "undefined" || width < 1 || height < 1) return null;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.ceil(width);
+  canvas.height = Math.ceil(height);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+
+  const colors = ctx.createLinearGradient(0, 0, canvas.width, 0);
+  slots.forEach((color, i) => colors.addColorStop(i / (slots.length - 1), color));
+  ctx.fillStyle = colors;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const fade = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  fade.addColorStop(0, `rgba(0, 0, 0, ${reverse ? 0 : 0.1})`);
+  fade.addColorStop(1, `rgba(0, 0, 0, ${reverse ? 0.1 : 0})`);
+  ctx.globalCompositeOperation = "destination-in";
+  ctx.fillStyle = fade;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  return canvas;
+}
+
+// A pattern fill (dotted/lines/hatched) faded vertically — opaque at the top
+// (near the line), transparent toward the baseline — so it reads like the
+// gradient variant instead of a flat wall of pattern. The tiling pattern can't
+// itself carry an alpha ramp, so bake it into a plot-sized texture: tile the
+// pattern (reusing patternFill's tile + rotation), then mask it with a vertical
+// alpha ramp via destination-in.
+function patternFadeTexture(
+  kind: "dotted" | "lines" | "hatched",
+  color: string,
+  width: number,
+  height: number,
+): HTMLCanvasElement | null {
+  const patternObj = patternFill(kind, color);
+  if (!patternObj || typeof document === "undefined" || width < 1 || height < 1) return null;
+  const tile = patternObj.image;
+  if (!(tile instanceof HTMLCanvasElement)) return null;
+  const rotation = patternObj.rotation ?? 0;
+  const tileScale = patternObj.scaleX ?? 1; // patternFill draws the tile at dpr; 1/dpr scales it back
+
+  const w = Math.ceil(width);
+  const h = Math.ceil(height);
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+
+  const pat = ctx.createPattern(tile, "repeat");
+  if (!pat) return null;
+  // Replicate the ECharts ImagePattern transform (rotate the tiling, scale the
+  // dpr tile back to CSS size) so the baked texture matches the plain pattern.
+  if (typeof pat.setTransform === "function") {
+    const m = new DOMMatrix();
+    m.rotateSelf((rotation * 180) / Math.PI);
+    m.scaleSelf(tileScale, tileScale);
+    pat.setTransform(m);
+  }
+  ctx.fillStyle = pat;
+  ctx.fillRect(0, 0, w, h);
+
+  const fade = ctx.createLinearGradient(0, 0, 0, h);
+  fade.addColorStop(0, "rgba(0, 0, 0, 1)"); // top: keep the pattern
+  fade.addColorStop(1, "rgba(0, 0, 0, 0)"); // baseline: fade it out
+  ctx.globalCompositeOperation = "destination-in";
+  ctx.fillStyle = fade;
+  ctx.fillRect(0, 0, w, h);
+
+  return canvas;
+}
+
+// Resolves the area fill for a variant into an ECharts color value. `size` is the
+// full renderer size, used to bake 2D gradients for multi-color series.
+function fillPaint(
+  variant: AreaVariant,
+  showUnselected: boolean,
+  slots: string[],
+  size: { width: number; height: number },
+): string | echarts.graphic.LinearGradient | ImagePatternObject {
+  const base = slots[0] ?? "rgba(120, 120, 120, 1)";
+  const multi = slots.length > 1;
+
+  // "none" — stroke only, no fill (even when unselected).
+  if (variant === "none") return "transparent";
+
+  // A non-selected area in a clickable chart recedes as a 45° stripe texture.
+  if (showUnselected) {
+    return patternFill("stripe", base) ?? withAlpha(base, 0.1);
+  }
+
+  switch (variant) {
+    case "gradient":
+    case "gradient-reverse": {
+      const reverse = variant === "gradient-reverse";
+      if (multi) {
+        const texture = gradientFillTexture(slots, size.width, size.height, reverse);
+        if (texture) return { image: texture, repeat: "no-repeat" };
+      }
+      return new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+        { offset: 0, color: withAlpha(base, reverse ? 0 : 0.1) },
+        { offset: 1, color: withAlpha(base, reverse ? 0.1 : 0) },
+      ]);
+    }
+    case "solid": {
+      // Uniform alpha, so the horizontal color run survives as one gradient.
+      if (multi) {
+        return new echarts.graphic.LinearGradient(
+          0,
+          0,
+          1,
+          0,
+          slots.map((color, i) => ({
+            offset: i / (slots.length - 1),
+            color: withAlpha(color, 0.1),
+          })),
+        );
+      }
+      return withAlpha(base, 0.1);
+    }
+    case "dotted":
+    case "lines":
+    case "hatched": {
+      // Faded by default (opaque near the line, transparent at the baseline).
+      const texture = patternFadeTexture(variant, base, size.width, size.height);
+      if (texture) return { image: texture, repeat: "no-repeat" };
+      return patternFill(variant, base) ?? withAlpha(base, 0.1);
+    }
+    default:
+      return withAlpha(base, 0.1);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Curve mapping — linear → straight, step → step:"end", everything else → smooth.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function curveConfig(curveType: CurveType): { smooth: boolean; step: "middle" | false } {
+  // Recharts "step" is d3's curveStep: the transition happens at the MIDPOINT
+  // between points, so each dot sits centered on its plateau.
+  if (curveType === "step") return { smooth: false, step: "middle" };
+  if (curveType === "linear") return { smooth: false, step: false };
+  return { smooth: true, step: false };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Selection opacities (§4.3) — dims a series only when another one is selected.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getOpacity(selected: string | null, key: string) {
+  if (selected === null || selected === key) return { fill: 0.8, stroke: 1, dot: 1 };
+  return { fill: 0.1, stroke: 0.3, dot: 0.3 };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loading skeleton helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Skeleton data as a smooth random walk in a comfortable band — reads like a
+// resting chart instead of raw noise spikes.
+function getLoadingData(points: number): number[] {
+  const rows: number[] = [];
+  let value = 30 + Math.random() * 20;
+  for (let i = 0; i < points; i++) {
+    value = Math.min(58, Math.max(16, value + (Math.random() - 0.5) * 16));
+    rows.push(Math.round(value));
+  }
+  return rows;
+}
+
+// Gradient stops forming a hard clip window around `center`: full `peak` alpha
+// inside, zero outside, with a small feather so the edge isn't aliased.
+// `center` may run outside [0, 1] so the window fully enters and exits the frame.
+function shimmerWindowStops(center: number, color: string, peak: number) {
+  const half = LOADING_SHIMMER_BAND;
+  const feather = LOADING_SHIMMER_FEATHER;
+
+  const alphaAt = (x: number) => {
+    const dist = Math.abs(x - center);
+    if (dist <= half - feather) return peak;
+    if (dist >= half) return 0;
+    // Sine-eased falloff — a linear ramp still reads as a hard cut.
+    return peak * Math.sin(((1 - (dist - (half - feather)) / feather) * Math.PI) / 2);
+  };
+
+  const offsets = [
+    0,
+    center - half,
+    center - half + feather,
+    center,
+    center + half - feather,
+    center + half,
+    1,
+  ]
+    .filter((x) => x >= 0 && x <= 1)
+    .sort((a, b) => a - b);
+
+  const stops: { offset: number; color: string }[] = [];
+  for (const offset of offsets) {
+    if (stops.length === 0 || offset - stops[stops.length - 1]!.offset > 1e-4) {
+      stops.push({ offset, color: withAlpha(color, alphaAt(offset)) });
+    }
+  }
+  return stops;
+}
+
+// The `__buffer-` prefix marks the dashed forecast overlay of a buffer area; it
+// carries the SAME key's value, so the tooltip recovers the key from it (see
+// createTooltipFormatter). Every other `__`-prefixed series (mini chart, loading
+// skeleton, hover-reveal base) is truly internal and never surfaces.
+const BUFFER_PREFIX = "__buffer-";
+// The fill-only patch under a buffer area's dashed tail (the main area's fill
+// stops one point early). Internal, so the tooltip drops it.
+const BUFFERFILL_PREFIX = "__bufferfill-";
+// The `__reveal-` prefix marks the muted base layer of a hover-reveal area — see
+// buildAreaSeries. Internal, so the tooltip drops it like the mini/loading rows.
+const REVEAL_PREFIX = "__reveal-";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option builders — pure functions from a snapshot context to ECharts option
+// fragments. The component reads its refs and renderer size ONCE per build into
+// this context; nothing below touches React state or the chart instance, so
+// each fragment can be reasoned about (and tested) in isolation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OptionBuildContext = {
+  data: Record<string, unknown>[];
+  config: ChartConfig;
+  areas: AreaSeriesConfig[];
+  seriesKeys: string[];
+  curveType: CurveType;
+  isStacked: boolean;
+  isExpanded: boolean;
+  selectedDataKey: string | null;
+  hasSelection: boolean;
+  showGrid: boolean;
+  xAxisSlot: XAxisSlot;
+  yAxisSlot: YAxisSlot;
+  tooltipSlot: TooltipSlot;
+  legendSlot: LegendSlot;
+  isLoading: boolean;
+  loadingData: () => number[];
+  showBrush: boolean;
+  brushHeight: number;
+  enableHoverHighlight: boolean;
+  enableHoverReveal: boolean; // hover colors each area up to the pointer, mutes the rest
+  revealIndex: number | null; // pointer's x-index while revealing (null = idle → chart looks normal)
+  revealSink: Record<string, unknown[]>; // buildAreaSeries writes each area's full per-datum points here for the hover handler
+  resolved: ResolvedColors;
+  rendererSize: { width: number; height: number }; // 2D gradient textures bake at renderer size
+  categories: string[];
+  brushRange: BrushRange; // zoom window carried through rebuilds
+  getHoveredKey: () => string | null; // read per tooltip render — hover never repushes the option
+};
+
+// Grid insets plus the footer band reserved for the brush. ECharts 6 contains
+// axis labels automatically (the legacy `containLabel` flag now only triggers a
+// deprecation warning).
+function buildChartLayout({ legendSlot, xAxisSlot, showBrush, brushHeight }: OptionBuildContext): {
+  grid: GridComponentOption;
+  brushBottom: number;
+} {
+  const legendTop = legendSlot.present && legendSlot.verticalAlign === "top";
+  const legendBottom = legendSlot.present && legendSlot.verticalAlign === "bottom";
+  // Clearance covers the x-axis labels plus the same breathing room the
+  // Recharts twin leaves between them and the brush. An x-axis TITLE renders
+  // below the labels (nameGap), so it needs its own band above the brush frame.
+  const brushGap = showBrush ? brushHeight + 30 + (xAxisSlot.label ? 22 : 0) : 0;
+
+  return {
+    grid: {
+      left: 0,
+      right: 0,
+      top: legendTop ? 42 : 0,
+      bottom: brushGap + (legendBottom ? 34 : 0),
+    },
+    brushBottom: legendBottom ? 34 : 6,
+  };
+}
+
+function buildMainAxes(ctx: OptionBuildContext): { xAxis: XAxisOption; yAxis: YAxisOption } {
+  const { xAxisSlot, yAxisSlot, showGrid, isLoading, isExpanded, categories, loadingData } = ctx;
+  const { tokens } = ctx.resolved;
+
+  const axisLabelColor = tokens.mutedForeground;
+  const splitLineColor = withAlpha(tokens.border, GRID_LINE_OPACITY);
+  // Gridline gray as an opaque color — see flattenColor.
+  const tickDotColor = flattenColor(splitLineColor, tokens.background);
+
+  const xTickFormatter = xAxisSlot.tickFormatter;
+  const yTickFormatter = yAxisSlot.tickFormatter;
+
+  const xAxis: XAxisOption = {
+    type: "category",
+    boundaryGap: false,
+    show: true,
+    data: isLoading ? loadingData().map((_, i) => i) : categories,
+    // Axis title — same size/color as the tick labels, pushed clear of them.
+    name: isLoading ? undefined : xAxisSlot.label,
+    nameLocation: "middle",
+    nameGap: 30,
+    nameTextStyle: { color: axisLabelColor, fontSize: 10 },
+    axisLine: { show: false },
+    // Tick DOTS: a near-zero-length tick whose round caps form a true circle,
+    // in the gridline gray (flattened opaque so the caps don't stack).
+    axisTick: {
+      show: !isLoading && xAxisSlot.present && !xAxisSlot.hideDots,
+      // Ticks default to the BOUNDARY between categories, which on a boundaryGap
+      // axis drops the dot in the gap instead of under its label. A no-op here
+      // (boundaryGap is false), kept for parity with the bar/composed charts.
+      alignWithLabel: true,
+      length: 0.5,
+      lineStyle: { color: tickDotColor, width: 3, cap: "round" },
+    },
+    splitLine: { show: false },
+    axisLabel: {
+      show: !isLoading && xAxisSlot.present,
+      color: axisLabelColor,
+      fontSize: 10,
+      margin: 8,
+      formatter: xTickFormatter
+        ? (value: string, index: number) => xTickFormatter(value, index)
+        : undefined,
+    },
+  };
+
+  // An ECharts axis with `show: false` hides its splitLines too, but Recharts'
+  // <CartesianGrid> draws with or without a visible <YAxis>. Keep the axis on
+  // whenever <Grid/> is present and gate the LABELS on <YAxis/> instead.
+  const yAxis: YAxisOption = {
+    type: "value",
+    show: yAxisSlot.present || showGrid,
+    max: isExpanded ? 1 : undefined,
+    // Axis title — rendered rotated alongside the tick labels, same styling.
+    name: isLoading ? undefined : yAxisSlot.label,
+    nameLocation: "middle",
+    nameGap: 38,
+    nameTextStyle: { color: axisLabelColor, fontSize: 10 },
+    axisLine: { show: false },
+    // Same tick dots as the x-axis, beside each value label. No alignWithLabel
+    // here: ECharts types it on the CATEGORY axis only, and a value axis already
+    // puts its ticks on the labels.
+    axisTick: {
+      show: yAxisSlot.present && !isLoading && !yAxisSlot.hideDots,
+      length: 0.5,
+      lineStyle: { color: tickDotColor, width: 3, cap: "round" },
+    },
+    splitLine: {
+      // Hidden while loading — the skeleton floats on a clean canvas.
+      show: showGrid && !isLoading,
+      lineStyle: { color: splitLineColor, type: [3, 3] as [number, number], width: 1 },
+    },
+    axisLabel: {
+      // Hidden while loading — skeleton values are meaningless, and the
+      // Recharts YAxis unmounts during loading too.
+      show: yAxisSlot.present && !isLoading,
+      color: axisLabelColor,
+      fontSize: 10,
+      margin: 8,
+      formatter: isExpanded
+        ? (value: number) => `${Math.round(value * 100)}%`
+        : yTickFormatter
+          ? (value: number, index: number) => yTickFormatter(value, index)
+          : undefined,
+    },
+  };
+
+  return { xAxis, yAxis };
+}
+
+// Tooltip HTML builder, closed over the build context. `getHoveredKey` is read
+// per invocation — ECharts calls the formatter at hover time, and syncing hover
+// through an option push instead would reset the native blur state mid-hover.
+function createTooltipFormatter(ctx: OptionBuildContext) {
+  const { config, selectedDataKey, tooltipSlot, getHoveredKey } = ctx;
+
+  return (params: unknown): string => {
+    const rows = Array.isArray(params) ? params : [params];
+    if (!rows.length) return "";
+
+    const first = rows[0] as { axisValue?: string | number; name?: string };
+    // Label shows the RAW axis value — matches ChartTooltipContent (no tick formatter).
+    const axisValue = first.axisValue ?? first.name ?? "";
+    const label = String(axisValue);
+
+    // Dedupe by effective key: a buffer area contributes both its solid part
+    // (id=key) and its dashed overlay (id=`__buffer-{key}`) at the shared
+    // second-to-last point. Keep the first non-null value seen per key so the
+    // final point (only the overlay has data there) still shows its number.
+    const seen = new Set<string>();
+    const body = rows
+      .map((param) => {
+        const p = param as {
+          seriesId?: string;
+          seriesName?: string;
+          value?: number | string | null;
+        };
+        const rawId = String(p.seriesId ?? "");
+        // Map the dashed buffer overlay back onto its series; drop every other
+        // internal series (mini chart, loading skeleton, hover-reveal base).
+        const key = rawId.startsWith(BUFFER_PREFIX)
+          ? rawId.slice(BUFFER_PREFIX.length)
+          : rawId.startsWith("__")
+            ? ""
+            : (p.seriesId ?? p.seriesName ?? "");
+        if (!key) return "";
+        // A null value means this series does not reach the hovered x (a buffer
+        // area's solid part stops before the last point, a revealed series stops
+        // at the cursor) — skip it, letting another row for the key stand in.
+        if (p.value === null || p.value === undefined) return "";
+        if (seen.has(key)) return "";
+        seen.add(key);
+
+        const item = config[key];
+        const colorsCount = item ? getColorsCount(item) : 1;
+        const labelText = typeof item?.label === "string" ? item.label : (p.seriesName ?? key);
+        const hovered = getHoveredKey();
+        const dimmed =
+          (selectedDataKey != null && selectedDataKey !== key) ||
+          (hovered != null && hovered !== key)
+            ? " opacity-30"
+            : "";
+        return tooltipRow({
+          indicatorHtml: tooltipIndicatorHtml(key, colorsCount),
+          labelText,
+          valueText: formatTooltipValue(p.value),
+          suffix: tooltipSlot.suffix,
+          dimmed,
+        });
+      })
+      .join("");
+
+    return tooltipShell({
+      label,
+      body,
+      roundness: tooltipSlot.roundness,
+      variant: tooltipSlot.variant,
+    });
+  };
+}
+
+function buildTooltipOption(ctx: OptionBuildContext): TooltipComponentOption {
+  const { tooltipSlot, isLoading } = ctx;
+  const { tokens } = ctx.resolved;
+
+  return {
+    ...tooltipBaseOption({
+      present: tooltipSlot.present && !isLoading,
+      cursor: tooltipSlot.cursor,
+      tokens,
+      position: tooltipSlot.position,
+      axisPointerColor: withAlpha(tokens.border, AXIS_POINTER_OPACITY),
+      strokeWidth: STROKE_WIDTH,
+    }),
+    formatter: createTooltipFormatter(ctx),
+  };
+}
+
+// ── Brush — the evil-brush look, canvas-style: a real mini chart of the full
+// data in a second grid, with a transparent slider dataZoom laid over it. Both
+// zoom entries target only the MAIN x-axis, so the mini chart never filters
+// itself. Only called when `showBrush` is set.
+function buildBrushOption(
+  ctx: OptionBuildContext,
+  brushBottom: number,
+): {
+  miniGrid: GridComponentOption;
+  miniXAxis: XAxisOption;
+  miniYAxis: YAxisOption;
+  miniSeries: LineSeriesOption[];
+  dataZoom: DataZoomComponentOption[];
+} {
+  const { data, areas, curveType, isStacked, selectedDataKey, brushHeight, categories } = ctx;
+  const { tokens } = ctx.resolved;
+
+  const miniGrid: GridComponentOption = {
+    left: 8,
+    right: 8,
+    bottom: brushBottom,
+    height: brushHeight,
+    // No visible axes here — opt out of label containment so the mini chart
+    // spans the full brush frame.
+    outerBoundsMode: "none",
+  };
+
+  const miniXAxis: XAxisOption = {
+    type: "category",
+    gridIndex: 1,
+    boundaryGap: false,
+    show: false,
+    data: categories,
+    axisPointer: { show: false },
+  };
+
+  const miniYAxis: YAxisOption = { type: "value", gridIndex: 1, show: false };
+
+  const miniSeries: LineSeriesOption[] = areas.map((area) => {
+    const key = area.dataKey;
+    const base = (ctx.resolved.series[key] ?? [])[0] ?? "rgba(120, 120, 120, 1)";
+    const curve = curveConfig(area.curveType ?? curveType);
+
+    // The mini chart mirrors the click selection: unselected series recede
+    // by the same ratios as the main plot.
+    // Dim ratios normalize against the base opacities (stroke 1, fill 0.8).
+    const opacity = getOpacity(selectedDataKey, key);
+    const strokeDim = opacity.stroke;
+    const fillDim = opacity.fill / 0.8;
+
+    return {
+      id: `__mini-${key}`,
+      type: "line",
+      xAxisIndex: 1,
+      yAxisIndex: 1,
+      data: data.map((row) => Number(row[key]) || 0),
+      stack: isStacked ? "__mini-total" : undefined,
+      smooth: curve.smooth,
+      step: curve.step,
+      connectNulls: area.connectNulls,
+      silent: true,
+      showSymbol: false,
+      emphasis: { disabled: true },
+      tooltip: { show: false },
+      lineStyle: { color: base, width: 1, opacity: BRUSH_STROKE_OPACITY * strokeDim },
+      areaStyle: {
+        color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+          { offset: 0, color: withAlpha(base, BRUSH_FILL_OPACITY * fillDim) },
+          { offset: 1, color: withAlpha(base, 0) },
+        ]),
+      },
+      z: 0,
+    };
+  });
+
+  const dataZoom = buildBrushDataZoom({
+    brushBottom,
+    brushHeight,
+    brushRange: ctx.brushRange,
+    fillerColor: withAlpha(tokens.foreground, BRUSH_FILLER_OPACITY),
+  });
+
+  return { miniGrid, miniXAxis, miniYAxis, miniSeries, dataZoom };
+}
+
+// Loading skeleton — ONE gray wave regardless of declared areas (Recharts
+// parity: its skeleton is a single LoadingArea), swept by the shimmer rAF.
+function buildLoadingOption(
+  ctx: OptionBuildContext,
+  frame: { grid: GridComponentOption; xAxis: XAxisOption; yAxis: YAxisOption },
+): EChartsOption {
+  const { tokens } = ctx.resolved;
+  const curve = curveConfig(ctx.curveType);
+
+  return {
+    animation: false,
+    grid: frame.grid,
+    xAxis: frame.xAxis,
+    yAxis: frame.yAxis,
+    tooltip: { show: false },
+    series: [
+      {
+        id: "__loading",
+        type: "line",
+        data: ctx.loadingData(),
+        smooth: curve.smooth,
+        step: curve.step,
+        showSymbol: false,
+        silent: true,
+        // Invisible until the first shimmer tick positions the clip window.
+        lineStyle: { color: withAlpha(tokens.foreground, 0), width: 1 },
+        areaStyle: { color: withAlpha(tokens.foreground, 0) },
+        z: 1,
+      },
+    ],
+  };
+}
+
+function buildAreaSeries(ctx: OptionBuildContext): LineSeriesOption[] {
+  const {
+    data,
+    config,
+    areas,
+    seriesKeys,
+    curveType,
+    isStacked,
+    isExpanded,
+    selectedDataKey,
+    hasSelection,
+    enableHoverHighlight,
+    enableHoverReveal,
+    revealIndex,
+    revealSink,
+    resolved,
+    rendererSize,
+  } = ctx;
+
+  // Optional per-row normalization for the expanded (100%) stack.
+  const rowTotals = isExpanded
+    ? data.map((row) => seriesKeys.reduce((sum, key) => sum + (Number(row[key]) || 0), 0))
+    : [];
+
+  return areas.flatMap((area): LineSeriesOption[] => {
+    const key = area.dataKey;
+    const slots = resolved.series[key] ?? ["rgba(120, 120, 120, 1)"];
+    const paint = seriesPaint(slots);
+    const isSelected = selectedDataKey === key;
+    const showUnselected = hasSelection && !isSelected;
+    const opacity = getOpacity(selectedDataKey, key);
+    const curve = curveConfig(area.curveType ?? curveType);
+
+    const values = data.map((row, i) => {
+      const value = Number(row[key]) || 0;
+      if (!isExpanded) return value;
+      const total = rowTotals[i];
+      return total ? value / total : 0;
+    });
+    const n = values.length;
+    // Hover-reveal is a root-level mode and owns the whole area rendering, so it
+    // takes precedence over a per-area buffer tail when both are set.
+    const reveal = enableHoverReveal;
+    const buffer = !reveal && area.enableBufferLine && n >= 2;
+    const revealActive = reveal && revealIndex !== null;
+
+    const restingDot = dotStyle(area.dotVariant, paint, resolved.tokens.background);
+    const activeDot = dotStyle(area.activeDotVariant, paint, resolved.tokens.background);
+    const restingVisible = area.dotVariant !== "none";
+    const dotOpacity = opacity.dot;
+    const multiColor = slots.length > 1;
+
+    // The reveal truncates the line to the cursor, which would COMPRESS a
+    // bbox-relative stroke gradient into the shorter span — misaligning it from
+    // the plot-anchored fill texture and the index-sampled dots. Anchor the
+    // stroke to the plot in absolute pixels so every x keeps its own color.
+    const strokePaint =
+      reveal && multiColor
+        ? new echarts.graphic.LinearGradient(
+            8,
+            0,
+            Math.max(rendererSize.width - 8, 9),
+            0,
+            slots.map((color, i) => ({ offset: i / (slots.length - 1), color })),
+            true,
+          )
+        : paint;
+
+    // Turn a value list into ECharts data — attaching per-datum symbol colors
+    // for multi-color areas (like the Recharts dots; the line/fill keep the full
+    // gradient), and passing `null` gaps through so a buffer area's two parts
+    // each draw only their own segment.
+    type AreaPoint =
+      | number
+      | null
+      | {
+          value: number;
+          itemStyle: Record<string, unknown>;
+          emphasis: { itemStyle: Record<string, unknown> };
+        };
+    const toPoints = (vals: (number | null)[]): AreaPoint[] =>
+      !multiColor
+        ? vals
+        : vals.map((value, i): AreaPoint => {
+            if (value === null) return null;
+            const t = vals.length > 1 ? i / (vals.length - 1) : 0;
+            const pointColor = sampleGradient(slots, t);
+            return {
+              value,
+              itemStyle: {
+                ...dotItemStyle(
+                  restingVisible ? area.dotVariant : area.activeDotVariant,
+                  pointColor,
+                  resolved.tokens.background,
+                ),
+                opacity: dotOpacity,
+              },
+              emphasis: {
+                itemStyle: {
+                  ...dotItemStyle(
+                    area.activeDotVariant === "none" ? "default" : area.activeDotVariant,
+                    pointColor,
+                    resolved.tokens.background,
+                  ),
+                  opacity: 1,
+                },
+              },
+            };
+          });
+
+    // Buffer area: the solid MAIN part drops the last point (its final segment —
+    // both fill and stroke — becomes the dashed, fill-less overlay); the overlay
+    // carries only the last two points. Reveal instead TRUNCATES the real series
+    // at the cursor's x-index (points beyond it null'd), so its line + fill stop
+    // there and the muted base layer shows through past it. When idle
+    // (revealIndex null) the real series carries its full data — the chart looks
+    // completely normal.
+    // Snapshot the FULL per-datum points (with the multi-color dot itemStyle) so
+    // the reveal hover handler can slice them without losing each dot's sampled
+    // gradient color — plain values would fall back to the default palette.
+    if (reveal) revealSink[key] = toPoints(values);
+
+    const mainValues: (number | null)[] = buffer
+      ? values.map((v, i) => (i === n - 1 ? null : v))
+      : revealActive
+        ? sliceToNull(values, revealIndex as number)
+        : values;
+
+    // A buffer area keeps its body solid and dashes only the tail overlay, so
+    // the main stroke is always solid regardless of strokeVariant (matches the
+    // Recharts twin, which suppresses the base dasharray while buffering).
+    const mainDash: "solid" | [number, number] =
+      buffer || area.strokeVariant === "solid" ? "solid" : ([3, 3] as [number, number]);
+
+    const z = isSelected ? 3 : hasSelection ? 1 : 2;
+
+    const mainSeries: LineSeriesOption = {
+      id: key,
+      name: typeof config[key]?.label === "string" ? config[key]?.label : key,
+      type: "line",
+      data: toPoints(mainValues),
+      stack: isStacked ? "total" : undefined,
+      smooth: curve.smooth,
+      step: curve.step,
+      connectNulls: area.connectNulls,
+      cursor: area.isClickable ? "pointer" : "default",
+      // By default ECharts only fires mouse events on the symbols — this makes
+      // the line AND the filled area clickable, like the Recharts <Area>.
+      // (`true` covers both; the deprecated `triggerLineEvent` did the same.)
+      triggerEvent: area.isClickable,
+      showSymbol: restingVisible,
+      symbol: "circle",
+      symbolSize: restingVisible ? restingDot.size : activeDot.size,
+      z,
+      lineStyle: {
+        color: strokePaint,
+        width: area.strokeWidth,
+        opacity: opacity.stroke,
+        type: mainDash,
+        dashOffset: 0,
+      },
+      itemStyle: multiColor
+        ? { opacity: dotOpacity }
+        : {
+            ...(restingVisible ? restingDot.itemStyle : activeDot.itemStyle),
+            opacity: dotOpacity,
+          },
+      areaStyle: {
+        color: fillPaint(area.variant, showUnselected, slots, rendererSize),
+        opacity: opacity.fill,
+      },
+      emphasis: {
+        // focus "series" blurs every other series in this grid while one is
+        // hovered — the hover twin of the click selection. Suppressed entirely
+        // while a series is click-selected: the selection dim owns the canvas,
+        // so hover highlighting stops until the selection clears (the option
+        // rebuilds on selection change, making this a build-time conditional).
+        // Reveal owns the hover visual, so native focus-blur stands down when it
+        // is on (they must not blend).
+        focus: enableHoverHighlight && !enableHoverReveal && !hasSelection ? "series" : "none",
+        scale: restingVisible ? activeDot.size / Math.max(restingDot.size, 1) : 1,
+        ...(multiColor ? {} : { itemStyle: { ...activeDot.itemStyle, opacity: 1 } }),
+      },
+      // Blur styling mirrors the click-selection dim (fill 0.1 / stroke 0.3 / dot 0.3).
+      blur: {
+        lineStyle: { opacity: 0.3 },
+        areaStyle: { opacity: 0.1 },
+        itemStyle: { opacity: 0.3 },
+      },
+    };
+
+    // Hover-reveal: a muted gray BASE layer of the FULL series sits one z below
+    // the real one. It is invisible while idle (opacity 0 → the chart looks
+    // normal) and fades in only while hovering, so the region PAST the cursor —
+    // where the truncated real series has stopped — shows as neutral gray.
+    if (reveal) {
+      const muted = resolved.tokens.mutedForeground;
+      const revealBase: LineSeriesOption = {
+        id: `${REVEAL_PREFIX}${key}`,
+        type: "line",
+        // Only the region FROM the cursor onward (null before it), so the gray
+        // never sits under the colored part — the two meet exactly at the
+        // pointer and their colors can't mix.
+        data: revealActive ? sliceFrom(values, revealIndex as number) : values,
+        // Its OWN stack, not "total" — a second series in the real stack would
+        // double every key's contribution (broken geometry). This mirror stack
+        // reproduces the same cumulative shape in a separate layer.
+        stack: isStacked ? "__reveal-total" : undefined,
+        smooth: curve.smooth,
+        step: curve.step,
+        connectNulls: false,
+        silent: true,
+        showSymbol: false,
+        symbol: "circle",
+        z: z - 1,
+        // Neutral gray, NO fill, SAME dash pattern as the colored line.
+        lineStyle: {
+          color: muted,
+          width: area.strokeWidth,
+          type: mainDash,
+          opacity: revealActive ? 0.3 : 0,
+        },
+        emphasis: { disabled: true },
+        blur: { lineStyle: { opacity: revealActive ? 0.3 : 0 } },
+        tooltip: { show: false },
+      };
+      return [revealBase, mainSeries];
+    }
+
+    if (!buffer) return [mainSeries];
+
+    // Dashed forecast overlay — draws ONLY the last segment's stroke, with NO
+    // fill (matching the line twin's fill-less buffer). Silent, so it never
+    // intercepts clicks/hover; it still feeds the axis tooltip (silent series
+    // are aggregated by axis), which is why the last point keeps its number.
+    const bufferValues: (number | null)[] = values.map((v, i) => (i >= n - 2 ? v : null));
+    const bufferSeries: LineSeriesOption = {
+      id: `${BUFFER_PREFIX}${key}`,
+      type: "line",
+      data: toPoints(bufferValues),
+      // Own mirror stack — a second series in "total" would double the last
+      // points' stacked height (buffer drawn too high). Same values in the same
+      // order give the identical cumulative height, so the dash lines up.
+      stack: isStacked ? "__buffer-total" : undefined,
+      smooth: curve.smooth,
+      step: curve.step,
+      connectNulls: true,
+      silent: true,
+      showSymbol: restingVisible,
+      symbol: "circle",
+      symbolSize: restingVisible ? restingDot.size : activeDot.size,
+      z,
+      lineStyle: {
+        color: paint,
+        width: area.strokeWidth,
+        opacity: opacity.stroke,
+        type: BUFFER_DASH,
+      },
+      itemStyle: multiColor
+        ? { opacity: dotOpacity }
+        : {
+            ...(restingVisible ? restingDot.itemStyle : activeDot.itemStyle),
+            opacity: dotOpacity,
+          },
+      // The dashed tail is a separate silent series, so focus:"series" on its
+      // parent would blur it apart from the area it belongs to. The root
+      // dispatch-links this id (companionIdsByKey) so it focuses WITH its parent;
+      // these styles give it the parent's look while focused and the
+      // click-selection dim while another series is hovered.
+      emphasis: {
+        focus: "none",
+        scale: false,
+        lineStyle: { opacity: opacity.stroke },
+        itemStyle: { opacity: dotOpacity },
+      },
+      blur: { lineStyle: { opacity: 0.3 }, itemStyle: { opacity: 0.3 } },
+    };
+
+    // Fill patch — the main area drops its last point (so the tail stroke can be
+    // the dashed overlay), which also removes the FILL under that last segment.
+    // This fill-only layer (no stroke, no dots) fills just that segment so the
+    // area reads as full under the dashed tail. Its OWN mirror stack keeps the
+    // stacked geometry right — a second series in "total" would double the last
+    // points' cumulative height (same reason as the reveal base + mini chart).
+    const bufferFillSeries: LineSeriesOption = {
+      id: `${BUFFERFILL_PREFIX}${key}`,
+      type: "line",
+      data: toPoints(bufferValues),
+      stack: isStacked ? "__bufferfill-total" : undefined,
+      smooth: curve.smooth,
+      step: curve.step,
+      connectNulls: true,
+      silent: true,
+      showSymbol: false,
+      z: z - 1,
+      lineStyle: { opacity: 0 },
+      areaStyle: {
+        color: fillPaint(area.variant, showUnselected, slots, rendererSize),
+        opacity: opacity.fill,
+      },
+      emphasis: { disabled: true },
+      blur: { areaStyle: { opacity: 0.1 } },
+      tooltip: { show: false },
+    };
+
+    return [mainSeries, bufferSeries, bufferFillSeries];
+  });
+}
+
+// Copy a value list with everything AFTER `idx` nulled — the hover-reveal cut:
+// the colored real series keeps its data up to the cursor and drops the rest, so
+// (with connectNulls false) its line and fill stop dead at the pointer.
+function sliceToNull<T>(vals: readonly T[], idx: number): (T | null)[] {
+  return vals.map((v, i) => (i > idx ? null : v));
+}
+
+// Copy a value list with everything BEFORE `idx` nulled — the reveal's gray tail.
+// The muted base keeps only the region from the cursor onward, so it never sits
+// under the colored part; both include `idx` so they meet at the pointer.
+// Generic so it preserves per-datum point objects (multi-color dot itemStyle).
+function sliceFrom<T>(vals: readonly T[], idx: number): (T | null)[] {
+  return vals.map((v, i) => (i < idx ? null : v));
+}
+
+// Per-series PLOTTED top value per category index — expanded normalization and
+// stack accumulation applied — so pointer hit-testing can reason in data space.
+function computePlottedTops(ctx: OptionBuildContext): Record<string, number[]> {
+  const { data, areas, seriesKeys, isStacked, isExpanded } = ctx;
+  const rowTotals = isExpanded
+    ? data.map((row) => seriesKeys.reduce((sum, key) => sum + (Number(row[key]) || 0), 0))
+    : [];
+  const running = new Array(data.length).fill(0);
+  const tops: Record<string, number[]> = {};
+  for (const area of areas) {
+    const key = area.dataKey;
+    tops[key] = data.map((row, i) => {
+      let value = Number(row[key]) || 0;
+      if (isExpanded) value = rowTotals[i] ? value / rowTotals[i] : 0;
+      return isStacked ? (running[i] += value) : value;
+    });
+  }
+  return tops;
+}
+
+// Overlapping area polygons all contain the same pixel, so ECharts' native hit
+// test lands on whichever series drew topmost — not the band the user SEES.
+// Resolve the intended series geometrically: a plotted line within grab
+// distance of the pointer wins outright; otherwise the point belongs to the
+// nearest line ABOVE it (the boundary of the band the pointer is inside).
+// Returns null when the pointer is outside the grid or above every line.
+function resolveAreaAtPixel(
+  chart: EChartsInstance,
+  tops: Record<string, number[]>,
+  keys: string[],
+  x: number,
+  y: number,
+): string | null {
+  if (keys.length < 2) return null;
+  if (!chart.containPixel({ gridIndex: 0 }, [x, y])) return null;
+  const [rawIndex] = chart.convertFromPixel({ gridIndex: 0 }, [x, y]);
+  const index = Math.round(rawIndex!);
+
+  let nearest: string | null = null;
+  let nearestDist = Infinity;
+  let above: string | null = null;
+  let abovePixelY = -Infinity;
+  for (const key of keys) {
+    const value = tops[key]?.[index];
+    if (value === undefined) continue;
+    const pixelY = chart.convertToPixel({ gridIndex: 0 }, [index, value])[1]!;
+    const dist = Math.abs(pixelY - y);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearest = key;
+    }
+    // Pixel y grows downward: a line above the pointer has the larger pixelY
+    // among those ≤ the pointer's.
+    if (pixelY <= y && pixelY > abovePixelY) {
+      abovePixelY = pixelY;
+      above = key;
+    }
+  }
+  return nearestDist <= 10 ? nearest : above;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live imperative state — everything the ECharts event handlers, rAF loops, and
+// theme/resize repushes read or write OUTSIDE the React render cycle, grouped in
+// one ref-stable object so the whole imperative surface is visible at a glance.
+// None of it is render output, which is exactly why it is not React state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LiveState = {
+  resolved: ResolvedColors | null; // colors read off the live DOM — feeds builds and rAF loops
+  hoveredKey: string | null; // tooltip's view of hover — the legend's twin lives in React state
+  hasRevealed: boolean; // the intro draw-in already played on this chart instance
+  revealEndsAt: number; // performance.now() timestamp when the entrance settles
+  loadingRows: number[] | null; // skeleton data, lazily rolled and re-rolled per shimmer sweep
+  categories: string[]; // x labels of the last build, for the brush label pills
+  dataLength: number; // row count, for the datazoom index math
+  plottedTops: Record<string, number[]>; // per-series plotted line value per index, for pointer hit-testing
+  seriesKeyByIndex: (string | undefined)[]; // built series order → key, so a polygon click's seriesIndex recovers its key past interleaved buffer/reveal/mini series
+  companionIdsByKey: Map<string, string[]>; // per-key silent companion series ids (buffer tail, reveal base) — highlighted/downplayed with their parent
+  revealIndex: number | null; // hover-reveal pointer x-index (null = idle); read by builds and the reveal hover handler
+  revealValues: Record<string, unknown[]>; // per-area FULL per-datum points (with dot itemStyle), sliced to the cursor on hover without a rebuild
+  brushRange: BrushRange; // live zoom window — carried through every rebuild
+  brushGeom: BrushGeometry | null; // brush footer layout of the last build
+  brushOverlay: BrushOverlayElements | null; // zrender elements, owned by syncBrushOverlay
+  brushHover: { inside: boolean; left: boolean; right: boolean };
+  // Latest callbacks/flags for the imperative ECharts event handlers.
+  handlers: {
+    onBrushChange?: (range: { startIndex: number; endIndex: number }) => void;
+    onSelectionChange?: (key: string | null) => void;
+    clickableKeys: Set<string>;
+    selectedDataKey: string | null;
+    brushFormatLabel?: (value: string, index: number) => string;
+    seriesKeys: string[];
+    enableHoverHighlight: boolean;
+    enableHoverReveal: boolean;
+  };
+  // Update-style re-push for paths that bypass React entirely (theme flips,
+  // resizes) — set by the sync effect.
+  repush: () => void;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Apache ECharts port of the EvilCharts area chart, exposing a compound-as-config
+ * API so its JSX reads identically to the Recharts twin. The root owns the data,
+ * config, selection state, loading skeleton, intro reveal, and optional zoom
+ * brush; every visual part — `<Area>`, `<XAxis>`, `<YAxis>`, `<Grid>`,
+ * `<Tooltip>`, `<Legend>` — is composed as a declarative child that renders
+ * nothing. The root walks those children by reference and drives a single
+ * imperative ECharts instance. Fully self-contained: its only dependencies are
+ * `react` and `echarts`.
+ */
+export function EChartsAreaChart<TData extends Record<string, unknown>>({
+  data,
+  config,
+  xDataKey,
+  className,
+  curveType = "linear",
+  stackType = "default",
+  animation = true,
+  animationType = "left-to-right",
+  enableHoverHighlight = false,
+  enableHoverReveal = false,
+  defaultSelectedDataKey = null,
+  selectedDataKey: selectedDataKeyProp,
+  onSelectionChange,
+  isLoading = false,
+  loadingPoints = LOADING_DEFAULT_POINTS,
+  chartOptions,
+  children,
+}: EChartsAreaChartProps<TData>) {
+  const rawId = useId();
+  const chartId = `chart-${rawId.replace(/:/g, "")}`;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<HTMLDivElement>(null);
+  const echartsRef = useRef<EChartsInstance | null>(null);
+
+  // The single imperative surface (see LiveState). `resolved` lives here rather
+  // than in state: as state it forced an extra render pass and an effect whose
+  // only job was to trigger the option push — the "chain of computations"
+  // react.dev/learn/you-might-not-need-an-effect warns about. The object
+  // identity is stable for the component's lifetime.
+  const live = useRef<LiveState>({
+    resolved: null,
+    hoveredKey: null,
+    hasRevealed: false,
+    revealEndsAt: 0,
+    loadingRows: null,
+    categories: [],
+    dataLength: 0,
+    plottedTops: {},
+    seriesKeyByIndex: [],
+    companionIdsByKey: new Map<string, string[]>(),
+    revealIndex: null,
+    revealValues: {},
+    brushRange: { start: 0, end: 100 },
+    brushGeom: null,
+    brushOverlay: null,
+    brushHover: { inside: false, left: false, right: false },
+    handlers: {
+      onBrushChange: undefined, // set per-render from the <Brush> child's onChange
+      onSelectionChange,
+      clickableKeys: new Set<string>(),
+      selectedDataKey: defaultSelectedDataKey,
+      brushFormatLabel: undefined, // set per-render from the <Brush> child's formatLabel
+      seriesKeys: [],
+      enableHoverHighlight,
+      enableHoverReveal,
+    },
+    repush: () => {},
+  }).current;
+
+  // Skeleton rows roll lazily on first use — an impure useRef initializer would
+  // re-roll Math.random() on every render.
+  const loadingData = useCallback(
+    () => (live.loadingRows ??= getLoadingData(loadingPoints)),
+    [live, loadingPoints],
+  );
+  const shouldReduceMotion = useReducedMotion();
+
+  // Selection is controlled when the `selectedDataKey` prop is provided;
+  // otherwise the internal state (seeded by defaultSelectedDataKey) drives it.
+  const [internalSelectedKey, setSelectedDataKey] = useState<string | null>(defaultSelectedDataKey);
+  const selectedDataKey =
+    selectedDataKeyProp !== undefined ? selectedDataKeyProp : internalSelectedKey;
+
+  // Hover-highlight mirrors into the legend (React state) and tooltip
+  // (live.hoveredKey — its formatter runs on every hover, and pushing an option
+  // to sync it would reset ECharts' blur state mid-hover).
+  const [hoveredDataKey, setHoveredDataKey] = useState<string | null>(null);
+
+  // ── Declarative config, collected from children by reference ─────────────────
+  const collected = useMemo(() => collectConfig(children), [children]);
+  const {
+    areas,
+    xAxis: xAxisSlot,
+    yAxis: yAxisSlot,
+    showGrid,
+    tooltip: tooltipSlot,
+    legend: legendSlot,
+    brush: brushSlot,
+  } = collected;
+  // Brush is a <Brush> child now (not props): presence turns it on, its props
+  // carry height/formatLabel/onChange.
+  const showBrush = brushSlot.present;
+  const brushHeight = brushSlot.height ?? 56;
+
+  const seriesKeys = useMemo(() => areas.map((area) => area.dataKey), [areas]);
+
+  // x category key: <XAxis dataKey> → root xDataKey → first data column no <Area> claims.
+  const xCategoryKey = useMemo(() => {
+    if (xAxisSlot.dataKey) return xAxisSlot.dataKey;
+    if (xDataKey) return xDataKey as string;
+    const firstRow = data[0];
+    if (firstRow) {
+      const claimed = new Set(seriesKeys);
+      const found = Object.keys(firstRow).find((key) => !claimed.has(key));
+      if (found) return found;
+    }
+    return "";
+  }, [xAxisSlot.dataKey, xDataKey, data, seriesKeys]);
+
+  // The intro draw-in follows the first area's setting, falling back to the root default.
+  const effectiveAnimation = areas[0]?.animationType ?? animationType;
+
+  const css = useMemo(() => buildChartCss(chartId, config), [chartId, config]);
+
+  const hasSelection = selectedDataKey !== null;
+  const isExpanded = stackType === "expanded";
+  const isStacked = stackType === "stacked" || isExpanded;
+
+  // Which series may be clicked to toggle selection (consulted by the click handler).
+  const clickableKeys = useMemo(
+    () => new Set(areas.filter((area) => area.isClickable).map((area) => area.dataKey)),
+    [areas],
+  );
+
+  // Refresh the handlers' snapshot of the latest callbacks/flags every render.
+  live.handlers = {
+    onBrushChange: brushSlot.onChange,
+    onSelectionChange,
+    clickableKeys,
+    selectedDataKey,
+    brushFormatLabel: brushSlot.formatLabel,
+    seriesKeys,
+    enableHoverHighlight,
+    enableHoverReveal,
+  };
+  live.dataLength = data.length;
+
+  // Reads the CURRENT selection through live.handlers so the identity stays
+  // stable for the init effect's click closure, and stays correct when the
+  // selection is controlled from outside.
+  const toggleSelection = useCallback(
+    (key: string) => {
+      const next = live.handlers.selectedDataKey === key ? null : key;
+      // Making a selection hands the canvas to the selection dim — clear any
+      // active hover highlight at that moment so it doesn't linger in the
+      // legend/tooltip or fight the notMerge rebuild that follows.
+      if (next !== null && live.hoveredKey !== null) {
+        const previous = live.hoveredKey;
+        live.hoveredKey = null;
+        setHoveredDataKey(null);
+        echartsRef.current?.dispatchAction({
+          type: "downplay",
+          seriesIndex: live.handlers.seriesKeys.indexOf(previous),
+        });
+      }
+      setSelectedDataKey(next);
+      live.handlers.onSelectionChange?.(next);
+    },
+    [live],
+  );
+
+  // Reposition the brush overlays from the live refs — safe to call from drag
+  // events, hover tracking, and pushes alike, since it never touches setOption.
+  const syncBrushOverlayNow = useCallback(() => {
+    const chart = echartsRef.current;
+    if (!chart) return;
+
+    const geom = live.brushGeom;
+    const tokens = live.resolved?.tokens;
+    if (!geom || !tokens) {
+      syncBrushOverlay(chart, live, null);
+      return;
+    }
+
+    const range = live.brushRange;
+    const categories = live.categories;
+    const format = live.handlers.brushFormatLabel;
+    const lastIndex = Math.max(categories.length - 1, 0);
+    const startIndex = Math.round((range.start / 100) * lastIndex);
+    const endIndex = Math.round((range.end / 100) * lastIndex);
+    const labels =
+      format && categories.length
+        ? {
+            start: format(categories[startIndex] ?? "", startIndex),
+            end: format(categories[endIndex] ?? "", endIndex),
+          }
+        : null;
+
+    syncBrushOverlay(chart, live, {
+      range,
+      geom,
+      size: { width: chart.getWidth(), height: chart.getHeight() },
+      tokens,
+      labels,
+      showLabels: live.brushHover.inside,
+      hover: live.brushHover,
+    });
+  }, [live]);
+
+  // ── Option builder ─────────────────────────────────────────────────────────
+  // Thin orchestrator over the pure builders above: snapshot the imperative
+  // surface (refs, renderer size) into an OptionBuildContext, then assemble.
+  const buildOption = useCallback((): EChartsOption => {
+    const resolved = live.resolved;
+    if (!resolved) return {};
+
+    const categories = data.map((row) => String(row[xCategoryKey]));
+    live.categories = categories;
+
+    // buildAreaSeries fills this with each area's full per-datum points (with the
+    // multi-color dot itemStyle) so the reveal hover handler slices real data.
+    const revealSink: Record<string, unknown[]> = {};
+
+    const ctx: OptionBuildContext = {
+      data,
+      config,
+      areas,
+      seriesKeys,
+      curveType,
+      isStacked,
+      isExpanded,
+      selectedDataKey,
+      hasSelection,
+      showGrid,
+      xAxisSlot,
+      yAxisSlot,
+      tooltipSlot,
+      legendSlot,
+      isLoading,
+      loadingData,
+      showBrush,
+      brushHeight,
+      enableHoverHighlight,
+      enableHoverReveal,
+      revealIndex: live.revealIndex,
+      resolved,
+      rendererSize: {
+        width: echartsRef.current?.getWidth() ?? mountRef.current?.clientWidth ?? 0,
+        height: echartsRef.current?.getHeight() ?? mountRef.current?.clientHeight ?? 0,
+      },
+      categories,
+      brushRange: live.brushRange,
+      getHoveredKey: () => live.hoveredKey,
+      revealSink,
+    };
+
+    live.plottedTops = computePlottedTops(ctx);
+
+    const { grid, brushBottom } = buildChartLayout(ctx);
+    live.brushGeom = showBrush ? { bottom: brushBottom, height: brushHeight } : null;
+
+    const { xAxis, yAxis } = buildMainAxes(ctx);
+
+    if (isLoading) return buildLoadingOption(ctx, { grid, xAxis, yAxis });
+
+    const brush = showBrush ? buildBrushOption(ctx, brushBottom) : null;
+
+    const series = [...buildAreaSeries(ctx), ...(brush?.miniSeries ?? [])];
+    // buildAreaSeries has now filled revealSink with each area's full per-datum
+    // points — hand them to the hover handler for slicing.
+    if (enableHoverReveal) live.revealValues = revealSink;
+    // Record the exact series order so an area-polygon click (which reports only
+    // a seriesIndex) can recover its key — buffer/reveal/mini/loading series
+    // break the "index === key position" shortcut, so map each index to its id.
+    live.seriesKeyByIndex = series.map((s) => {
+      const id = String(s.id ?? "");
+      return id && !id.startsWith("__") ? id : undefined;
+    });
+    // Map each key to its silent companion series ids (buffer tail, hover-reveal
+    // base), mirroring exactly what buildAreaSeries emits — the hover handlers
+    // highlight/downplay these with the parent so focus:"series" never strands
+    // an area's own forecast tail or muted reveal base apart from it.
+    const companionIdsByKey = new Map<string, string[]>();
+    for (const area of areas) {
+      const ids: string[] = [];
+      if (area.enableBufferLine && data.length >= 2) {
+        ids.push(`${BUFFER_PREFIX}${area.dataKey}`, `${BUFFERFILL_PREFIX}${area.dataKey}`);
+      }
+      if (enableHoverReveal) ids.push(`${REVEAL_PREFIX}${area.dataKey}`);
+      if (ids.length) companionIdsByKey.set(area.dataKey, ids);
+    }
+    live.companionIdsByKey = companionIdsByKey;
+
+    return {
+      animation: false,
+      grid: brush ? [grid, brush.miniGrid] : grid,
+      xAxis: brush ? [xAxis, brush.miniXAxis] : xAxis,
+      yAxis: brush ? [yAxis, brush.miniYAxis] : yAxis,
+      tooltip: buildTooltipOption(ctx),
+      dataZoom: brush?.dataZoom,
+      series,
+    };
+  }, [
+    live,
+    data,
+    config,
+    areas,
+    seriesKeys,
+    xCategoryKey,
+    curveType,
+    isStacked,
+    isExpanded,
+    selectedDataKey,
+    hasSelection,
+    showGrid,
+    xAxisSlot,
+    yAxisSlot,
+    tooltipSlot,
+    legendSlot,
+    isLoading,
+    loadingData,
+    showBrush,
+    brushHeight,
+    enableHoverHighlight,
+    enableHoverReveal,
+  ]);
+
+  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  useEffect(() => {
+    const mount = mountRef.current;
+    const container = containerRef.current;
+    if (!mount || !container) return;
+
+    const chart = echarts.init(mount);
+    echartsRef.current = chart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Observers always fire once right after observe(). Repushing on that
+      // no-op fire would land one frame into the intro and stomp the line's
+      // reveal clip — only react when the renderer size actually changed.
+      if (mount.clientWidth === chart.getWidth() && mount.clientHeight === chart.getHeight()) {
+        return;
+      }
+      chart.resize();
+      // 2D gradient textures are baked at renderer size — rebuild them to fit.
+      live.repush();
+    });
+    resizeObserver.observe(mount);
+
+    // Light/dark flips change no React state — re-resolve and push directly.
+    const themeObserver = new MutationObserver(() => {
+      live.repush();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    chart.on("click", (params) => {
+      const { clickableKeys: clickable, seriesKeys: keys } = live.handlers;
+      const p = params as {
+        seriesId?: string;
+        seriesIndex?: number;
+        event?: { offsetX?: number; offsetY?: number };
+      };
+      // Symbol clicks carry seriesId; area-polygon clicks (triggerEvent)
+      // only carry seriesIndex — recover the key from the last build's index map,
+      // which accounts for the extra `__buffer-`/`__reveal-`/`__mini-` series
+      // interleaved between the main ones (a raw seriesKeys lookup would miss).
+      let id =
+        p.seriesId ??
+        (typeof p.seriesIndex === "number" ? live.seriesKeyByIndex[p.seriesIndex] : undefined);
+      // Overlapping polygons: the native hit is the topmost series, not the
+      // band the pointer is visually inside — resolve geometrically.
+      if (typeof p.event?.offsetX === "number" && typeof p.event?.offsetY === "number") {
+        const resolved = resolveAreaAtPixel(
+          chart,
+          live.plottedTops,
+          keys,
+          p.event.offsetX,
+          p.event.offsetY,
+        );
+        if (resolved) id = resolved;
+      }
+      if (typeof id === "string" && clickable.has(id)) toggleSelection(id);
+    });
+
+    // Hover-highlight is POINTER-driven, not series-mouseover-driven:
+    // overlapping polygons would pin the native hover on the topmost series and
+    // never re-fire while the pointer moves within it. A zrender mousemove
+    // tracker resolves the visually-hovered band, drives the canvas emphasis
+    // via dispatchAction, and mirrors into the HTML legend (React state) and
+    // tooltip (live.hoveredKey — its formatter runs per pointer move).
+    const applyHoverKey = (key: string | null) => {
+      if (live.hoveredKey === key) return;
+      const previous = live.hoveredKey;
+      live.hoveredKey = key;
+      setHoveredDataKey(key);
+      // Dispatch by seriesId (buffer/reveal series shift the numeric indices), and
+      // link each key's silent companions (buffer tail, reveal base) so
+      // focus:"series" never strands them apart from their parent.
+      if (previous) {
+        chart.dispatchAction({ type: "downplay", seriesId: previous });
+        for (const id of live.companionIdsByKey.get(previous) ?? [])
+          chart.dispatchAction({ type: "downplay", seriesId: id });
+      }
+      if (key) {
+        chart.dispatchAction({ type: "highlight", seriesId: key });
+        for (const id of live.companionIdsByKey.get(key) ?? [])
+          chart.dispatchAction({ type: "highlight", seriesId: id });
+      }
+    };
+
+    // Hover-reveal: color each area up to the pointer's x-index, mute the rest.
+    // Purely TARGETED series updates (real series data + muted base opacity) — we
+    // NEVER rebuild the whole option on mousemove, which would replay transitions
+    // and fight the tooltip's axis pointer.
+    const pushReveal = (idx: number | null) => {
+      const keys = live.handlers.seriesKeys;
+      const on = idx !== null;
+      chart.setOption(
+        {
+          series: keys.flatMap((key) => [
+            {
+              id: key,
+              data: on
+                ? sliceToNull(live.revealValues[key] ?? [], idx)
+                : (live.revealValues[key] ?? []),
+            },
+            {
+              id: `${REVEAL_PREFIX}${key}`,
+              // Gray tail keeps only the region from the cursor onward.
+              data: on
+                ? sliceFrom(live.revealValues[key] ?? [], idx)
+                : (live.revealValues[key] ?? []),
+              lineStyle: { opacity: on ? 0.3 : 0 },
+            },
+          ]),
+        },
+        // NOT lazy: the highlight dispatched just below re-draws the active dot
+        // the setOption wipes, so the option must be committed first — a queued
+        // (lazy) update would land after the dispatch and erase the dot again.
+        { silent: true },
+      );
+      // The per-frame setOption above cancels the axis tooltip's transient hover
+      // symbol, so the <ActiveDot> never lands at the cursor. Re-assert it:
+      // highlighting a real series at the cursor index draws its emphasis symbol
+      // (the active dot) even with showSymbol:false; downplay clears it on exit.
+      for (const key of keys) {
+        chart.dispatchAction(
+          on
+            ? { type: "highlight", seriesId: key, dataIndex: idx as number }
+            : { type: "downplay", seriesId: key },
+        );
+      }
+    };
+    const applyReveal = (event: { offsetX?: number; offsetY?: number }) => {
+      const len = live.dataLength;
+      if (len < 1) return;
+      const x = event.offsetX ?? -1;
+      const y = event.offsetY ?? -1;
+      if (!chart.containPixel({ gridIndex: 0 }, [x, y])) {
+        clearReveal();
+        return;
+      }
+      const raw = chart.convertFromPixel({ gridIndex: 0 }, [x, y])[0];
+      const idx = Math.max(0, Math.min(len - 1, Math.round(raw!)));
+      if (idx === live.revealIndex) return;
+      live.revealIndex = idx;
+      pushReveal(idx);
+    };
+    const clearReveal = () => {
+      if (live.revealIndex === null) return;
+      live.revealIndex = null;
+      pushReveal(null);
+    };
+
+    const zrHover = chart.getZr();
+    const onZrHoverMove = (event: { offsetX?: number; offsetY?: number }) => {
+      // Reveal is a standalone hover mode and takes precedence over highlight.
+      if (live.handlers.enableHoverReveal) {
+        applyReveal(event);
+        return;
+      }
+      if (!live.handlers.enableHoverHighlight) return;
+      // A click selection owns the canvas dim — hover highlighting stops
+      // entirely while one exists and resumes once it clears.
+      if (live.handlers.selectedDataKey !== null) return;
+      applyHoverKey(
+        resolveAreaAtPixel(
+          chart,
+          live.plottedTops,
+          live.handlers.seriesKeys,
+          event.offsetX ?? -1,
+          event.offsetY ?? -1,
+        ),
+      );
+    };
+    const onZrHoverOut = () => {
+      if (live.handlers.enableHoverReveal) clearReveal();
+      else if (live.handlers.enableHoverHighlight) applyHoverKey(null);
+    };
+    zrHover.on("mousemove", onZrHoverMove);
+    zrHover.on("globalout", onZrHoverOut);
+
+    // The native hover still emphasizes whichever element the pointer entered —
+    // cancel it whenever it disagrees with the tracker's resolved key.
+    chart.on("mouseover", (params) => {
+      const { enableHoverHighlight: hoverOn, enableHoverReveal: revealOn } = live.handlers;
+      if (!hoverOn || revealOn) return;
+      // While a selection is active, hover highlighting is disabled — never
+      // dispatch emphasis/downplay so the selection dim is the only dimming.
+      if (live.handlers.selectedDataKey !== null) return;
+      const p = params as { seriesIndex?: number; componentType?: string };
+      if (p.componentType !== "series" || typeof p.seriesIndex !== "number") return;
+      const key = live.seriesKeyByIndex[p.seriesIndex];
+      if (!key || key.startsWith("__")) return;
+      if (key !== live.hoveredKey) {
+        chart.dispatchAction({ type: "downplay", seriesIndex: p.seriesIndex });
+        if (live.hoveredKey) {
+          chart.dispatchAction({ type: "highlight", seriesId: live.hoveredKey });
+        }
+      }
+    });
+
+    chart.on("datazoom", () => {
+      const option = chart.getOption() as { dataZoom?: { start?: number; end?: number }[] };
+      const zoom = option.dataZoom?.[0];
+      if (!zoom) return;
+
+      // Ride the selection — pure zrender updates, so the drag stays 1:1.
+      live.brushRange = { start: zoom.start ?? 0, end: zoom.end ?? 100 };
+      syncBrushOverlayNow();
+
+      const { onBrushChange: onChange } = live.handlers;
+      if (!onChange) return;
+      const len = live.dataLength;
+      const startIndex = Math.round(((zoom.start ?? 0) / 100) * (len - 1));
+      const endIndex = Math.round(((zoom.end ?? 100) / 100) * (len - 1));
+      onChange({ startIndex, endIndex });
+    });
+
+    // Hover tracking for the overlay: labels show while the pointer is over the
+    // brush, and each pill brightens when the pointer is near its edge.
+    const zr = chart.getZr();
+    const applyHover = (next: { inside: boolean; left: boolean; right: boolean }) => {
+      const prev = live.brushHover;
+      if (prev.inside === next.inside && prev.left === next.left && prev.right === next.right) {
+        return;
+      }
+      live.brushHover = next;
+      syncBrushOverlayNow();
+    };
+    const onZrMove = (event: { offsetX?: number; offsetY?: number }) => {
+      const geom = live.brushGeom;
+      if (!geom) return;
+      const x = event.offsetX ?? -1;
+      const y = event.offsetY ?? -1;
+      const top = chart.getHeight() - geom.bottom - geom.height;
+      const inside = y >= top - 4 && y <= top + geom.height + 4;
+      const trackLeft = 8;
+      const trackWidth = Math.max(chart.getWidth() - 16, 1);
+      const { start, end } = live.brushRange;
+      const selectionLeft = trackLeft + (trackWidth * start) / 100;
+      const selectionRight = trackLeft + (trackWidth * end) / 100;
+      applyHover({
+        inside,
+        left: inside && Math.abs(x - selectionLeft) <= 8,
+        right: inside && Math.abs(x - selectionRight) <= 8,
+      });
+    };
+    const onZrOut = () => applyHover({ inside: false, left: false, right: false });
+    zr.on("mousemove", onZrMove);
+    zr.on("globalout", onZrOut);
+
+    return () => {
+      zrHover.off("mousemove", onZrHoverMove);
+      zrHover.off("globalout", onZrHoverOut);
+      zr.off("mousemove", onZrMove);
+      zr.off("globalout", onZrOut);
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      chart.dispose();
+      echartsRef.current = null;
+      // The overlay elements died with the zrender instance.
+      live.brushOverlay = null;
+      // The reveal guard belongs to the chart instance it guarded. Without this
+      // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
+      // the throwaway instance and the surviving one renders without it.
+      live.hasRevealed = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    const container = containerRef.current;
+    if (!chart || !container) return;
+
+    // Colors come from the <style> committed just before this effect ran — read
+    // them here, right before the push, rather than round-tripping through state.
+    live.resolved = resolveColors(container, config, seriesKeys);
+
+    const push = (withEntrance: boolean) => {
+      const option = buildOption();
+      const merged = chartOptions ? { ...option, ...chartOptions } : option;
+      Object.assign(merged, {
+        animation: withEntrance,
+        animationDuration: REVEAL_DURATION,
+        animationDurationUpdate: 0,
+      });
+      // chartOptions is an untyped escape hatch — the spread erases the option's
+      // shape, so re-assert it. The only cast in the file.
+      chart.setOption(merged as EChartsOption, { notMerge: true });
+      // Overlays live outside the option — reposition them after every push.
+      syncBrushOverlayNow();
+    };
+
+    // Intro reveal — ECharts' native progressive draw, enabled only for the first
+    // real render: the line traces in, dots pop up as its front passes. Every
+    // later push (selection, theme, zoom) applies instantly, since notMerge would
+    // otherwise replay the entrance on each of them. A loading cycle re-arms it:
+    // the Recharts twin unmounts its <Area>s while loading and replays the intro
+    // on remount, so data → loading → data draws in again here too.
+    if (isLoading) live.hasRevealed = false;
+    const shouldReveal = !live.hasRevealed && !isLoading;
+    if (shouldReveal) live.hasRevealed = true;
+    const revealEnabled =
+      animation && shouldReveal && effectiveAnimation !== "none" && !shouldReduceMotion;
+    if (revealEnabled) live.revealEndsAt = performance.now() + REVEAL_DURATION;
+    push(revealEnabled);
+
+    // Theme flips and resizes re-enter here without touching React: re-read the
+    // tokens (the .dark class changed, or textures need renderer-sized rebakes)
+    // and push an update-style option.
+    live.repush = () => {
+      live.resolved = resolveColors(container, config, seriesKeys);
+      push(false);
+    };
+  }, [
+    live,
+    buildOption,
+    chartOptions,
+    isLoading,
+    animation,
+    effectiveAnimation,
+    shouldReduceMotion,
+    config,
+    seriesKeys,
+    syncBrushOverlayNow,
+  ]);
+
+  // ── Animated dashed stroke — rAF sweeps the dash offset while unselected ─────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || isLoading) return;
+    const animatedKeys = areas
+      .filter((area) => area.strokeVariant === "animated-dashed" && !area.enableBufferLine)
+      .map((area) => area.dataKey);
+    if (animatedKeys.length === 0 || hasSelection) return;
+
+    let raf = 0;
+    let delayTimer: ReturnType<typeof setTimeout> | undefined;
+    const begin = () => {
+      const loopStart = performance.now();
+      const tick = (now: number) => {
+        const offset = -(((now - loopStart) / 1000) % 1) * 6; // 0 → -6 per second
+        chart.setOption(
+          { series: animatedKeys.map((id) => ({ id, lineStyle: { dashOffset: offset } })) },
+          { silent: true, lazyUpdate: true },
+        );
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    };
+
+    // Per-frame setOption churn fights the intro draw-in (each update pass
+    // recomputes the reveal clip, crawling it to a standstill) — hold the dash
+    // sweep until the entrance has finished.
+    const delay = Math.max(0, live.revealEndsAt - performance.now());
+    if (delay > 0) delayTimer = setTimeout(begin, delay + 50);
+    else begin();
+
+    return () => {
+      if (delayTimer !== undefined) clearTimeout(delayTimer);
+      cancelAnimationFrame(raf);
+    };
+  }, [live, areas, hasSelection, isLoading]);
+
+  // ── Loading shimmer — rAF sweeps a bright band, regenerating data off-screen ─
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || !isLoading) return;
+
+    let raf = 0;
+    let lastPhase = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const phase = ((((now - start) / LOADING_ANIMATION_DURATION) % 1) + 1) % 1;
+      // Wrapped past 1 → the band is off-screen; swap in fresh random data.
+      if (phase < lastPhase) live.loadingRows = getLoadingData(loadingPoints);
+      lastPhase = phase;
+
+      // Read tokens per frame, so a theme flip mid-loading retints the shimmer.
+      const foreground = live.resolved?.tokens.foreground ?? "rgba(120, 120, 120, 1)";
+      // Sweep the clip window from fully off-screen left to fully off-screen
+      // right, leaned 45°. The gradient uses ABSOLUTE pixel coordinates shared
+      // by stroke and fill — bbox-relative coords put the window at different
+      // positions for the line vs the area polygon (their bounding boxes
+      // differ), which made the line trail the fill near the sweep's end.
+      const w = chart.getWidth();
+      const h = chart.getHeight();
+      if (!w || !h) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      // Farthest plot corner projected onto the 45° axis — keeps the sweep
+      // tight instead of dawdling off-plot at the end of each loop.
+      const maxT = (w + h) / (2 * w);
+      const center = phase * (maxT + 2 * LOADING_SHIMMER_BAND) - LOADING_SHIMMER_BAND;
+      const clip = (peak: number) =>
+        new echarts.graphic.LinearGradient(
+          0,
+          0,
+          w,
+          w,
+          shimmerWindowStops(center, foreground, peak),
+          true,
+        );
+      chart.setOption(
+        {
+          series: [
+            {
+              id: "__loading",
+              data: loadingData(),
+              lineStyle: { color: clip(LOADING_STROKE_OPACITY), width: 1 },
+              areaStyle: { color: clip(LOADING_SHIMMER_MAX_OPACITY) },
+            },
+          ],
+        },
+        { silent: true, lazyUpdate: true },
+      );
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [live, isLoading, loadingPoints, loadingData]);
+
+  // ── Legend overlay position ──────────────────────────────────────────────────
+  // Insets match the Recharts legend's breathing room inside the plot frame.
+  const legendStyle: CSSProperties = {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    pointerEvents: "auto",
+    ...(legendSlot.verticalAlign === "top"
+      ? { top: 12 }
+      : legendSlot.verticalAlign === "bottom"
+        ? { bottom: showBrush ? brushHeight + 16 : 12 }
+        : { top: "50%", transform: "translateY(-50%)" }),
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      data-chart={chartId}
+      className={`relative flex flex-col text-xs ${className ?? ""}`}
+    >
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+
+      <div className="relative min-h-0 w-full flex-1">
+        <div ref={mountRef} className="h-full min-h-0 w-full" />
+      </div>
+
+      {legendSlot.present && !isLoading && (
+        <LegendOverlay
+          seriesKeys={seriesKeys}
+          config={config}
+          variant={legendSlot.variant}
+          align={legendSlot.align}
+          verticalAlign={legendSlot.verticalAlign}
+          selectedKey={selectedDataKey}
+          hoveredKey={hoveredDataKey}
+          isClickable={legendSlot.isClickable}
+          onToggle={toggleSelection}
+          style={legendStyle}
+        />
+      )}
+
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+          <motion.div
+            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+            className="flex items-center justify-center gap-2 rounded-md border bg-background px-2 py-0.5 text-sm text-primary"
+          >
+            <div className="h-3 w-3 animate-spin rounded-full border border-border border-t-primary" />
+            <span>Loading</span>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Compound API: every part hangs off the root as a static member, so a consumer
+// writes <EChartsAreaChart.Area/>, <EChartsAreaChart.Tooltip/>, … from a single
+// import — no colliding named marker exports when several charts share one file.
+EChartsAreaChart.Area = Area;
+EChartsAreaChart.Dot = Dot;
+EChartsAreaChart.ActiveDot = ActiveDot;
+EChartsAreaChart.XAxis = XAxis;
+EChartsAreaChart.YAxis = YAxis;
+EChartsAreaChart.Grid = Grid;
+EChartsAreaChart.Tooltip = Tooltip;
+EChartsAreaChart.Legend = Legend;
+EChartsAreaChart.Brush = Brush;

--- a/packages/charts/src/components/evilcharts/charts/echarts-bar-chart.tsx
+++ b/packages/charts/src/components/evilcharts/charts/echarts-bar-chart.tsx
@@ -1,0 +1,2258 @@
+"use client";
+
+import type { ComposeOption, ImagePatternObject } from "echarts/core";
+
+import {
+  Brush,
+  buildBrushDataZoom,
+  syncBrushOverlay,
+  type BrushGeometry,
+  type BrushOverlayElements,
+  type BrushProps,
+  type BrushRange,
+} from "@harmony/charts/components/evilcharts/ui/echarts-brush";
+import {
+  buildChartCss,
+  flattenColor,
+  getColorsCount,
+  resolveColors,
+  withAlpha,
+  type ChartConfig,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+import { sampleGradient } from "@harmony/charts/components/evilcharts/ui/echarts-dot";
+import {
+  LegendOverlay,
+  type LegendVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-legend";
+import {
+  formatTooltipValue,
+  tooltipBaseOption,
+  tooltipIndicatorHtml,
+  tooltipRow,
+  tooltipShell,
+  type TooltipPosition,
+  type TooltipRoundness,
+  type TooltipVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-tooltip";
+import { BarChart, type BarSeriesOption } from "echarts/charts";
+import {
+  DataZoomComponent,
+  GridComponent,
+  TooltipComponent,
+  type DataZoomComponentOption,
+  type GridComponentOption,
+  type TooltipComponentOption,
+} from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { motion, useReducedMotion } from "motion/react";
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FC,
+  type ReactNode,
+} from "react";
+
+// Re-export the shared types that were previously declared inline here, so
+// existing consumers/examples keep importing them from the chart module.
+export type { ChartConfig, LegendVariant, TooltipPosition, TooltipRoundness, TooltipVariant };
+
+// Modular registration keeps the bundle lean — only the pieces this chart needs.
+// `DataZoomComponent` bundles both the slider (brush footer) and inside (wheel/drag)
+// zoom. The brush's frame/handles/labels are raw zrender elements, not the
+// graphic component — see syncBrushOverlay. No LineChart: the main plot, the
+// loading skeleton, and the brush mini chart are ALL bar series.
+echarts.use([BarChart, GridComponent, TooltipComponent, DataZoomComponent, CanvasRenderer]);
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+// The exact option surface this chart uses — bar series, grid, tooltip, and
+// dataZoom, plus the axis options they pull in as dependencies. Narrower than
+// echarts' full EChartsOption, so a misspelled key fails the compile instead of
+// silently reaching setOption.
+type EChartsOption = ComposeOption<
+  BarSeriesOption | GridComponentOption | TooltipComponentOption | DataZoomComponentOption
+>;
+
+// Single-entry views of the composed option's array-or-single fields — the
+// modular entry points don't export the axis option types directly.
+type ArrayItem<T> = T extends readonly (infer U)[] ? U : T;
+type XAxisOption = ArrayItem<NonNullable<EChartsOption["xAxis"]>>;
+type YAxisOption = ArrayItem<NonNullable<EChartsOption["yAxis"]>>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_BAR_RADIUS = 0;
+const STROKE_WIDTH = 1; // buffer-bar outline width
+const LOADING_ANIMATION_DURATION = 2000; // shimmer loop, in milliseconds
+const BAR_GROW_DURATION = 500; // per-bar grow-in length, in milliseconds
+const BAR_STAGGER = 15; // delay between consecutive bars in the reveal, in milliseconds
+const LOADING_DEFAULT_BARS = 12;
+// `revealEndsAt` marks when the intro grow-in finishes. The stripped-cap post-layout
+// correction (a notMerge repush) waits for it so it never lands mid-entrance and
+// stomps the grow — the same reason the area chart tracks this timestamp.
+const SELECTION_DIM = 0.3; // opacity of an unselected series while a selection is active
+const HOVER_BLUR = 0.5; // opacity of the non-hovered bars while hover-highlight is on
+// Soft outer glow — the canvas analogue of the Recharts feGaussianBlur filter
+// (stdDeviation 8, alpha 0.5). A generous shadowBlur keeps the halo soft with no
+// hard rim; the shadowColor is sampled PER BAR so a multi-stop gradient series
+// glows in its own colors across the plot instead of one flat tint.
+const GLOW_BLUR = 18; // shadowBlur radius, in device-independent pixels
+const GLOW_OPACITY = 0.65; // per-datum shadowColor alpha, × the sampled series color
+
+// The `blocks` variant renders each bar as a stack of segments instead of a solid
+// column: a repeating tile paints a BLOCK_SIZE band then leaves a BLOCK_GAP of
+// transparency. The same tile, in a muted tone, fills the column's unused space
+// via ECharts' native `showBackground`, so the empty part of every bar reads as a
+// dim grid of the same blocks. Both tile from the renderer origin, so the bands
+// line up across every column.
+// The `expandable` variant draws every bar at full width but fills only a narrow
+// centre strip, so it reads as a thin line; hovering one grows its strip out to
+// the full width and back on leave. The bar geometry never changes — only the
+// horizontal extent of its fill — so nothing re-lays out mid-hover.
+const EXPAND_COLLAPSED = 0.12; // resting strip width, as a fraction of the bar
+const EXPAND_TAU = 70; // ease time-constant, in milliseconds (exponential approach)
+
+const BLOCK_SIZE = 2; // filled segment height, in pixels
+const BLOCK_GAP = 2; // transparent gap between segments, in pixels
+const BLOCK_TRACK_OPACITY = 0.22; // unfilled block tone, x the muted-foreground alpha
+// Stacked segments would otherwise butt straight into each other and read as one
+// solid column. The separation is a REAL gap — transparent spacer series stacked
+// between the real ones — not a background-colored border: a border paints on all
+// four sides, so it outlines each segment (obvious the moment a bar glows) instead
+// of only parting them.
+const STACK_SEGMENT_GAP = 2; // separation between stacked segments, in pixels
+const MAX_HIGHLIGHT_DIM = 0.16; // non-winning columns under enableMaxValueHighlight, x muted-foreground
+
+// The `stripped` variant caps each bar with a small BRIGHT pill of CONSTANT pixel
+// height (Recharts draws a fixed ~2px strip on top of a dimmed body, identical on
+// tall and short bars). The cap is expressed PER DATUM as a fraction of that bar's
+// own pixel height, so a fixed pixel height maps to a shrinking fraction as the bar
+// grows — the fraction is derived at runtime from the measured value-axis
+// pixels-per-unit (see measureValuePxPerUnit). A canvas gradient alone can't do
+// this: its bright band is a fraction of the bounding box, so it would scale with
+// bar length (the bug this replaced).
+const STRIPPED_CAP_HEIGHT = 4; // bright cap height, in device-independent pixels
+const STRIPPED_BODY_ALPHA = 0.2; // dimmed bar body below the cap, × series color
+const STRIPPED_CAP_MAX_FRACTION = 0.85; // cap never swallows a whole (very short) bar
+const STRIPPED_FALLBACK_FRACTION = 0.12; // used before the axis geometry is measured
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Theme knobs — every neutral line in the chart draws from these. Base colors
+// come from the consumer's CSS tokens (resolved from the live DOM), so only the
+// opacity factors live here. Factors MULTIPLY the token's own alpha — a border
+// token that is already 10%-white stays subtle. Tune here, not in the builder.
+// ─────────────────────────────────────────────────────────────────────────────
+// Recharts draws its grid at border/50, but SVG dashes render pixel-crisp while
+// canvas at 2× DPR spreads a 1px line across device pixels — roughly halving
+// perceived intensity. Using the border token's full alpha lands both engines at
+// the same apparent brightness.
+const GRID_LINE_OPACITY = 1; // dashed value-axis split lines, × border alpha
+// The skeleton is CLIPPED to a small sweeping window — only the bars inside it
+// exist, everything outside is fully transparent, like a spotlight sliding across.
+const LOADING_SHIMMER_MAX_OPACITY = 0.22; // gray bar fill inside the window, × foreground alpha
+const LOADING_SHIMMER_BAND = 0.2; // window half-width, fraction of the 45° sweep axis
+const LOADING_SHIMMER_FEATHER = 0.2; // eased edge softening of the clip window
+const BRUSH_FILL_OPACITY = 0.5; // mini-chart bar fill
+const BRUSH_FILLER_OPACITY = 0; // selected-range wash — evil-brush draws none
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BarVariant =
+  | "default"
+  | "hatched"
+  | "duotone"
+  | "duotone-reverse"
+  | "gradient"
+  | "stripped"
+  | "blocks"
+  | "expandable";
+export type StackType = "default" | "stacked" | "percent";
+export type BarLayout = "vertical" | "horizontal";
+export type BarAnimationType =
+  | "none"
+  | "left-to-right"
+  | "right-to-left"
+  | "center-out"
+  | "edges-in";
+// TooltipVariant, TooltipRoundness, LegendVariant, and ChartConfig now live in
+// the shared @/registry/ui/echarts/* modules and are imported + re-exported at
+// the top of this file.
+
+export interface EChartsBarChartProps<TData extends Record<string, unknown>> {
+  data: TData[]; // rows rendered by the chart
+  config: ChartConfig; // series colors + labels
+  xDataKey?: keyof TData & string; // category key — falls back to the axis dataKey / first free column
+  className?: string; // extra classes for the chart container
+  stackType?: StackType; // how multiple bars combine
+  layout?: BarLayout; // orientation of the bars
+  barRadius?: number; // default corner radius every <Bar> inherits
+  animation?: boolean; // master switch for the intro grow-in — false renders instantly
+  animationType?: BarAnimationType; // default grow-in order each <Bar> inherits
+  barGap?: number; // gap between bars within the same category, in pixels
+  barCategoryGap?: number; // gap between categories of bars, in pixels
+  defaultSelectedDataKey?: string | null; // series selected on first render
+  onSelectionChange?: (key: string | null) => void; // fires when the selected series changes
+  // Colors ONLY the tallest column and mutes the rest. With several series the
+  // comparison is per COLUMN — the totals across every series at that category —
+  // so a whole stack or group lights up together, not one bar inside it.
+  enableMaxValueHighlight?: boolean;
+  isLoading?: boolean; // shows the animated loading skeleton
+  loadingBars?: number; // number of bars in the loading skeleton
+  chartOptions?: Record<string, unknown>; // escape hatch merged over the built ECharts option
+  children?: ReactNode; // declarative config — <Bar>, <XAxis>, <YAxis>, <Grid>, <Tooltip>, <Legend>, <Brush>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Composible parts — DECLARATIVE CONFIG. Every part renders `null`; the root
+// walks `children` by reference (child.type === Bar, …) to collect its props.
+// Presence semantics mirror the Recharts twin: omit a child and that part does
+// not render. These are never mounted into the tree — they only carry props.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface BarProps {
+  dataKey: string; // series key — must exist on the data + config
+  variant?: BarVariant; // fill style for this bar only
+  radius?: number; // corner radius — falls back to the root barRadius
+  animationType?: BarAnimationType; // grow-in order — falls back to the root animationType
+  isClickable?: boolean; // lets this bar be selected by clicking it
+  enableHoverHighlight?: boolean; // dims the other bars while one is hovered
+  glowing?: boolean; // applies a soft outer glow to this bar
+  bufferBar?: boolean; // renders the last data point as a hatched "buffer" bar
+}
+
+/**
+ * A single bar series. Declares its own fill variant, radius, glow, buffer, and
+ * clickability. Renders nothing — the root reads these props to build the
+ * ECharts series.
+ */
+const Bar: FC<BarProps> = () => null;
+
+export interface XAxisProps {
+  dataKey?: string; // category key — overrides the root xDataKey (vertical layout)
+  // Category values are stringified, so the formatter always sees a string —
+  // letting examples share `(value) => value.substring(0, 3)` with the Recharts twin.
+  tickFormatter?: (value: string, index: number) => string; // formats x tick labels
+  label?: string; // axis title, centered below the x-position tick labels
+  hideDots?: boolean; // hides the tick dots beside this axis's labels
+}
+
+/**
+ * The x-axis. Category axis in the default (vertical) layout, value axis when
+ * `layout="horizontal"`. Presence shows its tick labels. Renders nothing.
+ */
+const XAxis: FC<XAxisProps> = () => null;
+
+export interface YAxisProps {
+  dataKey?: string; // category key — overrides the root xDataKey (horizontal layout)
+  tickFormatter?: (value: string, index: number) => string; // formats y tick labels
+  label?: string; // axis title, rotated alongside the y-position tick labels
+  hideDots?: boolean; // hides the tick dots beside this axis's labels
+}
+
+/**
+ * The y-axis. Value axis in the default (vertical) layout, category axis when
+ * `layout="horizontal"`. Presence shows its tick labels. Renders nothing.
+ */
+const YAxis: FC<YAxisProps> = () => null;
+
+/** Presence shows the dashed split lines on the value axis. Renders nothing. */
+const Grid: FC = () => null;
+
+export interface TooltipProps {
+  variant?: TooltipVariant; // visual style of the tooltip surface
+  roundness?: TooltipRoundness; // border-radius of the tooltip
+  defaultIndex?: number; // data index the tooltip shows by default, with no hover
+  position?: TooltipPosition; // "variable" follows the pointer (default); "fixed" pins the tooltip near the top and only tracks the pointer's X
+  suffix?: string; // unit appended after each row's value (e.g. "min")
+}
+
+/** Presence enables the hover tooltip. Renders nothing. */
+const Tooltip: FC<TooltipProps> = () => null;
+
+export interface LegendProps {
+  variant?: LegendVariant; // visual style of the legend indicators
+  align?: "left" | "center" | "right"; // horizontal placement
+  verticalAlign?: "top" | "middle" | "bottom"; // vertical placement
+  isClickable?: boolean; // lets each entry toggle selection of its series
+}
+
+/** Presence enables the HTML legend overlay. Renders nothing. */
+const Legend: FC<LegendProps> = () => null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Children collection — walk the declarative config into plain objects the
+// option builder consumes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type BarSeriesConfig = {
+  dataKey: string;
+  variant: BarVariant;
+  radius?: number;
+  animationType?: BarAnimationType;
+  isClickable: boolean;
+  enableHoverHighlight: boolean;
+  glowing: boolean;
+  bufferBar: boolean;
+};
+
+type AxisSlot = {
+  present: boolean;
+  dataKey?: string;
+  tickFormatter?: (value: string, index: number) => string;
+  label?: string;
+  hideDots: boolean;
+};
+type TooltipSlot = {
+  present: boolean;
+  variant: TooltipVariant;
+  roundness: TooltipRoundness;
+  defaultIndex?: number;
+  position: TooltipPosition;
+  suffix?: string;
+};
+type LegendSlot = {
+  present: boolean;
+  variant: LegendVariant;
+  align: "left" | "center" | "right";
+  verticalAlign: "top" | "middle" | "bottom";
+  isClickable: boolean;
+};
+type BrushSlot = {
+  present: boolean; // a <Brush> child was passed — replaces the old showBrush prop
+  height?: number;
+  formatLabel?: (value: string, index: number) => string;
+  onChange?: (range: { startIndex: number; endIndex: number }) => void;
+};
+
+type CollectedConfig = {
+  bars: BarSeriesConfig[];
+  xAxis: AxisSlot;
+  yAxis: AxisSlot;
+  showGrid: boolean;
+  tooltip: TooltipSlot;
+  legend: LegendSlot;
+  brush: BrushSlot;
+};
+
+function collectConfig(children: ReactNode): CollectedConfig {
+  const bars: BarSeriesConfig[] = [];
+  let xAxis: AxisSlot = { present: false, hideDots: false };
+  let yAxis: AxisSlot = { present: false, hideDots: false };
+  let showGrid = false;
+  let tooltip: TooltipSlot = {
+    present: false,
+    variant: "default",
+    roundness: "lg",
+    position: "variable",
+  };
+  let legend: LegendSlot = {
+    present: false,
+    variant: "rounded-square",
+    align: "right",
+    verticalAlign: "top",
+    isClickable: false,
+  };
+  let brush: BrushSlot = { present: false };
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const type = child.type;
+
+    if (type === Bar) {
+      const props = child.props as BarProps;
+      bars.push({
+        dataKey: props.dataKey,
+        variant: props.variant ?? "default",
+        radius: props.radius,
+        animationType: props.animationType,
+        isClickable: props.isClickable ?? false,
+        enableHoverHighlight: props.enableHoverHighlight ?? false,
+        glowing: props.glowing ?? false,
+        bufferBar: props.bufferBar ?? false,
+      });
+    } else if (type === XAxis) {
+      const props = child.props as XAxisProps;
+      xAxis = {
+        present: true,
+        dataKey: props.dataKey,
+        tickFormatter: props.tickFormatter,
+        label: props.label,
+        hideDots: props.hideDots ?? false,
+      };
+    } else if (type === YAxis) {
+      const props = child.props as YAxisProps;
+      yAxis = {
+        present: true,
+        dataKey: props.dataKey,
+        tickFormatter: props.tickFormatter,
+        label: props.label,
+        hideDots: props.hideDots ?? false,
+      };
+    } else if (type === Grid) {
+      showGrid = true;
+    } else if (type === Tooltip) {
+      const props = child.props as TooltipProps;
+      tooltip = {
+        present: true,
+        variant: props.variant ?? "default",
+        roundness: props.roundness ?? "lg",
+        defaultIndex: props.defaultIndex,
+        position: props.position ?? "variable",
+        suffix: props.suffix,
+      };
+    } else if (type === Legend) {
+      const props = child.props as LegendProps;
+      legend = {
+        present: true,
+        variant: props.variant ?? "rounded-square",
+        align: props.align ?? "right",
+        verticalAlign: props.verticalAlign ?? "top",
+        isClickable: props.isClickable ?? false,
+      };
+    } else if (type === Brush) {
+      const props = child.props as BrushProps;
+      brush = {
+        present: true,
+        height: props.height,
+        formatLabel: props.formatLabel,
+        onChange: props.onChange,
+      };
+    }
+  });
+
+  return { bars, xAxis, yAxis, showGrid, tooltip, legend, brush };
+}
+
+// Color plumbing (ChartConfig, getColorsCount, distributeColors, buildChartCss,
+// normalizeColor, withAlpha, ResolvedColors, resolveColors, flattenColor) plus
+// the theme keys now live in @/registry/ui/echarts-chart and are imported at the
+// top of this file.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fill paints — the ECharts analogue of the Recharts bar fill variants. Unlike
+// the area chart's fills (which run the color gradient HORIZONTALLY), a bar's
+// base color gradient runs VERTICALLY top→bottom (Recharts `ColorGradient` uses
+// x1=x2=0), so each bar shows the full multi-stop gradient in its own box.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GRAY = "rgba(120, 120, 120, 1)";
+
+// sampleGradient (the color the series gradient shows at t ∈ [0, 1]) now lives in
+// @/registry/ui/echarts-dot and is imported at the top of this file.
+
+// Solid vertical top→bottom color for a series — a plain string when there is
+// one color, else a vertical multi-stop LinearGradient in each bar's own box.
+// The `default` variant paints from this at full alpha.
+function solidVerticalPaint(
+  slots: string[],
+  alpha: number,
+): string | echarts.graphic.LinearGradient {
+  if (slots.length <= 1) {
+    const base = slots[0] ?? GRAY;
+    return alpha === 1 ? base : withAlpha(base, alpha);
+  }
+  const stops = slots.map((color, i) => ({
+    offset: i / (slots.length - 1),
+    color: withAlpha(color, alpha),
+  }));
+  return new echarts.graphic.LinearGradient(0, 0, 0, 1, stops);
+}
+
+// The `gradient` variant: the vertical color gradient faded from solid at the
+// top to clear at the bottom. Recharts masks with white@1 at 20% → white@0 at
+// 90%, so the alpha holds full through the top fifth and vanishes by 90%.
+function verticalFadePaint(slots: string[]): echarts.graphic.LinearGradient {
+  const offsets = [0, 0.2, 0.45, 0.7, 0.9, 1];
+  const alphaAt = (t: number) => (t <= 0.2 ? 1 : t >= 0.9 ? 0 : 1 - (t - 0.2) / 0.7);
+  const stops = offsets.map((t) => ({
+    offset: t,
+    color: withAlpha(sampleGradient(slots, t), alphaAt(t)),
+  }));
+  return new echarts.graphic.LinearGradient(0, 0, 0, 1, stops);
+}
+
+// The `duotone` family: a hard alpha split across the bar's short axis (its width
+// for vertical bars, its height for horizontal). Recharts splits at 50% via an
+// objectBoundingBox mask — exact for single-color series; multi-color duotone
+// falls back to the base color (an accepted approximation, matching the twin's
+// single-color examples).
+function duotoneSplitPaint(
+  base: string,
+  leftAlpha: number,
+  rightAlpha: number,
+  isHorizontal: boolean,
+): echarts.graphic.LinearGradient {
+  const stops = [
+    { offset: 0, color: withAlpha(base, leftAlpha) },
+    { offset: 0.5, color: withAlpha(base, leftAlpha) },
+    { offset: 0.5, color: withAlpha(base, rightAlpha) },
+    { offset: 1, color: withAlpha(base, rightAlpha) },
+  ];
+  // Split across the cross-axis: horizontal (0→1 in x) for vertical bars, and
+  // vertical (0→1 in y) for horizontal bars, so it always reads across the bar.
+  return isHorizontal
+    ? new echarts.graphic.LinearGradient(0, 0, 0, 1, stops)
+    : new echarts.graphic.LinearGradient(1, 0, 0, 0, stops);
+}
+
+// The `stripped` variant: a small BRIGHT cap sitting on top of a dimmed (20%) body
+// — the canvas twin of Recharts' fixed strip. The cap is baked into a per-datum
+// vertical gradient whose bright band spans exactly `capFraction` of the bar
+// (offset 0 = the tip). Because `capFraction` is passed in as
+// STRIPPED_CAP_HEIGHT / barPixelHeight (see strippedCapFraction), the cap reads the
+// SAME pixel height on every bar — the fraction shrinks as the bar grows. A hard
+// two-stop edge (coincident offsets at `capFraction`) keeps the cap a crisp pill
+// rather than a fade, and the bar's rounded top corners round the cap's top. The
+// cap sits at the tip: the top for vertical bars, the value end (right) for
+// horizontal.
+function strippedDatumPaint(
+  slots: string[],
+  isHorizontal: boolean,
+  capFraction: number,
+): echarts.graphic.LinearGradient {
+  const f = Math.min(Math.max(capFraction, 0), 1);
+  const cap = withAlpha(sampleGradient(slots, 0), 1);
+  const bodyTop = withAlpha(sampleGradient(slots, f), STRIPPED_BODY_ALPHA);
+  const bodyEnd = withAlpha(sampleGradient(slots, 1), STRIPPED_BODY_ALPHA);
+  const stops = [
+    { offset: 0, color: cap },
+    { offset: f, color: cap },
+    { offset: f, color: bodyTop },
+    { offset: 1, color: bodyEnd },
+  ];
+  // Tip at offset 0: top (y 0→1) for vertical bars, right (x 1→0) for horizontal.
+  return isHorizontal
+    ? new echarts.graphic.LinearGradient(1, 0, 0, 0, stops)
+    : new echarts.graphic.LinearGradient(0, 0, 0, 1, stops);
+}
+
+// The gradient fraction that renders a STRIPPED_CAP_HEIGHT-pixel cap on a bar whose
+// value-axis magnitude is `value`, given the measured pixels-per-unit. Falls back to
+// a small constant before the coordinate system has been measured (the very first
+// paint, corrected right after layout).
+function strippedCapFraction(value: number, valuePxPerUnit: number | null): number {
+  if (valuePxPerUnit == null) return STRIPPED_FALLBACK_FRACTION;
+  const barPx = Math.abs(value) * valuePxPerUnit;
+  if (!(barPx > 0)) return STRIPPED_FALLBACK_FRACTION;
+  return Math.min(STRIPPED_CAP_HEIGHT / barPx, STRIPPED_CAP_MAX_FRACTION);
+}
+
+// Pixels per one value-axis unit, read straight off the live coordinate system.
+// Returns null before the first layout (no coordinate system yet) — callers fall
+// back then. Turns the stripped cap's fixed pixel height into a per-bar gradient
+// fraction, so the cap stays constant as the value axis rescales on resize/zoom.
+function measureValuePxPerUnit(chart: EChartsInstance, isHorizontal: boolean): number | null {
+  const finder = isHorizontal ? { xAxisIndex: 0 } : { yAxisIndex: 0 };
+  // convertToPixel throws before the first setOption (no coordinate system yet) and
+  // whenever the value axis isn't laid out — treat any failure as "not measurable".
+  try {
+    const p0 = chart.convertToPixel(finder, 0);
+    const p1 = chart.convertToPixel(finder, 1);
+    if (typeof p0 !== "number" || typeof p1 !== "number") return null;
+    const delta = Math.abs(p1 - p0);
+    return Number.isFinite(delta) && delta > 0 ? delta : null;
+  } catch {
+    return null;
+  }
+}
+
+// Measures the rendered width of one bar, so the `blocks` variant can make its
+// segments square (their width IS the bar width, and only layout knows it). The
+// category pitch comes from the axis; the bar occupies that minus the category
+// gap — a px number when the consumer set one, else ECharts' own "20%" default.
+function measureBarWidthPx(
+  chart: EChartsInstance,
+  isHorizontal: boolean,
+  barCategoryGap: number | undefined,
+): number | null {
+  const finder = isHorizontal ? { yAxisIndex: 0 } : { xAxisIndex: 0 };
+  try {
+    const p0 = chart.convertToPixel(finder, 0);
+    const p1 = chart.convertToPixel(finder, 1);
+    if (typeof p0 !== "number" || typeof p1 !== "number") return null;
+    const pitch = Math.abs(p1 - p0);
+    if (!Number.isFinite(pitch) || pitch <= 0) return null;
+    const width = barCategoryGap != null ? pitch - barCategoryGap : pitch * 0.8;
+    return width > 1 ? width : null;
+  } catch {
+    return null;
+  }
+}
+
+// Tiling texture fills tinted with the series' first color. Stripes are drawn
+// STRAIGHT (trivially seamless) and the pattern itself is rotated — zrender
+// applies pattern transforms the same way ECharts decals do. Baking a diagonal
+// into a square tile clips the stroke at the corners, which reads as periodic
+// gaps once tiled. Tiles render at devicePixelRatio and scale back down so the
+// texture stays crisp on retina canvases.
+function patternFill(
+  kind: "hatched" | "buffer" | "blocks",
+  color: string,
+  blockSize = BLOCK_SIZE,
+): ImagePatternObject | null {
+  if (typeof document === "undefined") return null;
+  const dpr = Math.max(window.devicePixelRatio || 1, 1);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+
+  const size = (width: number, height: number) => {
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+  };
+  const pattern = (rotation = 0): ImagePatternObject => ({
+    image: canvas,
+    repeat: "repeat",
+    rotation,
+    scaleX: 1 / dpr,
+    scaleY: 1 / dpr,
+  });
+
+  if (kind === "blocks") {
+    // 1px-wide tile: it repeats horizontally into a full-width band, and
+    // vertically into the stack of blocks.
+    size(1, blockSize + BLOCK_GAP);
+    ctx.fillStyle = withAlpha(color, 1);
+    ctx.fillRect(0, 0, 1, blockSize);
+    return pattern();
+  }
+
+  if (kind === "hatched") {
+    // Recharts hatched: the color shown at 0.3 everywhere, punched to full along
+    // a 1.5px stripe every 5px, leaning -45°.
+    size(5, 5);
+    ctx.fillStyle = withAlpha(color, 0.3);
+    ctx.fillRect(0, 0, 5, 5);
+    ctx.fillStyle = withAlpha(color, 1);
+    ctx.fillRect(0, 0, 1.5, 5);
+    return pattern(-Math.PI / 4);
+  }
+
+  // buffer: bare diagonal lines on a transparent ground (no body fill), for the
+  // last "projected" bar.
+  size(5, 5);
+  ctx.fillStyle = withAlpha(color, 1);
+  ctx.fillRect(0, 0, 1, 5);
+  return pattern(-Math.PI / 4);
+}
+
+// The `expandable` fill at a given openness: a horizontal gradient with HARD
+// stops, transparent outside the centre strip and the series paint inside it.
+// Animating `fraction` slides those stops outward from the middle, which is the
+// expand; a real width change would relayout the bar group instead.
+function expandableDatumPaint(slots: string[], fraction: number): echarts.graphic.LinearGradient {
+  const base = slots[0] ?? GRAY;
+  const half = Math.max(0, Math.min(1, fraction)) / 2;
+  const left = 0.5 - half;
+  const right = 0.5 + half;
+  const clear = withAlpha(base, 0);
+  return new echarts.graphic.LinearGradient(0, 0, 1, 0, [
+    { offset: 0, color: clear },
+    { offset: left, color: clear },
+    { offset: left, color: base },
+    { offset: right, color: base },
+    { offset: right, color: clear },
+    { offset: 1, color: clear },
+  ]);
+}
+
+// Resolves a bar variant into an ECharts fill for its series. `base` is the
+// first color slot; `slots` the full vertical color run.
+function barFillPaint(
+  variant: BarVariant,
+  slots: string[],
+  isHorizontal: boolean,
+  blockSize = BLOCK_SIZE,
+): string | echarts.graphic.LinearGradient | ImagePatternObject {
+  const base = slots[0] ?? GRAY;
+  switch (variant) {
+    case "gradient":
+      return verticalFadePaint(slots);
+    case "duotone":
+      return duotoneSplitPaint(base, 0.4, 1, isHorizontal);
+    case "duotone-reverse":
+      return duotoneSplitPaint(base, 1, 0.4, isHorizontal);
+    case "hatched":
+      return patternFill("hatched", base) ?? solidVerticalPaint(slots, 1);
+    case "blocks":
+      return patternFill("blocks", base, blockSize) ?? solidVerticalPaint(slots, 1);
+    case "expandable":
+      // Series-level fallback only; buildBarSeries gives every datum its own
+      // openness so a single hovered bar can expand on its own.
+      return expandableDatumPaint(slots, EXPAND_COLLAPSED);
+    case "stripped":
+      // Series-level fallback only; buildBarSeries overrides every stripped datum
+      // with its own fixed-pixel cap fraction.
+      return strippedDatumPaint(slots, isHorizontal, STRIPPED_FALLBACK_FRACTION);
+    default:
+      return solidVerticalPaint(slots, 1);
+  }
+}
+
+// Border radius per variant/layout. Non-stripped bars round every corner
+// (Recharts passes a plain number); stripped rounds only the tip corners — the
+// top for vertical bars, the right end for horizontal.
+function barBorderRadius(
+  radius: number,
+  variant: BarVariant,
+  isHorizontal: boolean,
+): number | number[] {
+  // Blocks draw their own square segments; a radius would clip the end one. An
+  // expandable bar is a thin line at rest, where a radius would swallow it.
+  if (variant === "blocks" || variant === "expandable") return 0;
+  if (variant !== "stripped") return radius;
+  // ECharts corner order: [top-left, top-right, bottom-right, bottom-left].
+  return isHorizontal ? [0, radius, radius, 0] : [radius, radius, 0, 0];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Selection + entrance helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A bar dims to SELECTION_DIM only when a DIFFERENT series is selected.
+function selectionOpacity(selected: string | null, key: string): number {
+  return selected === null || selected === key ? 1 : SELECTION_DIM;
+}
+
+// How many stagger steps a bar at `index` waits before it grows in — the order
+// encoded by `animationType`. Bars are independent rectangles, so unlike the
+// area chart's single left-to-right clip, the direction values are honored here
+// via a per-datum `animationDelay`.
+function barStaggerDelay(type: BarAnimationType, index: number, count: number): number {
+  if (type === "none" || count <= 0) return 0;
+  const last = count - 1;
+  const center = last / 2;
+  let step: number;
+  switch (type) {
+    case "right-to-left":
+      step = last - index;
+      break;
+    case "center-out":
+      step = Math.abs(index - center);
+      break;
+    case "edges-in":
+      step = center - Math.abs(index - center);
+      break;
+    default: // left-to-right
+      step = index;
+  }
+  return step * BAR_STAGGER;
+}
+
+// The brush overlay primitives (BrushRange, BrushGeometry, BrushOverlayElements,
+// syncBrushOverlay) and the dataZoom builder (buildBrushDataZoom) now live in
+// @/registry/ui/echarts-brush and are imported at the top of this file. The
+// tooltip shell/row/styling (roundnessClass, tooltipVariantClass,
+// tooltipShell/tooltipRow/tooltipIndicatorHtml), the legend indicators
+// (LegendIndicator/LegendOverlay + fill/outline styles), and indicatorBackground
+// likewise live in the shared tooltip/legend/chart modules.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option builders — pure functions from a snapshot context to ECharts option
+// fragments. The component reads its refs ONCE per build into this context;
+// nothing below touches React state or the chart instance, so each fragment can
+// be reasoned about in isolation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OptionBuildContext = {
+  data: Record<string, unknown>[];
+  config: ChartConfig;
+  bars: BarSeriesConfig[];
+  seriesKeys: string[];
+  animationType: BarAnimationType;
+  barRadius: number;
+  isHorizontal: boolean;
+  isStacked: boolean;
+  isPercent: boolean;
+  selectedDataKey: string | null;
+  hasSelection: boolean;
+  showGrid: boolean;
+  // Category axis is x (vertical layout) or y (horizontal); value axis the other.
+  categorySlot: AxisSlot;
+  valueSlot: AxisSlot;
+  tooltipSlot: TooltipSlot;
+  legendSlot: LegendSlot;
+  isLoading: boolean;
+  loadingData: () => number[];
+  showBrush: boolean;
+  brushHeight: number;
+  barGap?: number;
+  barCategoryGap?: number;
+  resolved: ResolvedColors;
+  categories: string[];
+  brushRange: BrushRange; // zoom window carried through rebuilds
+  valuePxPerUnit: number | null; // measured value-axis pixels-per-unit (null pre-layout)
+  barWidthPx: number | null; // measured bar width — sizes the blocks variant's squares (null pre-layout)
+  // Openness per bar index for the expandable variant, plus which one the pointer
+  // is on — driven by the hover rAF, read at build.
+  expand: { key: string | null; hovered: number | null; progress: Map<number, number> };
+  maxHighlightIndex: number | null; // column to keep colored under enableMaxValueHighlight
+  chartWidth: number; // renderer px — gates edge-label alignMin/Max
+};
+
+// Grid insets plus the footer band reserved for the brush.
+//
+// ECharts 6 shrinks the plot when axis labels would overflow the canvas. That
+// pads (or, with clampWidth, slides) the chart for long <XAxis> labels. Opt out
+// with `outerBoundsMode: "none"` and reserve the label bands ourselves — same
+// approach as the brush mini-grid.
+function buildChartLayout({
+  legendSlot,
+  showBrush,
+  brushHeight,
+  isHorizontal,
+  categorySlot,
+  valueSlot,
+}: OptionBuildContext): {
+  grid: GridComponentOption;
+  brushBottom: number;
+} {
+  const legendTop = legendSlot.present && legendSlot.verticalAlign === "top";
+  const legendBottom = legendSlot.present && legendSlot.verticalAlign === "bottom";
+  // Clearance covers the axis labels plus the same breathing room the Recharts
+  // twin leaves between them and the brush. A bottom-axis TITLE renders below the
+  // labels (nameGap), so it needs its own band above the brush frame. The brush
+  // is vertical-layout only, where the bottom (x-position) axis is the category axis.
+  const bottomAxisLabel = isHorizontal ? valueSlot.label : categorySlot.label;
+  const brushGap = showBrush ? brushHeight + 30 + (bottomAxisLabel ? 22 : 0) : 0;
+  const bottomLabels = isHorizontal ? valueSlot.present : categorySlot.present;
+  const sideLabels = isHorizontal ? categorySlot.present : valueSlot.present;
+
+  return {
+    grid: {
+      left: sideLabels ? 36 : 0,
+      right: 0,
+      top: legendTop ? 42 : 0,
+      bottom: (bottomLabels ? 24 : 0) + brushGap + (legendBottom ? 34 : 0),
+      outerBoundsMode: "none",
+    },
+    brushBottom: legendBottom ? 34 : 6,
+  };
+}
+
+// The category + value axes, laid onto x/y per layout. Vertical bars → x is
+// category, y is value; horizontal bars → x is value, y is category.
+function buildMainAxes(ctx: OptionBuildContext): { xAxis: XAxisOption; yAxis: YAxisOption } {
+  const {
+    isHorizontal,
+    showGrid,
+    isLoading,
+    isPercent,
+    categories,
+    loadingData,
+    categorySlot,
+    valueSlot,
+    chartWidth,
+  } = ctx;
+  const { tokens } = ctx.resolved;
+
+  const axisLabelColor = tokens.mutedForeground;
+  const splitLineColor = withAlpha(tokens.border, GRID_LINE_OPACITY);
+  // Gridline gray as an opaque color — see flattenColor.
+  const tickDotColor = flattenColor(splitLineColor, tokens.background);
+  const catData = isLoading ? loadingData().map((_, i) => i) : categories;
+  const catFormatter = categorySlot.tickFormatter;
+  const valFormatter = valueSlot.tickFormatter;
+
+  // The axis title (name) follows the axis PART, not its category/value role: the
+  // category axis wears whichever <XAxis>/<YAxis> child renders it per layout, and
+  // its label sits at that child's physical position. nameGap is 30 for the bottom
+  // (x-position) axis and 38 for the side (y-position) one, so it swaps with the
+  // layout alongside the axisLabel styling.
+  const categoryNameGap = isHorizontal ? 38 : 30;
+  const valueNameGap = isHorizontal ? 30 : 38;
+
+  // With outerBoundsMode:"none", long first/last x labels can clip. Align them
+  // inward only when a centered label (~6px/char) wouldn't fit in the edge half-band.
+  const n = categories.length;
+  const halfBand = !isHorizontal && n > 0 && chartWidth > 0 ? chartWidth / n / 2 : 0;
+  const edgeLabel = (i: number) => {
+    const raw = categories[i] ?? "";
+    return catFormatter ? catFormatter(raw, i) : raw;
+  };
+
+  // NOTE: these are left un-annotated so their inferred literal type stays free
+  // of an axis-specific `position` — the layout swap below assigns the category
+  // axis to y (and the value axis to x) for horizontal bars, and XAxisOption vs
+  // YAxisOption disagree on `position`, so a fixed annotation would reject one
+  // branch. `type` is pinned with `as const` to satisfy the axis-kind union.
+  const categoryAxis = {
+    type: "category" as const,
+    // Bars sit BETWEEN ticks — the opposite of the area chart's boundaryGap:false.
+    boundaryGap: true,
+    show: true,
+    // The Recharts YAxis lists its first category at the TOP; ECharts' y category
+    // axis defaults to bottom-up, so flip it when the category axis is on y.
+    inverse: isHorizontal,
+    data: catData,
+    // Axis title — same size/color as the tick labels, pushed clear of them. The
+    // category axis carries the label of whichever <XAxis>/<YAxis> child renders it.
+    name: isLoading ? undefined : categorySlot.label,
+    nameLocation: "middle" as const,
+    nameGap: categoryNameGap,
+    nameTextStyle: { color: axisLabelColor, fontSize: 10 },
+    axisLine: { show: false },
+    // Tick DOTS: a near-zero-length tick whose round caps form a true circle, in
+    // the gridline gray (flattened opaque so the caps don't stack).
+    axisTick: {
+      show: !isLoading && categorySlot.present && !categorySlot.hideDots,
+      length: 0.5,
+      // Bars use boundaryGap, so ECharts would drop each tick on the BOUNDARY
+      // between two categories — a dot floating between labels rather than under
+      // one. Align them to the labels instead.
+      alignWithLabel: true,
+      lineStyle: { color: tickDotColor, width: 3, cap: "round" as const },
+    },
+    splitLine: { show: false },
+    axisLabel: {
+      show: !isLoading && categorySlot.present,
+      color: axisLabelColor,
+      fontSize: 10,
+      margin: 8,
+      ...(halfBand > 0 && edgeLabel(0).length * 6 > halfBand * 2
+        ? { alignMinLabel: "left" as const }
+        : {}),
+      ...(halfBand > 0 && edgeLabel(n - 1).length * 6 > halfBand * 2
+        ? { alignMaxLabel: "right" as const }
+        : {}),
+      formatter: catFormatter
+        ? (value: string, index: number) => catFormatter(value, index)
+        : undefined,
+    },
+  };
+
+  // An ECharts axis with `show: false` hides its splitLines too, but Recharts'
+  // <CartesianGrid> draws with or without a visible value axis. Keep the axis on
+  // whenever <Grid/> is present and gate the LABELS on the slot instead.
+  const valueAxis = {
+    type: "value" as const,
+    show: valueSlot.present || showGrid,
+    max: isPercent ? 1 : undefined,
+    // Axis title — same styling as the category axis; the value axis carries the
+    // label of the other of the two <XAxis>/<YAxis> children.
+    name: isLoading ? undefined : valueSlot.label,
+    nameLocation: "middle" as const,
+    nameGap: valueNameGap,
+    nameTextStyle: { color: axisLabelColor, fontSize: 10 },
+    axisLine: { show: false },
+    // Same tick dots as the category axis, beside each value label.
+    axisTick: {
+      show: valueSlot.present && !isLoading && !valueSlot.hideDots,
+      length: 0.5,
+      // Inert here — ECharts only honors it for CATEGORY ticks, and this axis is
+      // always type:"value". Carried so both axes' tick config stays identical.
+      lineStyle: { color: tickDotColor, width: 3, cap: "round" as const },
+    },
+    splitLine: {
+      // Hidden while loading — the skeleton floats on a clean canvas.
+      show: showGrid && !isLoading,
+      lineStyle: { color: splitLineColor, type: [3, 3] as [number, number], width: 1 },
+    },
+    axisLabel: {
+      // Hidden while loading — skeleton values are meaningless, and the Recharts
+      // axes unmount during loading too.
+      show: valueSlot.present && !isLoading,
+      color: axisLabelColor,
+      fontSize: 10,
+      margin: 8,
+      formatter: isPercent
+        ? (value: number) => `${Math.round(value * 100)}%`
+        : valFormatter
+          ? (value: number, index: number) => valFormatter(String(value), index)
+          : undefined,
+    },
+  };
+
+  return isHorizontal
+    ? { xAxis: valueAxis, yAxis: categoryAxis }
+    : { xAxis: categoryAxis, yAxis: valueAxis };
+}
+
+// Tooltip HTML builder, closed over the build context. Dims by the click
+// selection only — the Recharts twin passes `cursor={false}`, so there is no
+// axis-pointer line and hover-highlight never touches the tooltip.
+function createTooltipFormatter(ctx: OptionBuildContext) {
+  const { config, selectedDataKey, tooltipSlot } = ctx;
+
+  return (params: unknown): string => {
+    const rows = Array.isArray(params) ? params : [params];
+    if (!rows.length) return "";
+
+    const first = rows[0] as { axisValue?: string | number; name?: string };
+    // Label shows the RAW axis value — matches ChartTooltipContent (no tick formatter).
+    const axisValue = first.axisValue ?? first.name ?? "";
+    const label = String(axisValue);
+
+    const body = rows
+      .map((param) => {
+        const p = param as {
+          seriesId?: string;
+          seriesName?: string;
+          value?: number | string;
+        };
+        // Internal series (the brush's mini chart, the loading skeleton) never
+        // surface in the tooltip.
+        if (String(p.seriesId ?? "").startsWith("__")) return "";
+        const key = p.seriesId ?? p.seriesName ?? "";
+        const item = config[key];
+        const colorsCount = item ? getColorsCount(item) : 1;
+        const labelText = typeof item?.label === "string" ? item.label : (p.seriesName ?? key);
+        const dimmed = selectedDataKey != null && selectedDataKey !== key ? " opacity-30" : "";
+        return tooltipRow({
+          indicatorHtml: tooltipIndicatorHtml(key, colorsCount),
+          labelText,
+          valueText: formatTooltipValue(p.value),
+          suffix: tooltipSlot.suffix,
+          dimmed,
+        });
+      })
+      .join("");
+
+    return tooltipShell({
+      label,
+      body,
+      roundness: tooltipSlot.roundness,
+      variant: tooltipSlot.variant,
+    });
+  };
+}
+
+function buildTooltipOption(ctx: OptionBuildContext): TooltipComponentOption {
+  const { tooltipSlot, isLoading } = ctx;
+  const { tokens } = ctx.resolved;
+
+  return {
+    ...tooltipBaseOption({
+      present: tooltipSlot.present && !isLoading,
+      // The twin disables the cursor (`cursor={false}`) — no shadow, no line —
+      // so the axisPointer color/width below go unused; only `position` applies.
+      cursor: false,
+      tokens,
+      position: tooltipSlot.position,
+      axisPointerColor: tokens.border,
+      strokeWidth: STROKE_WIDTH,
+    }),
+    formatter: createTooltipFormatter(ctx),
+  };
+}
+
+// ── Brush — the evil-brush "bar" look, canvas-style: a real mini chart of the
+// full data in a second grid, with a transparent slider dataZoom laid over it.
+// Both zoom entries target only the MAIN x-axis, so the mini chart never filters
+// itself. Only called for the vertical layout, where the category axis is x.
+function buildBrushOption(
+  ctx: OptionBuildContext,
+  brushBottom: number,
+): {
+  miniGrid: GridComponentOption;
+  miniXAxis: XAxisOption;
+  miniYAxis: YAxisOption;
+  miniSeries: BarSeriesOption[];
+  dataZoom: DataZoomComponentOption[];
+} {
+  const { data, bars, isStacked, selectedDataKey, hasSelection, brushHeight, categories } = ctx;
+  const { tokens } = ctx.resolved;
+
+  const miniGrid: GridComponentOption = {
+    left: 8,
+    right: 8,
+    bottom: brushBottom,
+    height: brushHeight,
+    // No visible axes here — opt out of label containment so the mini chart
+    // spans the full brush frame.
+    outerBoundsMode: "none",
+  };
+
+  const miniXAxis: XAxisOption = {
+    type: "category",
+    gridIndex: 1,
+    boundaryGap: true,
+    show: false,
+    data: categories,
+    axisPointer: { show: false },
+  };
+
+  const miniYAxis: YAxisOption = { type: "value", gridIndex: 1, show: false };
+
+  const miniSeries: BarSeriesOption[] = bars.map((bar) => {
+    const key = bar.dataKey;
+    const base = (ctx.resolved.series[key] ?? [])[0] ?? GRAY;
+    // The mini chart mirrors the click selection: unselected series recede.
+    const dim = hasSelection && selectedDataKey !== key ? SELECTION_DIM : 1;
+
+    return {
+      id: `__mini-${key}`,
+      type: "bar",
+      xAxisIndex: 1,
+      yAxisIndex: 1,
+      data: data.map((row) => Number(row[key]) || 0),
+      stack: isStacked ? "__mini-total" : undefined,
+      silent: true,
+      barCategoryGap: "20%",
+      emphasis: { disabled: true },
+      tooltip: { show: false },
+      itemStyle: { color: base, opacity: BRUSH_FILL_OPACITY * dim, borderRadius: 1 },
+      z: 0,
+      animation: false,
+    };
+  });
+
+  const dataZoom = buildBrushDataZoom({
+    brushBottom,
+    brushHeight,
+    brushRange: ctx.brushRange,
+    fillerColor: withAlpha(tokens.foreground, BRUSH_FILLER_OPACITY),
+  });
+
+  return { miniGrid, miniXAxis, miniYAxis, miniSeries, dataZoom };
+}
+
+// Loading skeleton — ONE gray row of bars regardless of declared series (Recharts
+// parity: its skeleton is a single LoadingBar), swept by the shimmer rAF.
+function buildLoadingOption(
+  ctx: OptionBuildContext,
+  frame: { grid: GridComponentOption; xAxis: XAxisOption; yAxis: YAxisOption },
+): EChartsOption {
+  const { tokens } = ctx.resolved;
+
+  return {
+    animation: false,
+    grid: frame.grid,
+    xAxis: frame.xAxis,
+    yAxis: frame.yAxis,
+    tooltip: { show: false },
+    series: [
+      {
+        id: "__loading",
+        type: "bar",
+        data: ctx.loadingData(),
+        barCategoryGap: "30%",
+        silent: true,
+        // Invisible until the first shimmer tick positions the clip window.
+        itemStyle: {
+          color: withAlpha(tokens.foreground, 0),
+          borderRadius: barBorderRadius(DEFAULT_BAR_RADIUS, "default", ctx.isHorizontal),
+        },
+        z: 1,
+      },
+    ],
+  };
+}
+
+function buildBarSeries(ctx: OptionBuildContext): BarSeriesOption[] {
+  const {
+    data,
+    config,
+    bars,
+    seriesKeys,
+    animationType,
+    isHorizontal,
+    isStacked,
+    isPercent,
+    selectedDataKey,
+    hasSelection,
+    barGap,
+    barCategoryGap,
+    resolved,
+  } = ctx;
+
+  const lastIndex = data.length - 1;
+
+  // Optional per-row normalization for the percent (100%) stack.
+  const rowTotals = isPercent
+    ? data.map((row) => seriesKeys.reduce((sum, key) => sum + (Number(row[key]) || 0), 0))
+    : [];
+
+  const series: BarSeriesOption[] = bars.map((bar) => {
+    const key = bar.dataKey;
+    const slots = resolved.series[key] ?? [GRAY];
+    const base = slots[0] ?? GRAY;
+    const isSelected = selectedDataKey === key;
+    const dim = selectionOpacity(selectedDataKey, key);
+    const resolvedRadius = bar.radius ?? ctx.barRadius;
+    const borderRadius = barBorderRadius(resolvedRadius, bar.variant, isHorizontal);
+    // Square segments: the tile's height matches the measured bar width, so each
+    // block is 1:1. Falls back to BLOCK_SIZE on the first push, before layout.
+    const blockSize = ctx.barWidthPx ?? BLOCK_SIZE;
+    const fill = barFillPaint(bar.variant, slots, isHorizontal, blockSize);
+    const barAnim = bar.animationType ?? animationType;
+    const isStripped = bar.variant === "stripped";
+    const isExpandable = bar.variant === "expandable";
+    // Under enableMaxValueHighlight every column except the tallest is muted, so a
+    // single flat tone replaces whatever fill the variant would have painted.
+    const mutedFill = withAlpha(resolved.tokens.mutedForeground, MAX_HIGHLIGHT_DIM);
+    const isMuted = (i: number) => ctx.maxHighlightIndex != null && i !== ctx.maxHighlightIndex;
+
+    // Openness per datum, driven by the hover rAF. Bars not in the map are shut.
+    const expandOf = (i: number) =>
+      ctx.expand.key === key ? (ctx.expand.progress.get(i) ?? EXPAND_COLLAPSED) : EXPAND_COLLAPSED;
+    const expandHovered = ctx.expand.key === key ? ctx.expand.hovered : null;
+    // The unfilled part of a blocks bar: the same tile in a muted tone, drawn by
+    // ECharts' own bar background so it spans the column's full height.
+    const isBlocks = bar.variant === "blocks";
+    const blockTrack = isBlocks
+      ? patternFill(
+          "blocks",
+          withAlpha(resolved.tokens.mutedForeground, BLOCK_TRACK_OPACITY),
+          blockSize,
+        )
+      : null;
+
+    const values = data.map((row, i) => {
+      const value = Number(row[key]) || 0;
+      if (!isPercent) return value;
+      const total = rowTotals[i];
+      return total ? value / total : 0;
+    });
+
+    // Buffer bar: the last datum becomes a bare hatched rectangle with a
+    // series-colored outline, marking projected/incomplete data.
+    const bufferStyle = bar.bufferBar
+      ? {
+          color: patternFill("buffer", base) ?? "transparent",
+          borderColor: base,
+          borderWidth: STROKE_WIDTH,
+          borderRadius,
+        }
+      : null;
+
+    // Per-bar glow shadow — the shadowColor is sampled from the series gradient
+    // at each bar's horizontal position, so a multi-stop series glows in its own
+    // colors across the plot instead of one flat tint (a single shadowColor was
+    // the bug). A canvas shape carries only one shadow, so the sample is per bar,
+    // not within a bar; the wide, soft shadowBlur reads as the Recharts blur's
+    // colored halo with no hard rim.
+    // `glowing` haloes every bar in the series; enableMaxValueHighlight haloes only
+    // the winning column — the muted ones must stay flat or the "one bar stands
+    // out" reading collapses. Same shadow either way, so the two share a builder.
+    const glowAt = (i: number) => ({
+      shadowBlur: GLOW_BLUR,
+      shadowColor: withAlpha(
+        sampleGradient(slots, values.length > 1 ? i / (values.length - 1) : 0),
+        GLOW_OPACITY,
+      ),
+    });
+    const glowFor = bar.glowing
+      ? glowAt
+      : ctx.maxHighlightIndex != null
+        ? (i: number) => (i === ctx.maxHighlightIndex ? glowAt(i) : {})
+        : null;
+
+    // Only wrap a datum in an object when it needs per-point overrides (stripped
+    // cap, buffer tip, or glow); otherwise keep the bare number so the series
+    // itemStyle applies untouched. Stripped and glow touch every datum; buffer only
+    // the last one.
+    const dataPoints =
+      isStripped ||
+      isExpandable ||
+      glowFor ||
+      ctx.maxHighlightIndex != null ||
+      (bufferStyle && lastIndex >= 0)
+        ? values.map((value, i) => {
+            const isBuffer = !!bufferStyle && i === lastIndex;
+            if (!isBuffer && !glowFor && !isStripped && !isExpandable && !isMuted(i)) return value;
+            return {
+              value,
+              ...(isExpandable ? { label: { show: i === expandHovered } } : {}),
+              itemStyle: {
+                // The stripped cap is per datum: its fixed pixel height becomes a
+                // fraction of THIS bar's own height, so the cap is a constant pixel
+                // height across bars. The buffer tip (bare hatched) still wins on
+                // the last datum.
+                ...(isStripped && !isBuffer
+                  ? {
+                      color: strippedDatumPaint(
+                        slots,
+                        isHorizontal,
+                        strippedCapFraction(value, ctx.valuePxPerUnit),
+                      ),
+                    }
+                  : {}),
+                ...(isExpandable && !isBuffer
+                  ? { color: expandableDatumPaint(slots, expandOf(i)) }
+                  : {}),
+                ...(isBuffer && bufferStyle ? bufferStyle : {}),
+                ...(glowFor ? glowFor(i) : {}),
+                // Last so it overrides the variant's own paint.
+                ...(isMuted(i) ? { color: mutedFill } : {}),
+              },
+            };
+          })
+        : values;
+
+    return {
+      id: key,
+      name: typeof config[key]?.label === "string" ? config[key]?.label : key,
+      type: "bar",
+      data: dataPoints,
+      stack: isStacked ? "total" : undefined,
+      barGap,
+      barCategoryGap,
+      cursor: bar.isClickable ? "pointer" : "default",
+      // Selected series ride on top; when a selection is active the rest sink below.
+      z: isSelected ? 3 : hasSelection ? 1 : 2,
+      // The hovered bar names its value above itself (Recharts twin parity).
+      label: isExpandable
+        ? {
+            show: false,
+            position: "top",
+            color: resolved.tokens.foreground,
+            fontFamily: "var(--font-mono, monospace)",
+            fontSize: 11,
+          }
+        : undefined,
+      showBackground: isBlocks,
+      backgroundStyle: blockTrack ? { color: blockTrack, borderRadius } : undefined,
+      itemStyle: {
+        color: fill,
+        borderRadius,
+        opacity: dim,
+        // The glow lives on each datum's itemStyle (per-bar sampled shadowColor),
+        // not here — a single series-level shadowColor can't follow a gradient.
+      },
+      // Hover-highlight uses ECharts-native focus/blur: `self` keeps only the
+      // hovered bar lit and dims every other, matching the twin's per-bar dim.
+      // A click-selection OWNS the dim while it is active, so hover highlighting
+      // switches off entirely whenever a selection exists (this option rebuilds on
+      // every selection change, and the notMerge push clears any live blur) and
+      // resumes once the selection clears. Otherwise emphasis is disabled so
+      // hovering leaves the bar untouched.
+      emphasis:
+        bar.enableHoverHighlight && !hasSelection
+          ? { focus: "self" as const, blurScope: "coordinateSystem" as const }
+          : { disabled: true },
+      blur:
+        bar.enableHoverHighlight && !hasSelection
+          ? { itemStyle: { opacity: HOVER_BLUR } }
+          : undefined,
+      // The grow-in envelope. Only takes effect on the reveal push (top-level
+      // `animation: true`); every later push sends `animation: false`, so the
+      // per-datum stagger is dormant then.
+      animationDuration: BAR_GROW_DURATION,
+      animationEasing: "cubicOut",
+      animationDelay: (idx: number) => barStaggerDelay(barAnim, idx, data.length),
+    };
+  });
+
+  // Stacked segments butt together into one solid column, so part them with a REAL
+  // gap: a transparent series stacked between each adjacent pair. A background
+  // -colored border can't do this — a border paints all four sides, outlining every
+  // segment (glaring the moment a bar glows) instead of only separating them.
+  //
+  // The spacer's value is in DATA units, so it is derived from the measured
+  // pixels-per-unit to keep the gap a constant pixel height whatever the scale.
+  // Before the first layout that measurement is null and the gap is simply skipped;
+  // the push re-applies once it exists, in the same frame (see the sync effect).
+  const gapUnits =
+    (isStacked || isPercent) && series.length > 1 && ctx.valuePxPerUnit
+      ? STACK_SEGMENT_GAP / ctx.valuePxPerUnit
+      : 0;
+  if (!gapUnits) return series;
+
+  const spaced: BarSeriesOption[] = [];
+  series.forEach((entry, i) => {
+    spaced.push(entry);
+    if (i === series.length - 1) return;
+    spaced.push({
+      id: `__stackgap-${i}`,
+      type: "bar",
+      stack: isStacked ? "total" : undefined,
+      data: data.map(() => gapUnits),
+      itemStyle: { color: "transparent" },
+      silent: true,
+      tooltip: { show: false },
+      legendHoverLink: false,
+      emphasis: { disabled: true },
+      animation: false,
+      z: 1,
+    });
+  });
+  return spaced;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live imperative state — everything the ECharts event handlers, rAF loops, and
+// theme/resize repushes read or write OUTSIDE the React render cycle, grouped in
+// one ref-stable object. None of it is render output, which is exactly why it is
+// not React state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LiveState = {
+  resolved: ResolvedColors | null; // colors read off the live DOM — feeds builds and rAF loops
+  hasRevealed: boolean; // the intro grow-in already played on this chart instance
+  revealEndsAt: number; // performance.now() the entrance settles — gates the stripped-cap correction
+  valuePxPerUnit: number | null; // measured value-axis pixels-per-unit — sizes the stripped cap
+  barWidthPx: number | null; // measured bar width — sizes the blocks variant's squares
+  // Openness per bar index for the expandable variant, plus which one the pointer
+  // is on. Per-index so a bar being left keeps easing shut while the next one
+  // opens — a single shared value made the outgoing bar snap.
+  expand: { key: string | null; hovered: number | null; progress: Map<number, number> };
+  expandRaf: number; // in-flight expand animation frame
+  animateExpand: (key: string | null, index: number | null) => void;
+  loadingRows: number[] | null; // skeleton data, lazily rolled and re-rolled per shimmer sweep
+  categories: string[]; // x labels of the last build, for the brush label pills
+  dataLength: number; // row count, for the datazoom index math
+  brushRange: BrushRange; // live zoom window — carried through every rebuild
+  brushGeom: BrushGeometry | null; // brush footer layout of the last build
+  brushOverlay: BrushOverlayElements | null; // zrender elements, owned by syncBrushOverlay
+  brushHover: { inside: boolean; left: boolean; right: boolean };
+  // Latest callbacks/flags for the imperative ECharts event handlers.
+  handlers: {
+    onBrushChange?: (range: { startIndex: number; endIndex: number }) => void;
+    clickableKeys: Set<string>;
+    brushFormatLabel?: (value: string, index: number) => string;
+    seriesKeys: string[];
+    hasStripped: boolean; // any visible stripped bar → run the post-layout cap correction
+    hasBlocks: boolean; // any blocks bar → re-push once the bar width is measurable
+    hasStackGap: boolean; // stacked with >1 series → the segment gap needs the axis scale
+    expandableKey: string | null; // the expandable series, if any — drives the column hover
+    barCategoryGap?: number; // consumer's category gap, needed to derive the bar width
+    isHorizontal: boolean; // layout, for measuring the value axis in the finished handler
+  };
+  // Update-style re-push for paths that bypass React entirely (theme flips,
+  // resizes) — set by the sync effect.
+  repush: () => void;
+  // Rebuilds ONLY the stripped bar series (fresh per-datum cap fractions) and
+  // merges them with a silent lazyUpdate — never notMerge, so it leaves the
+  // dataZoom drag anchor and the running entrance untouched. Set by the sync effect.
+  patchStrippedCaps: () => void;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Apache ECharts port of the EvilCharts bar chart, exposing a compound-as-config
+ * API so its JSX reads identically to the Recharts twin. The root owns the data,
+ * config, selection state, loading skeleton, intro grow-in, and optional zoom
+ * brush; every visual part — `<Bar>`, `<XAxis>`, `<YAxis>`, `<Grid>`,
+ * `<Tooltip>`, `<Legend>` — is composed as a declarative child that renders
+ * nothing. The root walks those children by reference and drives a single
+ * imperative ECharts instance. Fully self-contained: its only dependencies are
+ * `react`, `echarts`, and `motion`.
+ */
+export function EChartsBarChart<TData extends Record<string, unknown>>({
+  data,
+  config,
+  xDataKey,
+  className,
+  stackType = "default",
+  layout = "vertical",
+  barRadius = DEFAULT_BAR_RADIUS,
+  animation = true,
+  animationType = "left-to-right",
+  barGap,
+  barCategoryGap,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+  enableMaxValueHighlight = false,
+  isLoading = false,
+  loadingBars = LOADING_DEFAULT_BARS,
+  chartOptions,
+  children,
+}: EChartsBarChartProps<TData>) {
+  const rawId = useId();
+  const chartId = `chart-${rawId.replace(/:/g, "")}`;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<HTMLDivElement>(null);
+  const echartsRef = useRef<EChartsInstance | null>(null);
+
+  // The single imperative surface (see LiveState). `resolved` lives here rather
+  // than in state: as state it forced an extra render pass and an effect whose
+  // only job was to trigger the option push. The object identity is stable for
+  // the component's lifetime.
+  const live = useRef<LiveState>({
+    resolved: null,
+    hasRevealed: false,
+    revealEndsAt: 0,
+    valuePxPerUnit: null,
+    barWidthPx: null,
+    expand: { key: null, hovered: null, progress: new Map<number, number>() },
+    expandRaf: 0,
+    animateExpand: () => {},
+    loadingRows: null,
+    categories: [],
+    dataLength: 0,
+    brushRange: { start: 0, end: 100 },
+    brushGeom: null,
+    brushOverlay: null,
+    brushHover: { inside: false, left: false, right: false },
+    handlers: {
+      onBrushChange: undefined, // set per-render from the <Brush> child's onChange
+      clickableKeys: new Set<string>(),
+      brushFormatLabel: undefined, // set per-render from the <Brush> child's formatLabel
+      seriesKeys: [],
+      hasStripped: false,
+      hasBlocks: false,
+      hasStackGap: false,
+      expandableKey: null,
+      isHorizontal: false,
+    },
+    repush: () => {},
+    patchStrippedCaps: () => {},
+  }).current;
+
+  // Skeleton rows roll lazily on first use — an impure useRef initializer would
+  // re-roll Math.random() on every render.
+  const loadingData = useCallback(
+    () => (live.loadingRows ??= getLoadingBarData(loadingBars)),
+    [live, loadingBars],
+  );
+  const shouldReduceMotion = useReducedMotion();
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(defaultSelectedDataKey);
+
+  // ── Declarative config, collected from children by reference ─────────────────
+  const collected = useMemo(() => collectConfig(children), [children]);
+  const {
+    bars,
+    xAxis: xAxisSlot,
+    yAxis: yAxisSlot,
+    showGrid,
+    tooltip: tooltipSlot,
+    legend: legendSlot,
+    brush: brushSlot,
+  } = collected;
+  // Brush is a <Brush> child now (not props): presence turns it on, its props
+  // carry height/formatLabel/onChange.
+  const showBrush = brushSlot.present;
+  const brushHeight = brushSlot.height ?? 56;
+
+  const isHorizontal = layout === "horizontal";
+  const isPercent = stackType === "percent";
+  const isStacked = stackType === "stacked" || isPercent;
+
+  // Category axis is x when vertical, y when horizontal; value axis the other.
+  const categorySlot = isHorizontal ? yAxisSlot : xAxisSlot;
+  const valueSlot = isHorizontal ? xAxisSlot : yAxisSlot;
+
+  const seriesKeys = useMemo(() => bars.map((bar) => bar.dataKey), [bars]);
+
+  // category key: category axis dataKey → root xDataKey → first data column no <Bar> claims.
+  const categoryKey = useMemo(() => {
+    if (categorySlot.dataKey) return categorySlot.dataKey;
+    if (xDataKey) return xDataKey as string;
+    const firstRow = data[0];
+    if (firstRow) {
+      const claimed = new Set(seriesKeys);
+      const found = Object.keys(firstRow).find((key) => !claimed.has(key));
+      if (found) return found;
+    }
+    return "";
+  }, [categorySlot.dataKey, xDataKey, data, seriesKeys]);
+
+  // The intro grow-in follows the first bar's setting, falling back to the root default.
+  const effectiveAnimation = bars[0]?.animationType ?? animationType;
+
+  // The tallest COLUMN, comparing totals across every series so a stack or group
+  // wins together rather than one bar inside it. Null when the flag is off.
+  const maxHighlightIndex = useMemo(() => {
+    if (!enableMaxValueHighlight || !data.length || !seriesKeys.length) return null;
+    let best = 0;
+    let bestTotal = -Infinity;
+    data.forEach((row, i) => {
+      const total = seriesKeys.reduce((sum, key) => sum + (Number(row[key]) || 0), 0);
+      if (total > bestTotal) {
+        bestTotal = total;
+        best = i;
+      }
+    });
+    return best;
+  }, [enableMaxValueHighlight, data, seriesKeys]);
+
+  const css = useMemo(() => buildChartCss(chartId, config), [chartId, config]);
+
+  const hasSelection = selectedDataKey !== null;
+
+  // Which series may be clicked to toggle selection (consulted by the click handler).
+  const clickableKeys = useMemo(
+    () => new Set(bars.filter((bar) => bar.isClickable).map((bar) => bar.dataKey)),
+    [bars],
+  );
+
+  // Any visible stripped bar? (never while loading — the skeleton has no stripped
+  // series.) Gates the post-layout cap correction in the `finished` handler.
+  const hasStrippedBars = !isLoading && bars.some((bar) => bar.variant === "stripped");
+
+  // Refresh the handlers' snapshot of the latest callbacks/flags every render.
+  live.handlers = {
+    onBrushChange: brushSlot.onChange,
+    clickableKeys,
+    brushFormatLabel: brushSlot.formatLabel,
+    seriesKeys,
+    hasStripped: hasStrippedBars,
+    hasBlocks: bars.some((bar) => bar.variant === "blocks"),
+    hasStackGap: (stackType === "stacked" || stackType === "percent") && bars.length > 1,
+    expandableKey: bars.find((bar) => bar.variant === "expandable")?.dataKey ?? null,
+    barCategoryGap,
+    isHorizontal,
+  };
+  live.dataLength = data.length;
+
+  const toggleSelection = useCallback(
+    (key: string) => {
+      setSelectedDataKey((prev) => {
+        const next = prev === key ? null : key;
+        onSelectionChange?.(next);
+        return next;
+      });
+    },
+    [onSelectionChange],
+  );
+
+  // The brush is meaningful only when the category axis is on x (vertical layout).
+  const brushEnabled = showBrush && !isHorizontal;
+
+  // Reposition the brush overlays from the live refs — safe to call from drag
+  // events, hover tracking, and pushes alike, since it never touches setOption.
+  const syncBrushOverlayNow = useCallback(() => {
+    const chart = echartsRef.current;
+    if (!chart) return;
+
+    const geom = live.brushGeom;
+    const tokens = live.resolved?.tokens;
+    if (!geom || !tokens) {
+      syncBrushOverlay(chart, live, null);
+      return;
+    }
+
+    const range = live.brushRange;
+    const categories = live.categories;
+    const format = live.handlers.brushFormatLabel;
+    const lastIndex = Math.max(categories.length - 1, 0);
+    const startIndex = Math.round((range.start / 100) * lastIndex);
+    const endIndex = Math.round((range.end / 100) * lastIndex);
+    const labels =
+      format && categories.length
+        ? {
+            start: format(categories[startIndex] ?? "", startIndex),
+            end: format(categories[endIndex] ?? "", endIndex),
+          }
+        : null;
+
+    syncBrushOverlay(chart, live, {
+      range,
+      geom,
+      size: { width: chart.getWidth(), height: chart.getHeight() },
+      tokens,
+      labels,
+      showLabels: live.brushHover.inside,
+      hover: live.brushHover,
+    });
+  }, [live]);
+
+  // ── Option builder ─────────────────────────────────────────────────────────
+  const buildOption = useCallback((): EChartsOption => {
+    const resolved = live.resolved;
+    if (!resolved) return {};
+
+    const categories = data.map((row) => String(row[categoryKey]));
+    live.categories = categories;
+
+    const ctx: OptionBuildContext = {
+      data,
+      config,
+      bars,
+      seriesKeys,
+      animationType,
+      barRadius,
+      isHorizontal,
+      isStacked,
+      isPercent,
+      selectedDataKey,
+      hasSelection,
+      showGrid,
+      categorySlot,
+      valueSlot,
+      tooltipSlot,
+      legendSlot,
+      isLoading,
+      loadingData,
+      showBrush: brushEnabled,
+      brushHeight,
+      barGap,
+      barCategoryGap,
+      resolved,
+      categories,
+      brushRange: live.brushRange,
+      valuePxPerUnit: live.valuePxPerUnit,
+      barWidthPx: live.barWidthPx,
+      expand: live.expand,
+      maxHighlightIndex,
+      chartWidth: echartsRef.current?.getWidth() ?? 0,
+    };
+
+    const { grid, brushBottom } = buildChartLayout(ctx);
+    live.brushGeom = brushEnabled ? { bottom: brushBottom, height: brushHeight } : null;
+
+    const { xAxis, yAxis } = buildMainAxes(ctx);
+
+    if (isLoading) return buildLoadingOption(ctx, { grid, xAxis, yAxis });
+
+    const brush = brushEnabled ? buildBrushOption(ctx, brushBottom) : null;
+
+    return {
+      animation: false,
+      grid: brush ? [grid, brush.miniGrid] : grid,
+      xAxis: brush ? [xAxis, brush.miniXAxis] : xAxis,
+      yAxis: brush ? [yAxis, brush.miniYAxis] : yAxis,
+      tooltip: buildTooltipOption(ctx),
+      dataZoom: brush?.dataZoom,
+      series: [...buildBarSeries(ctx), ...(brush?.miniSeries ?? [])],
+    };
+  }, [
+    live,
+    data,
+    config,
+    bars,
+    seriesKeys,
+    categoryKey,
+    animationType,
+    barRadius,
+    isHorizontal,
+    isStacked,
+    isPercent,
+    selectedDataKey,
+    hasSelection,
+    showGrid,
+    categorySlot,
+    valueSlot,
+    tooltipSlot,
+    legendSlot,
+    isLoading,
+    loadingData,
+    brushEnabled,
+    brushHeight,
+    barGap,
+    barCategoryGap,
+    maxHighlightIndex,
+  ]);
+
+  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  useEffect(() => {
+    const mount = mountRef.current;
+    const container = containerRef.current;
+    if (!mount || !container) return;
+
+    const chart = echarts.init(mount);
+    echartsRef.current = chart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Observers always fire once right after observe(). Repushing on that
+      // no-op fire would land one frame into the intro and stomp the grow-in —
+      // only react when the renderer size actually changed.
+      if (mount.clientWidth === chart.getWidth() && mount.clientHeight === chart.getHeight()) {
+        return;
+      }
+      chart.resize();
+      live.repush();
+    });
+    resizeObserver.observe(mount);
+
+    // Light/dark flips change no React state — re-resolve and push directly.
+    const themeObserver = new MutationObserver(() => {
+      live.repush();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    // Expandable hover, driven by the pointer's COLUMN rather than the bar element.
+    // An expandable bar is a hairline at rest, so element hover would only catch a
+    // couple of pixels — and hovering the empty space above a bar (where the axis
+    // tooltip still responds) would highlight it without expanding it. Converting
+    // the pointer's x back to a category index makes the whole column the target,
+    // matching what the tooltip already does. Registered ONCE here rather than in
+    // the sync effect, which re-runs on every prop/theme change and would stack
+    // duplicate listeners; it calls through live.animateExpand, always the current one.
+    chart.getZr().on("mousemove", (event: { offsetX: number; offsetY: number }) => {
+      const { expandableKey } = live.handlers;
+      if (!expandableKey) return;
+      const point = [event.offsetX, event.offsetY];
+      if (!chart.containPixel({ gridIndex: 0 }, point)) {
+        live.animateExpand(expandableKey, null);
+        return;
+      }
+      // A grid finder returns [xValue, yValue]; on a category axis the x value IS
+      // the index. An xAxisIndex finder returns null for a 2D point.
+      const converted = chart.convertFromPixel({ gridIndex: 0 }, point);
+      const index = Array.isArray(converted) ? converted[0] : converted;
+      live.animateExpand(expandableKey, typeof index === "number" ? Math.round(index) : null);
+    });
+    chart.getZr().on("globalout", () => {
+      const { expandableKey } = live.handlers;
+      if (expandableKey) live.animateExpand(expandableKey, null);
+    });
+
+    chart.on("click", (params) => {
+      const { clickableKeys: clickable, seriesKeys: keys } = live.handlers;
+      const p = params as { seriesId?: string; seriesIndex?: number };
+      // Bar clicks carry seriesId; keep the seriesIndex fallback for safety. Main
+      // series come first in the series array, so the index maps directly.
+      const id =
+        p.seriesId ?? (typeof p.seriesIndex === "number" ? keys[p.seriesIndex] : undefined);
+      if (typeof id === "string" && clickable.has(id)) toggleSelection(id);
+    });
+
+    chart.on("datazoom", () => {
+      const option = chart.getOption() as { dataZoom?: { start?: number; end?: number }[] };
+      const zoom = option.dataZoom?.[0];
+      if (!zoom) return;
+
+      // Ride the selection — pure zrender updates, so the drag stays 1:1.
+      live.brushRange = { start: zoom.start ?? 0, end: zoom.end ?? 100 };
+      syncBrushOverlayNow();
+
+      const { onBrushChange: onChange } = live.handlers;
+      if (!onChange) return;
+      const len = live.dataLength;
+      const startIndex = Math.round(((zoom.start ?? 0) / 100) * (len - 1));
+      const endIndex = Math.round(((zoom.end ?? 100) / 100) * (len - 1));
+      onChange({ startIndex, endIndex });
+    });
+
+    // The stripped cap needs the value-axis pixel scale, which only exists AFTER a
+    // layout. Once rendering settles — the first paint, a zoom that rescaled the
+    // axis — measure it and, if it moved, correct the caps. The correction is a
+    // SILENT series-only merge (patchStrippedCaps), so it can't reset a dataZoom
+    // drag. Held off until the entrance finishes (revealEndsAt) so it never lands
+    // mid-grow; guarded by an epsilon so a stable measurement doesn't loop.
+    chart.on("finished", () => {
+      const { hasStripped, isHorizontal: horiz } = live.handlers;
+      if (!hasStripped || performance.now() < live.revealEndsAt) return;
+      const measured = measureValuePxPerUnit(chart, horiz);
+      if (measured == null) return;
+      if (live.valuePxPerUnit != null && Math.abs(measured - live.valuePxPerUnit) < 0.5) return;
+      live.valuePxPerUnit = measured;
+      live.patchStrippedCaps();
+    });
+
+    // Hover tracking for the overlay: labels show while the pointer is over the
+    // brush, and each pill brightens when the pointer is near its edge.
+    const zr = chart.getZr();
+    const applyHover = (next: { inside: boolean; left: boolean; right: boolean }) => {
+      const prev = live.brushHover;
+      if (prev.inside === next.inside && prev.left === next.left && prev.right === next.right) {
+        return;
+      }
+      live.brushHover = next;
+      syncBrushOverlayNow();
+    };
+    const onZrMove = (event: { offsetX?: number; offsetY?: number }) => {
+      const geom = live.brushGeom;
+      if (!geom) return;
+      const x = event.offsetX ?? -1;
+      const y = event.offsetY ?? -1;
+      const top = chart.getHeight() - geom.bottom - geom.height;
+      const inside = y >= top - 4 && y <= top + geom.height + 4;
+      const trackLeft = 8;
+      const trackWidth = Math.max(chart.getWidth() - 16, 1);
+      const { start, end } = live.brushRange;
+      const selectionLeft = trackLeft + (trackWidth * start) / 100;
+      const selectionRight = trackLeft + (trackWidth * end) / 100;
+      applyHover({
+        inside,
+        left: inside && Math.abs(x - selectionLeft) <= 8,
+        right: inside && Math.abs(x - selectionRight) <= 8,
+      });
+    };
+    const onZrOut = () => applyHover({ inside: false, left: false, right: false });
+    zr.on("mousemove", onZrMove);
+    zr.on("globalout", onZrOut);
+
+    return () => {
+      zr.off("mousemove", onZrMove);
+      zr.off("globalout", onZrOut);
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      chart.dispose();
+      echartsRef.current = null;
+      // The overlay elements died with the zrender instance.
+      live.brushOverlay = null;
+      // The reveal guard belongs to the chart instance it guarded. Without this
+      // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
+      // the throwaway instance and the surviving one renders without it.
+      live.hasRevealed = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    const container = containerRef.current;
+    if (!chart || !container) return;
+
+    // Colors come from the <style> committed just before this effect ran — read
+    // them here, right before the push, rather than round-tripping through state.
+    live.resolved = resolveColors(container, config, seriesKeys);
+
+    const push = (withEntrance: boolean) => {
+      // Refresh the value-axis pixel scale before building, so stripped caps get the
+      // right per-bar fraction on this same push (after a resize the coordinate
+      // system is already updated here). Null before the very first push — the
+      // `finished` handler corrects that first paint once the axis exists.
+      const measured = measureValuePxPerUnit(chart, isHorizontal);
+      if (measured != null) live.valuePxPerUnit = measured;
+
+      const apply = () => {
+        const option = buildOption();
+        const merged = chartOptions ? { ...option, ...chartOptions } : option;
+        Object.assign(merged, {
+          animation: withEntrance,
+          animationDuration: BAR_GROW_DURATION,
+          animationDurationUpdate: 0,
+        });
+        // chartOptions is an untyped escape hatch — the spread erases the option's
+        // shape, so re-assert it. The only cast in the file.
+        chart.setOption(merged as EChartsOption, { notMerge: true });
+      };
+
+      apply();
+
+      // Two things can only be sized once a coordinate system has been laid out, so
+      // the first build uses fallbacks: the `blocks` variant's square segments (bar
+      // width) and the stacked-segment gap (value-axis pixels-per-unit). Measure
+      // both now and, if either moved, rebuild IMMEDIATELY — still inside this task,
+      // before the browser paints, so the corrected chart is the only thing ever
+      // shown. Doing this from the async `finished` handler instead made the bars
+      // visibly re-align a frame later.
+      let needsRebuild = false;
+      if (live.handlers.hasBlocks) {
+        const width = measureBarWidthPx(chart, isHorizontal, barCategoryGap);
+        if (width != null && (live.barWidthPx == null || Math.abs(width - live.barWidthPx) > 0.5)) {
+          live.barWidthPx = width;
+          needsRebuild = true;
+        }
+      }
+      if (live.handlers.hasStackGap) {
+        const scale = measureValuePxPerUnit(chart, isHorizontal);
+        if (scale != null && (live.valuePxPerUnit == null || live.valuePxPerUnit !== scale)) {
+          live.valuePxPerUnit = scale;
+          needsRebuild = true;
+        }
+      }
+      if (needsRebuild) apply();
+      // Mark when the entrance settles, so the stripped-cap correction holds off
+      // until the grow finishes (0 = nothing animating, correct immediately).
+      const maxStagger = data.length > 1 ? (data.length - 1) * BAR_STAGGER : 0;
+      live.revealEndsAt = withEntrance ? performance.now() + BAR_GROW_DURATION + maxStagger : 0;
+      // Overlays live outside the option — reposition them after every push.
+      syncBrushOverlayNow();
+    };
+
+    // A stripped-cap correction that never disturbs the entrance or a brush drag:
+    // rebuild only the stripped series with fresh per-datum cap fractions (the just
+    // -measured live.valuePxPerUnit) and merge them silently.
+    // Drives the `expandable` hover: eases live.expand.progress toward its target
+    // and re-merges ONLY the expandable series each frame, so the strip grows out
+    // of the bar's middle. A series-scoped silent merge (same shape as
+    // patchStrippedCaps) — never a full notMerge push, which would fight the
+    // hover state it is animating.
+    live.animateExpand = (key: string | null, index: number | null) => {
+      const expandKeys = new Set(
+        bars.filter((bar) => bar.variant === "expandable").map((bar) => bar.dataKey),
+      );
+      if (!expandKeys.size) return;
+
+      const next = index != null && key != null ? index : null;
+      if (live.expand.hovered === next && (key == null || live.expand.key === key)) return;
+      if (key != null) live.expand.key = key;
+      live.expand.hovered = next;
+      // Seed the newly hovered bar so it has something to ease from.
+      if (next != null && !live.expand.progress.has(next)) {
+        live.expand.progress.set(next, EXPAND_COLLAPSED);
+      }
+      if (live.expandRaf) return; // a loop is already running; it picks up the new target
+
+      const patchOnce = () => {
+        const option = buildOption();
+        const series = Array.isArray(option.series)
+          ? option.series
+          : option.series
+            ? [option.series]
+            : [];
+        const patch = series.filter(
+          (s): s is BarSeriesOption => typeof s?.id === "string" && expandKeys.has(s.id),
+        );
+        if (patch.length) chart.setOption({ series: patch }, { silent: true, lazyUpdate: true });
+      };
+
+      let last = performance.now();
+      const step = () => {
+        const now = performance.now();
+        const dt = Math.min(64, now - last);
+        last = now;
+        // Exponential approach — every bar eases toward its own target, so the one
+        // being left keeps animating shut while the next one opens.
+        const k = 1 - Math.exp(-dt / EXPAND_TAU);
+        let moving = false;
+        for (const [i, value] of live.expand.progress) {
+          const target = i === live.expand.hovered ? 1 : EXPAND_COLLAPSED;
+          const eased = value + (target - value) * k;
+          if (Math.abs(target - eased) < 0.004) {
+            if (target === EXPAND_COLLAPSED) live.expand.progress.delete(i);
+            else live.expand.progress.set(i, target);
+          } else {
+            live.expand.progress.set(i, eased);
+            moving = true;
+          }
+        }
+        patchOnce();
+        live.expandRaf = moving ? requestAnimationFrame(step) : 0;
+      };
+      live.expandRaf = requestAnimationFrame(step);
+    };
+
+    live.patchStrippedCaps = () => {
+      const option = buildOption();
+      const series = Array.isArray(option.series)
+        ? option.series
+        : option.series
+          ? [option.series]
+          : [];
+      const strippedKeys = new Set(
+        bars.filter((bar) => bar.variant === "stripped").map((bar) => bar.dataKey),
+      );
+      const patch = series.filter(
+        (s): s is BarSeriesOption => typeof s?.id === "string" && strippedKeys.has(s.id),
+      );
+      if (patch.length) chart.setOption({ series: patch }, { silent: true, lazyUpdate: true });
+    };
+
+    // Intro grow-in — ECharts' native bar entrance (bars rise from the baseline),
+    // staggered per-datum by animationType, enabled only for the first real
+    // render: every later push (selection, theme, zoom) applies instantly, since
+    // notMerge would otherwise replay the entrance on each. A loading cycle
+    // re-arms it: the Recharts twin remounts its <Bar>s while loading and replays
+    // the intro, so data → loading → data grows in again here too.
+    if (isLoading) live.hasRevealed = false;
+    const shouldReveal = !live.hasRevealed && !isLoading;
+    if (shouldReveal) live.hasRevealed = true;
+    const revealEnabled =
+      animation && shouldReveal && effectiveAnimation !== "none" && !shouldReduceMotion;
+    push(revealEnabled);
+
+    // Theme flips and resizes re-enter here without touching React: re-read the
+    // tokens (the .dark class changed, or textures need renderer-sized rebakes)
+    // and push an update-style option.
+    live.repush = () => {
+      live.resolved = resolveColors(container, config, seriesKeys);
+      push(false);
+    };
+  }, [
+    live,
+    buildOption,
+    chartOptions,
+    isLoading,
+    animation,
+    effectiveAnimation,
+    shouldReduceMotion,
+    config,
+    seriesKeys,
+    data.length,
+    bars,
+    isHorizontal,
+    barCategoryGap,
+    syncBrushOverlayNow,
+  ]);
+
+  // ── Default tooltip — show the tooltip at `defaultIndex` with no hover ────────
+  // Recharts' `defaultIndex` keeps a tooltip open on load; ECharts has no static
+  // equivalent, so dispatch `showTip` once the layout has settled.
+  useEffect(() => {
+    const chart = echartsRef.current;
+    const index = tooltipSlot.defaultIndex;
+    if (!chart || isLoading || !tooltipSlot.present || index == null) return;
+    const timer = setTimeout(() => {
+      chart.dispatchAction({ type: "showTip", seriesIndex: 0, dataIndex: index });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [tooltipSlot.present, tooltipSlot.defaultIndex, isLoading, data.length, seriesKeys.length]);
+
+  // ── Loading shimmer — rAF sweeps a bright band across the gray bars ──────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || !isLoading) return;
+
+    let raf = 0;
+    let lastPhase = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const phase = ((((now - start) / LOADING_ANIMATION_DURATION) % 1) + 1) % 1;
+      // Wrapped past 1 → the band is off-screen; swap in fresh random heights.
+      if (phase < lastPhase) live.loadingRows = getLoadingBarData(loadingBars);
+      lastPhase = phase;
+
+      // Read tokens per frame, so a theme flip mid-loading retints the shimmer.
+      const foreground = live.resolved?.tokens.foreground ?? GRAY;
+      const w = chart.getWidth();
+      const h = chart.getHeight();
+      if (!w || !h) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      // Sweep the clip window from fully off-screen to fully off-screen, leaned
+      // 45°. The gradient runs on ABSOLUTE pixel coordinates (0,0)→(w,w) shared
+      // by every bar — the whole skeleton lives in one coordinate frame, so each
+      // bar brightens as the diagonal band passes diagonally over it, the same
+      // sweep language as the area chart's loading shimmer. `maxT` is the farthest
+      // plot corner projected onto the 45° axis, keeping the sweep tight instead
+      // of dawdling off-plot at the end of each loop.
+      const maxT = (w + h) / (2 * w);
+      const center = phase * (maxT + 2 * LOADING_SHIMMER_BAND) - LOADING_SHIMMER_BAND;
+      const fill = new echarts.graphic.LinearGradient(
+        0,
+        0,
+        w,
+        w,
+        shimmerWindowStops(center, foreground, LOADING_SHIMMER_MAX_OPACITY),
+        true,
+      );
+      chart.setOption(
+        { series: [{ id: "__loading", data: loadingData(), itemStyle: { color: fill } }] },
+        { silent: true, lazyUpdate: true },
+      );
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [live, isLoading, loadingBars, loadingData]);
+
+  // ── Legend overlay position ──────────────────────────────────────────────────
+  // Insets match the Recharts legend's breathing room inside the plot frame.
+  const legendStyle: CSSProperties = {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    pointerEvents: "auto",
+    ...(legendSlot.verticalAlign === "top"
+      ? { top: 12 }
+      : legendSlot.verticalAlign === "bottom"
+        ? { bottom: brushEnabled ? brushHeight + 16 : 12 }
+        : { top: "50%", transform: "translateY(-50%)" }),
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      data-chart={chartId}
+      className={`relative flex flex-col text-xs ${className ?? ""}`}
+    >
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+
+      <div className="relative min-h-0 w-full flex-1">
+        <div ref={mountRef} className="h-full min-h-0 w-full" />
+      </div>
+
+      {legendSlot.present && !isLoading && (
+        <LegendOverlay
+          seriesKeys={seriesKeys}
+          config={config}
+          variant={legendSlot.variant}
+          align={legendSlot.align}
+          verticalAlign={legendSlot.verticalAlign}
+          selectedKey={selectedDataKey}
+          hoveredKey={null}
+          isClickable={legendSlot.isClickable}
+          onToggle={toggleSelection}
+          style={legendStyle}
+        />
+      )}
+
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+          <motion.div
+            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+            className="flex items-center justify-center gap-2 rounded-md border bg-background px-2 py-0.5 text-sm text-primary"
+          >
+            <div className="h-3 w-3 animate-spin rounded-full border border-border border-t-primary" />
+            <span>Loading</span>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loading skeleton helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Skeleton bar heights as a smooth random walk in a comfortable band — reads
+// like a resting chart instead of raw noise spikes.
+function getLoadingBarData(bars: number): number[] {
+  const rows: number[] = [];
+  let value = 40 + Math.random() * 25;
+  for (let i = 0; i < bars; i++) {
+    value = Math.min(85, Math.max(20, value + (Math.random() - 0.5) * 30));
+    rows.push(Math.round(value));
+  }
+  return rows;
+}
+
+// Gradient stops forming a hard clip window around `center`: full `peak` alpha
+// inside, zero outside, with a small feather so the edge isn't aliased.
+// `center` may run outside [0, 1] so the window fully enters and exits the frame.
+function shimmerWindowStops(center: number, color: string, peak: number) {
+  const half = LOADING_SHIMMER_BAND;
+  const feather = LOADING_SHIMMER_FEATHER;
+
+  const alphaAt = (x: number) => {
+    const dist = Math.abs(x - center);
+    if (dist <= half - feather) return peak;
+    if (dist >= half) return 0;
+    // Sine-eased falloff — a linear ramp still reads as a hard cut.
+    return peak * Math.sin(((1 - (dist - (half - feather)) / feather) * Math.PI) / 2);
+  };
+
+  const offsets = [
+    0,
+    center - half,
+    center - half + feather,
+    center,
+    center + half - feather,
+    center + half,
+    1,
+  ]
+    .filter((x) => x >= 0 && x <= 1)
+    .sort((a, b) => a - b);
+
+  const stops: { offset: number; color: string }[] = [];
+  for (const offset of offsets) {
+    if (stops.length === 0 || offset - stops[stops.length - 1]!.offset > 1e-4) {
+      stops.push({ offset, color: withAlpha(color, alphaAt(offset)) });
+    }
+  }
+  return stops;
+}
+
+// Compound API: every part hangs off the root as a static member, so a consumer
+// writes <EChartsBarChart.Bar/>, <EChartsBarChart.Tooltip/>, … from a single
+// import — no colliding named marker exports when several charts share one file.
+EChartsBarChart.Bar = Bar;
+EChartsBarChart.XAxis = XAxis;
+EChartsBarChart.YAxis = YAxis;
+EChartsBarChart.Grid = Grid;
+EChartsBarChart.Tooltip = Tooltip;
+EChartsBarChart.Legend = Legend;
+EChartsBarChart.Brush = Brush;

--- a/packages/charts/src/components/evilcharts/charts/echarts-line-chart.tsx
+++ b/packages/charts/src/components/evilcharts/charts/echarts-line-chart.tsx
@@ -1,0 +1,2103 @@
+"use client";
+
+import type { ComposeOption } from "echarts/core";
+
+import {
+  Brush,
+  buildBrushDataZoom,
+  syncBrushOverlay,
+  type BrushGeometry,
+  type BrushOverlayElements,
+  type BrushProps,
+  type BrushRange,
+} from "@harmony/charts/components/evilcharts/ui/echarts-brush";
+import {
+  buildChartCss,
+  flattenColor,
+  getColorsCount,
+  resolveColors,
+  seriesPaint,
+  withAlpha,
+  type ChartConfig,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+import {
+  dotItemStyle,
+  dotStyle,
+  sampleGradient,
+  type DotItemStyleOption,
+  type DotVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-dot";
+import {
+  LegendOverlay,
+  type LegendVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-legend";
+import {
+  formatTooltipValue,
+  tooltipBaseOption,
+  tooltipIndicatorHtml,
+  tooltipRow,
+  tooltipShell,
+  type TooltipPosition,
+  type TooltipRoundness,
+  type TooltipVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-tooltip";
+import { LineChart, type LineSeriesOption } from "echarts/charts";
+import {
+  DataZoomComponent,
+  GridComponent,
+  TooltipComponent,
+  type DataZoomComponentOption,
+  type GridComponentOption,
+  type TooltipComponentOption,
+} from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { motion, useReducedMotion } from "motion/react";
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FC,
+  type ReactNode,
+} from "react";
+
+// Re-export the shared types that were previously declared inline here, so
+// existing consumers/examples keep importing them from the chart module.
+export type {
+  ChartConfig,
+  DotVariant,
+  LegendVariant,
+  TooltipPosition,
+  TooltipRoundness,
+  TooltipVariant,
+};
+
+// Modular registration keeps the bundle lean — only the pieces this chart needs.
+// `DataZoomComponent` bundles both the slider (brush footer) and inside (wheel/drag)
+// zoom. The brush's frame/handles/labels are raw zrender elements, not the
+// graphic component — see syncBrushOverlay. No GraphicComponent is registered.
+echarts.use([LineChart, GridComponent, TooltipComponent, DataZoomComponent, CanvasRenderer]);
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+// The exact option surface this chart uses — line series, grid, tooltip, and
+// dataZoom, plus the axis options they pull in as dependencies. Narrower than
+// echarts' full EChartsOption, so a misspelled key fails the compile instead of
+// silently reaching setOption.
+type EChartsOption = ComposeOption<
+  LineSeriesOption | GridComponentOption | TooltipComponentOption | DataZoomComponentOption
+>;
+
+// Single-entry views of the composed option's array-or-single fields — the
+// modular entry points don't export the axis option types directly.
+type ArrayItem<T> = T extends readonly (infer U)[] ? U : T;
+type XAxisOption = ArrayItem<NonNullable<EChartsOption["xAxis"]>>;
+type YAxisOption = ArrayItem<NonNullable<EChartsOption["yAxis"]>>;
+
+// DotItemStyleOption now lives in @/registry/ui/echarts-dot and is imported at
+// the top of this file.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STROKE_WIDTH = 0.8; // default series stroke — <Line strokeWidth> overrides it
+const LOADING_ANIMATION_DURATION = 2000; // shimmer loop, in milliseconds
+const REVEAL_DURATION = 1000; // intro draw-in length, in milliseconds
+// NOTE: the intro draw-in runs ECharts' RAW default entrance animation. Custom
+// easing was tried and abandoned in the area twin — ECharts hardcodes the
+// line-entrance clip to linear and ignores animationEasing at every level.
+const LOADING_DEFAULT_POINTS = 14;
+// Buffer line: the last segment renders as this dash while the rest stays solid,
+// echoing the Recharts twin's 4px dash / 3px gap forecast tail.
+const BUFFER_DASH: [number, number] = [4, 3];
+
+// <Line glowing> glow. Canvas has no SVG blur filter over a whole shape, so the
+// glow is built from SILENT, stacked copies of the line laid UNDER the real one.
+//
+// The layers are all the SAME NARROW WIDTH on purpose. A wide translucent stroke
+// has a HARD edge, so widening each copy (the obvious approach) paints concentric
+// contour rings, not a glow — no number of layers hides it, because every layer
+// contributes another visible boundary. Here each copy stays hidden beneath the
+// real line and the visible halo comes entirely from its canvas `shadowBlur`,
+// which is a true gaussian: edgeless by construction, and summing several at
+// different radii stays perfectly smooth.
+//
+// The trade: a canvas shadow is a single flat color, so the halo is cast in the
+// gradient's mid tone (`sampleGradient(slots, 0.5)`) rather than tracking the
+// stroke's color along its length. The stroke copies themselves still carry the
+// real gradient, so the bright core reads correctly; only the soft bloom is one
+// hue. Smooth beats hue-accurate here. `symbolPad` grows the glow disc under each
+// visible dot so haloed markers bloom too.
+const GLOW_LAYERS: { width: number; opacity: number; blur: number; symbolPad: number }[] = [
+  { width: 2, opacity: 0.9, blur: 5, symbolPad: 2 },
+  { width: 2, opacity: 0.6, blur: 12, symbolPad: 6 },
+  { width: 2, opacity: 0.38, blur: 24, symbolPad: 11 },
+  { width: 2, opacity: 0.22, blur: 42, symbolPad: 16 },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Theme knobs — every neutral line in the chart draws from these. Base colors
+// come from the consumer's CSS tokens (resolved from the live DOM), so only the
+// opacity factors live here. Factors MULTIPLY the token's own alpha — a border
+// token that is already 10%-white stays subtle. Tune here, not in the builder.
+// ─────────────────────────────────────────────────────────────────────────────
+// Recharts draws its grid at border/50, but SVG dashes render pixel-crisp while
+// canvas at 2× DPR spreads a 1px line across device pixels — roughly halving
+// perceived intensity. Using the border token's full alpha lands both engines at
+// the same apparent brightness.
+const GRID_LINE_OPACITY = 1; // dashed y-axis split lines, × border alpha
+const AXIS_POINTER_OPACITY = 1; // tooltip cursor line, × border alpha
+// The skeleton is CLIPPED to a small sweeping window — only the stroke section
+// inside it exists, everything outside is fully transparent, like a clip-path
+// sliding across the chart.
+const LOADING_STROKE_OPACITY = 0.5; // outline inside the window, × foreground alpha
+const LOADING_SHIMMER_BAND = 0.2; // window half-width, fraction of chart width
+const LOADING_SHIMMER_FEATHER = 0.2; // eased edge softening of the clip window
+const BRUSH_STROKE_OPACITY = 0.5; // mini-chart series stroke (evil-brush "line" variant)
+const BRUSH_FILLER_OPACITY = 0; // selected-range wash — evil-brush draws none
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type StrokeVariant = "solid" | "dashed" | "animated-dashed";
+export type LineAnimationType =
+  | "none"
+  | "left-to-right"
+  | "right-to-left"
+  | "center-out"
+  | "edges-in";
+export type CurveType =
+  | "linear"
+  | "smooth"
+  | "bump"
+  | "monotone"
+  | "monotoneX"
+  | "monotoneY"
+  | "natural"
+  | "step";
+// DotVariant, TooltipVariant, TooltipRoundness, LegendVariant, and ChartConfig
+// now live in the shared @/registry/ui/echarts/* modules and are imported +
+// re-exported at the top of this file.
+
+export interface EChartsLineChartProps<TData extends Record<string, unknown>> {
+  data: TData[]; // rows rendered by the chart
+  config: ChartConfig; // series colors + labels
+  xDataKey?: keyof TData & string; // x category key — falls back to the <XAxis> dataKey / first free column
+  className?: string; // extra classes for the chart container
+  curveType?: CurveType; // default curve interpolation each <Line> inherits
+  animation?: boolean; // master switch for the intro draw-in — false renders instantly
+  animationType?: LineAnimationType; // default intro reveal (first <Line> overrides)
+  enableHoverHighlight?: boolean; // hovering a series dims the others, like a temporary selection
+  enableHoverReveal?: boolean; // hovering colors each line up to the pointer's x and mutes the rest
+  defaultSelectedDataKey?: string | null; // series selected on first render
+  onSelectionChange?: (key: string | null) => void; // fires when the selected series changes
+  isLoading?: boolean; // shows the animated loading skeleton
+  loadingPoints?: number; // number of points in the loading skeleton
+  chartOptions?: Record<string, unknown>; // escape hatch merged over the built ECharts option
+  children?: ReactNode; // declarative config — <Line>, <XAxis>, <Grid>, <Tooltip>, <Legend>, <Brush>, …
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Composible parts — DECLARATIVE CONFIG. Every part renders `null`; the root
+// walks `children` by reference (child.type === Line, …) to collect its props.
+// Presence semantics mirror the Recharts twin: omit a child and that part does
+// not render. These are never mounted into the tree — they only carry props.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface LineProps {
+  dataKey: string; // series key — must exist on the data + config
+  strokeVariant?: StrokeVariant; // stroke style for this line
+  strokeWidth?: number; // stroke thickness in pixels for this line
+  curveType?: CurveType; // curve interpolation — falls back to the root curveType
+  animationType?: LineAnimationType; // intro reveal — first line drives the wrapper wipe
+  connectNulls?: boolean; // join segments across null/missing values
+  isClickable?: boolean; // lets this line be selected by clicking it
+  glowing?: boolean; // applies a soft outer glow to this line
+  enableBufferLine?: boolean; // renders this line's last segment as a dashed buffer
+  children?: ReactNode; // optional <Dot> and <ActiveDot> config
+}
+
+/**
+ * A single line series. Declares its own stroke/curve/glow/clickability and,
+ * optionally, resting/active point markers via composed <Dot> / <ActiveDot>.
+ * Renders nothing — the root reads these props to build the ECharts series.
+ */
+const Line: FC<LineProps> = () => null;
+
+export interface DotProps {
+  variant?: DotVariant; // visual style of the point marker
+}
+
+/** Declares the resting point marker for the enclosing <Line>. Renders nothing. */
+const Dot: FC<DotProps> = () => null;
+
+/** Declares the hovered/active point marker for the enclosing <Line>. Renders nothing. */
+const ActiveDot: FC<DotProps> = () => null;
+
+export interface XAxisProps {
+  dataKey?: string; // x category key — overrides the root xDataKey
+  // Category-axis values are always stringified, so the formatter sees a string —
+  // letting examples share `(value) => value.substring(0, 3)` with the Recharts twin.
+  tickFormatter?: (value: string, index: number) => string; // formats x tick labels
+  label?: string; // axis title, centered below the tick labels
+  hideDots?: boolean; // hides the tick dots beside this axis's labels
+}
+
+/** Presence shows the x-axis category labels. Renders nothing. */
+const XAxis: FC<XAxisProps> = () => null;
+
+export interface YAxisProps {
+  dataKey?: string; // reserved for parity with the Recharts twin
+  tickFormatter?: (value: number, index: number) => string; // formats y tick labels
+  label?: string; // axis title, rotated alongside the tick labels
+  hideDots?: boolean; // hides the tick dots beside this axis's labels
+}
+
+/** Presence shows the y value axis. Renders nothing. */
+const YAxis: FC<YAxisProps> = () => null;
+
+/** Presence shows the dashed horizontal split lines. Renders nothing. */
+const Grid: FC = () => null;
+
+export interface TooltipProps {
+  variant?: TooltipVariant; // visual style of the tooltip surface
+  roundness?: TooltipRoundness; // border-radius of the tooltip
+  cursor?: boolean; // whether the vertical cursor line follows the pointer
+  position?: TooltipPosition; // "variable" follows both axes (default); "fixed" pins the tooltip near the top and tracks the pointer's X
+  suffix?: string; // unit appended after each row's value (e.g. "min")
+}
+
+/** Presence enables the hover tooltip. Renders nothing. */
+const Tooltip: FC<TooltipProps> = () => null;
+
+export interface LegendProps {
+  variant?: LegendVariant; // visual style of the legend indicators
+  align?: "left" | "center" | "right"; // horizontal placement
+  verticalAlign?: "top" | "middle" | "bottom"; // vertical placement
+  isClickable?: boolean; // lets each entry toggle selection of its series
+}
+
+/** Presence enables the HTML legend overlay. Renders nothing. */
+const Legend: FC<LegendProps> = () => null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Children collection — walk the declarative config into plain objects the
+// option builder consumes. <Dot> / <ActiveDot> are read from each <Line>'s own
+// children; a missing dot child means that marker does not render.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LineSeriesConfig = {
+  dataKey: string;
+  strokeVariant: StrokeVariant;
+  strokeWidth: number;
+  curveType?: CurveType;
+  animationType?: LineAnimationType;
+  connectNulls: boolean;
+  isClickable: boolean;
+  glowing: boolean;
+  enableBufferLine: boolean;
+  dotVariant: DotVariant; // "none" when no <Dot> child is present
+  activeDotVariant: DotVariant; // "none" when no <ActiveDot> child is present
+};
+
+type XAxisSlot = {
+  present: boolean;
+  dataKey?: string;
+  tickFormatter?: (value: string, index: number) => string;
+  label?: string;
+  hideDots: boolean;
+};
+type YAxisSlot = {
+  present: boolean;
+  dataKey?: string;
+  tickFormatter?: (value: number, index: number) => string;
+  label?: string;
+  hideDots: boolean;
+};
+type TooltipSlot = {
+  present: boolean;
+  variant: TooltipVariant;
+  roundness: TooltipRoundness;
+  cursor: boolean;
+  position: TooltipPosition;
+  suffix?: string;
+};
+type LegendSlot = {
+  present: boolean;
+  variant: LegendVariant;
+  align: "left" | "center" | "right";
+  verticalAlign: "top" | "middle" | "bottom";
+  isClickable: boolean;
+};
+type BrushSlot = {
+  present: boolean; // a <Brush> child was passed — replaces the old showBrush prop
+  height?: number;
+  formatLabel?: (value: string, index: number) => string;
+  onChange?: (range: { startIndex: number; endIndex: number }) => void;
+};
+
+type CollectedConfig = {
+  lines: LineSeriesConfig[];
+  xAxis: XAxisSlot;
+  yAxis: YAxisSlot;
+  showGrid: boolean;
+  tooltip: TooltipSlot;
+  legend: LegendSlot;
+  brush: BrushSlot;
+};
+
+function collectConfig(children: ReactNode): CollectedConfig {
+  const lines: LineSeriesConfig[] = [];
+  let xAxis: XAxisSlot = { present: false, hideDots: false };
+  let yAxis: YAxisSlot = { present: false, hideDots: false };
+  let showGrid = false;
+  let tooltip: TooltipSlot = {
+    present: false,
+    variant: "default",
+    roundness: "lg",
+    cursor: true,
+    position: "variable",
+  };
+  let legend: LegendSlot = {
+    present: false,
+    variant: "rounded-square",
+    align: "right",
+    verticalAlign: "top",
+    isClickable: false,
+  };
+  let brush: BrushSlot = { present: false };
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const type = child.type;
+
+    if (type === Line) {
+      const props = child.props as LineProps;
+      let dotVariant: DotVariant = "none";
+      let activeDotVariant: DotVariant = "none";
+      Children.forEach(props.children, (dotChild) => {
+        if (!isValidElement(dotChild)) return;
+        if (dotChild.type === Dot) {
+          dotVariant = (dotChild.props as DotProps).variant ?? "default";
+        } else if (dotChild.type === ActiveDot) {
+          activeDotVariant = (dotChild.props as DotProps).variant ?? "default";
+        }
+      });
+      lines.push({
+        dataKey: props.dataKey,
+        // The Recharts twin defaults a <Line> to a solid stroke (its <Area>
+        // defaults to dashed — a divergence intentionally preserved here).
+        strokeVariant: props.strokeVariant ?? "solid",
+        strokeWidth: props.strokeWidth ?? STROKE_WIDTH,
+        curveType: props.curveType,
+        animationType: props.animationType,
+        connectNulls: props.connectNulls ?? false,
+        isClickable: props.isClickable ?? false,
+        glowing: props.glowing ?? false,
+        enableBufferLine: props.enableBufferLine ?? false,
+        dotVariant,
+        activeDotVariant,
+      });
+    } else if (type === XAxis) {
+      const props = child.props as XAxisProps;
+      xAxis = {
+        present: true,
+        dataKey: props.dataKey,
+        tickFormatter: props.tickFormatter,
+        label: props.label,
+        hideDots: props.hideDots ?? false,
+      };
+    } else if (type === YAxis) {
+      const props = child.props as YAxisProps;
+      yAxis = {
+        present: true,
+        dataKey: props.dataKey,
+        tickFormatter: props.tickFormatter,
+        label: props.label,
+        hideDots: props.hideDots ?? false,
+      };
+    } else if (type === Grid) {
+      showGrid = true;
+    } else if (type === Tooltip) {
+      const props = child.props as TooltipProps;
+      tooltip = {
+        present: true,
+        variant: props.variant ?? "default",
+        roundness: props.roundness ?? "lg",
+        cursor: props.cursor ?? true,
+        position: props.position ?? "variable",
+        suffix: props.suffix,
+      };
+    } else if (type === Legend) {
+      const props = child.props as LegendProps;
+      legend = {
+        present: true,
+        variant: props.variant ?? "rounded-square",
+        align: props.align ?? "right",
+        verticalAlign: props.verticalAlign ?? "top",
+        isClickable: props.isClickable ?? false,
+      };
+    } else if (type === Brush) {
+      const props = child.props as BrushProps;
+      brush = {
+        present: true,
+        height: props.height,
+        formatLabel: props.formatLabel,
+        onChange: props.onChange,
+      };
+    }
+  });
+
+  return { lines, xAxis, yAxis, showGrid, tooltip, legend, brush };
+}
+
+// Color plumbing (ChartConfig, getColorsCount, distributeColors, buildChartCss,
+// normalizeColor, withAlpha, ResolvedColors, resolveColors, seriesPaint) now
+// lives in @/registry/ui/echarts-chart and is imported at the top of this file.
+// Dot helpers (DotVariant, DotItemStyleOption, DotStyle, DOT_SIZES, dotItemStyle,
+// dotStyle, sampleGradient) live in @/registry/ui/echarts-dot.
+
+// Builds the stacked glow overlay series for one <Line glowing> (see
+// GLOW_LAYERS). Each copy is silent, tooltip-less, and z-ordered beneath the real
+// line, so the widening low-alpha gradient strokes read as a soft colored blur
+// that tracks the series' gradient exactly like the stroke does. When the line
+// shows resting dots, each copy also draws an oversized faint symbol — coloured
+// per-datum via sampleGradient — so the markers bloom too. `selectionDim` fades
+// the whole glow with its parent when another series is selected; the
+// emphasis/blur styles let it focus/dim WITH its parent under
+// enableHoverHighlight (the root dispatch-links these ids — see companionIdsByKey).
+function buildGlowSeries(params: {
+  key: string;
+  paint: string | echarts.graphic.LinearGradient;
+  slots: string[];
+  values: (number | null)[];
+  curve: { smooth: boolean; step: "middle" | false };
+  connectNulls: boolean;
+  z: number;
+  selectionDim: number;
+  dotSize: number;
+}): LineSeriesOption[] {
+  const { key, paint, slots, values, curve, connectNulls, z, selectionDim, dotSize } = params;
+  const multiColor = slots.length > 1;
+  const base = slots[0] ?? "rgba(120, 120, 120, 1)";
+  const showDots = dotSize > 0;
+
+  return GLOW_LAYERS.map((layer, i): LineSeriesOption => {
+    const glowOpacity = layer.opacity * selectionDim;
+    const blurOpacity = glowOpacity * 0.3;
+    // Per-datum halo colours so a gradient glow tints each dot at its own
+    // x-position, matching sampleGradient on the real dots.
+    const glowData: LinePoint[] =
+      !multiColor || !showDots
+        ? values
+        : values.map((value, idx): LinePoint => {
+            if (value === null) return null;
+            const t = values.length > 1 ? idx / (values.length - 1) : 0;
+            const color = sampleGradient(slots, t);
+            return {
+              value,
+              itemStyle: { color, opacity: glowOpacity },
+              emphasis: { itemStyle: { color, opacity: glowOpacity } },
+            };
+          });
+
+    return {
+      id: `__glow-${i}-${key}`,
+      type: "line",
+      data: glowData,
+      smooth: curve.smooth,
+      step: curve.step,
+      connectNulls,
+      silent: true,
+      showSymbol: showDots,
+      symbol: "circle",
+      symbolSize: showDots ? dotSize + layer.symbolPad : 0,
+      tooltip: { show: false },
+      z,
+      lineStyle: {
+        color: paint,
+        width: layer.width,
+        opacity: glowOpacity,
+        // Feathers this layer's edge so the stack reads as one smooth falloff
+        // rather than concentric bands (see GLOW_LAYERS).
+        shadowBlur: layer.blur,
+        // Full-alpha shadow color: the element's own `opacity` above already
+        // scales its shadow, so pre-dimming here squares the alpha and washes
+        // the halo out.
+        shadowColor: sampleGradient(slots, 0.5),
+        cap: "round",
+        join: "round",
+      },
+      itemStyle: multiColor ? { opacity: glowOpacity } : { color: base, opacity: glowOpacity },
+      // Focus/dim WITH the parent line: on the parent's hover the root highlights
+      // these ids (emphasis → normal glow); when another series is hovered the
+      // parent's focus:"series" blurs these to a fainter still.
+      emphasis: {
+        focus: "none",
+        scale: false,
+        lineStyle: { opacity: glowOpacity },
+        itemStyle: { opacity: glowOpacity },
+      },
+      blur: { lineStyle: { opacity: blurOpacity }, itemStyle: { opacity: blurOpacity } },
+    };
+  });
+}
+
+// Brush overlays (BrushRange, BrushGeometry, BrushOverlayElements,
+// BrushOverlayParams, syncBrushOverlay) live in @/registry/ui/echarts-brush
+// and are imported at the top of this file.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Curve mapping — linear → straight, step → step:"middle", everything else → smooth.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function curveConfig(curveType: CurveType): { smooth: boolean; step: "middle" | false } {
+  // Recharts "step" is d3's curveStep: the transition happens at the MIDPOINT
+  // between points, so each dot sits centered on its plateau.
+  if (curveType === "step") return { smooth: false, step: "middle" };
+  if (curveType === "linear") return { smooth: false, step: false };
+  return { smooth: true, step: false };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Selection opacities — dims a series only when another one is selected. Lines
+// have no fill, so only the stroke and dots carry an opacity here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getOpacity(selected: string | null, key: string) {
+  if (selected === null || selected === key) return { stroke: 1, dot: 1 };
+  return { stroke: 0.3, dot: 0.3 };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loading skeleton helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Skeleton data as a smooth random walk in a comfortable band — reads like a
+// resting chart instead of raw noise spikes.
+function getLoadingData(points: number): number[] {
+  const rows: number[] = [];
+  let value = 30 + Math.random() * 20;
+  for (let i = 0; i < points; i++) {
+    value = Math.min(58, Math.max(16, value + (Math.random() - 0.5) * 16));
+    rows.push(Math.round(value));
+  }
+  return rows;
+}
+
+// Gradient stops forming a hard clip window around `center`: full `peak` alpha
+// inside, zero outside, with a small feather so the edge isn't aliased.
+// `center` may run outside [0, 1] so the window fully enters and exits the frame.
+function shimmerWindowStops(center: number, color: string, peak: number) {
+  const half = LOADING_SHIMMER_BAND;
+  const feather = LOADING_SHIMMER_FEATHER;
+
+  const alphaAt = (x: number) => {
+    const dist = Math.abs(x - center);
+    if (dist <= half - feather) return peak;
+    if (dist >= half) return 0;
+    // Sine-eased falloff — a linear ramp still reads as a hard cut.
+    return peak * Math.sin(((1 - (dist - (half - feather)) / feather) * Math.PI) / 2);
+  };
+
+  const offsets = [
+    0,
+    center - half,
+    center - half + feather,
+    center,
+    center + half - feather,
+    center + half,
+    1,
+  ]
+    .filter((x) => x >= 0 && x <= 1)
+    .sort((a, b) => a - b);
+
+  const stops: { offset: number; color: string }[] = [];
+  for (const offset of offsets) {
+    if (stops.length === 0 || offset - stops[stops.length - 1]!.offset > 1e-4) {
+      stops.push({ offset, color: withAlpha(color, alphaAt(offset)) });
+    }
+  }
+  return stops;
+}
+
+// Tooltip HTML primitives (roundnessClass, tooltipVariantClass,
+// tooltipIndicatorHtml, tooltipRow, tooltipShell) live in
+// @/registry/ui/echarts-tooltip; indicatorBackground lives in
+// @/registry/ui/echarts-chart. Both are imported at the top of this file.
+
+// The `__buffer-` prefix marks the dashed forecast overlay of a buffer line; it
+// carries the SAME key's value, so the tooltip recovers the key from it (see
+// createTooltipFormatter). Every other `__`-prefixed series (mini chart, loading
+// skeleton, hover-reveal base) is truly internal and never surfaces.
+const BUFFER_PREFIX = "__buffer-";
+// The `__reveal-` prefix marks the muted base layer of a hover-reveal line — see
+// buildLineSeries. Internal, so the tooltip drops it like the mini/loading rows.
+const REVEAL_PREFIX = "__reveal-";
+
+// Legend overlay (legendFillStyle, legendOutlineStyle, LegendIndicator,
+// LegendOverlay) lives in @/registry/ui/echarts-legend and is imported at the
+// top of this file.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option builders — pure functions from a snapshot context to ECharts option
+// fragments. The component reads its refs and renderer size ONCE per build into
+// this context; nothing below touches React state or the chart instance, so
+// each fragment can be reasoned about (and tested) in isolation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OptionBuildContext = {
+  data: Record<string, unknown>[];
+  config: ChartConfig;
+  lines: LineSeriesConfig[];
+  curveType: CurveType;
+  selectedDataKey: string | null;
+  hasSelection: boolean;
+  showGrid: boolean;
+  xAxisSlot: XAxisSlot;
+  yAxisSlot: YAxisSlot;
+  tooltipSlot: TooltipSlot;
+  legendSlot: LegendSlot;
+  isLoading: boolean;
+  loadingData: () => number[];
+  showBrush: boolean;
+  brushHeight: number;
+  enableHoverHighlight: boolean;
+  enableHoverReveal: boolean; // hover colors each line up to the pointer, mutes the rest
+  revealIndex: number | null; // pointer's x-index while revealing (null = idle → chart looks normal)
+  revealSink: Record<string, unknown[]>; // buildLineSeries writes each line's full per-datum points here for the hover handler
+  resolved: ResolvedColors;
+  rendererSize: { width: number; height: number }; // anchored reveal stroke gradients span the plot in absolute pixels
+  categories: string[];
+  brushRange: BrushRange; // zoom window carried through rebuilds
+  getHoveredKey: () => string | null; // read per tooltip render — hover never repushes the option
+};
+
+// Grid insets plus the footer band reserved for the brush. ECharts 6 contains
+// axis labels automatically (the legacy `containLabel` flag now only triggers a
+// deprecation warning).
+function buildChartLayout({ legendSlot, xAxisSlot, showBrush, brushHeight }: OptionBuildContext): {
+  grid: GridComponentOption;
+  brushBottom: number;
+} {
+  const legendTop = legendSlot.present && legendSlot.verticalAlign === "top";
+  const legendBottom = legendSlot.present && legendSlot.verticalAlign === "bottom";
+  // Clearance covers the x-axis labels plus the same breathing room the
+  // Recharts twin leaves between them and the brush. An x-axis TITLE renders
+  // below the labels (nameGap), so it needs its own band above the brush frame.
+  const brushGap = showBrush ? brushHeight + 30 + (xAxisSlot.label ? 22 : 0) : 0;
+
+  return {
+    grid: {
+      left: 0,
+      right: 0,
+      top: legendTop ? 42 : 0,
+      bottom: brushGap + (legendBottom ? 34 : 0),
+    },
+    brushBottom: legendBottom ? 34 : 6,
+  };
+}
+
+function buildMainAxes(ctx: OptionBuildContext): { xAxis: XAxisOption; yAxis: YAxisOption } {
+  const { xAxisSlot, yAxisSlot, showGrid, isLoading, categories, loadingData } = ctx;
+  const { tokens } = ctx.resolved;
+
+  const axisLabelColor = tokens.mutedForeground;
+  const splitLineColor = withAlpha(tokens.border, GRID_LINE_OPACITY);
+  // Gridline gray as an opaque color — see flattenColor.
+  const tickDotColor = flattenColor(splitLineColor, tokens.background);
+
+  const xTickFormatter = xAxisSlot.tickFormatter;
+  const yTickFormatter = yAxisSlot.tickFormatter;
+
+  const xAxis: XAxisOption = {
+    type: "category",
+    boundaryGap: false,
+    show: true,
+    data: isLoading ? loadingData().map((_, i) => i) : categories,
+    // Axis title — same size/color as the tick labels, pushed clear of them.
+    name: isLoading ? undefined : xAxisSlot.label,
+    nameLocation: "middle",
+    nameGap: 30,
+    nameTextStyle: { color: axisLabelColor, fontSize: 10 },
+    axisLine: { show: false },
+    // Tick DOTS: a near-zero-length tick whose round caps form a true circle,
+    // in the gridline gray (flattened opaque so the caps don't stack).
+    axisTick: {
+      show: !isLoading && xAxisSlot.present && !xAxisSlot.hideDots,
+      // Category ticks default to the BOUNDARY between categories, which on a
+      // boundaryGap axis drops the dot in the gap instead of under its label. A
+      // no-op here (boundaryGap is false) — set for parity with the bar/composed
+      // charts. The y-axis is always type:"value", which has no such option.
+      alignWithLabel: true,
+      length: 0.5,
+      lineStyle: { color: tickDotColor, width: 3, cap: "round" },
+    },
+    splitLine: { show: false },
+    axisLabel: {
+      show: !isLoading && xAxisSlot.present,
+      color: axisLabelColor,
+      fontSize: 10,
+      margin: 8,
+      formatter: xTickFormatter
+        ? (value: string, index: number) => xTickFormatter(value, index)
+        : undefined,
+    },
+  };
+
+  // An ECharts axis with `show: false` hides its splitLines too, but Recharts'
+  // <CartesianGrid> draws with or without a visible <YAxis>. Keep the axis on
+  // whenever <Grid/> is present and gate the LABELS on <YAxis/> instead.
+  const yAxis: YAxisOption = {
+    type: "value",
+    show: yAxisSlot.present || showGrid,
+    // Axis title — rendered rotated alongside the tick labels, same styling.
+    name: isLoading ? undefined : yAxisSlot.label,
+    nameLocation: "middle",
+    nameGap: 38,
+    nameTextStyle: { color: axisLabelColor, fontSize: 10 },
+    axisLine: { show: false },
+    // Same tick dots as the x-axis, beside each value label. No alignWithLabel
+    // here: ECharts types it on the CATEGORY axis only, and a value axis already
+    // puts its ticks on the labels.
+    axisTick: {
+      show: yAxisSlot.present && !isLoading && !yAxisSlot.hideDots,
+      length: 0.5,
+      lineStyle: { color: tickDotColor, width: 3, cap: "round" },
+    },
+    splitLine: {
+      // Hidden while loading — the skeleton floats on a clean canvas.
+      show: showGrid && !isLoading,
+      lineStyle: { color: splitLineColor, type: [3, 3] as [number, number], width: 1 },
+    },
+    axisLabel: {
+      // Hidden while loading — skeleton values are meaningless, and the
+      // Recharts YAxis unmounts during loading too.
+      show: yAxisSlot.present && !isLoading,
+      color: axisLabelColor,
+      fontSize: 10,
+      margin: 8,
+      formatter: yTickFormatter
+        ? (value: number, index: number) => yTickFormatter(value, index)
+        : undefined,
+    },
+  };
+
+  return { xAxis, yAxis };
+}
+
+// Tooltip HTML builder, closed over the build context. `trigger: "axis"` hands
+// the formatter every series' value at the hovered x; buffer overlays and the
+// mini/loading series are folded out here (see BUFFER_PREFIX).
+function createTooltipFormatter(ctx: OptionBuildContext) {
+  const { config, selectedDataKey, tooltipSlot, getHoveredKey } = ctx;
+
+  return (params: unknown): string => {
+    const rows = Array.isArray(params) ? params : [params];
+    if (!rows.length) return "";
+
+    const first = rows[0] as { axisValue?: string | number; name?: string };
+    // Label shows the RAW axis value — matches ChartTooltipContent (no tick formatter).
+    const axisValue = first.axisValue ?? first.name ?? "";
+    const label = String(axisValue);
+
+    // Dedupe by effective key: a buffer line contributes both its solid part
+    // (id=key) and its dashed overlay (id=`__buffer-{key}`) at the shared
+    // second-to-last point. Keep the first non-null value seen per key so the
+    // final point (only the overlay has data there) still shows its number.
+    const seen = new Set<string>();
+    const body = rows
+      .map((param) => {
+        const p = param as {
+          seriesId?: string;
+          seriesName?: string;
+          value?: number | string | null;
+        };
+        const rawId = String(p.seriesId ?? "");
+        // Map the dashed buffer overlay back onto its series; drop every other
+        // internal series (mini chart, loading skeleton).
+        const key = rawId.startsWith(BUFFER_PREFIX)
+          ? rawId.slice(BUFFER_PREFIX.length)
+          : rawId.startsWith("__")
+            ? ""
+            : (p.seriesId ?? p.seriesName ?? "");
+        if (!key) return "";
+        // A null value means this series does not reach the hovered x (a buffer
+        // line's solid part stops before the last point) — skip it, and let the
+        // overlay row for the same key stand in.
+        if (p.value === null || p.value === undefined) return "";
+        if (seen.has(key)) return "";
+        seen.add(key);
+
+        const item = config[key];
+        const colorsCount = item ? getColorsCount(item) : 1;
+        const labelText = typeof item?.label === "string" ? item.label : (p.seriesName ?? key);
+        const hovered = getHoveredKey();
+        const dimmed =
+          (selectedDataKey != null && selectedDataKey !== key) ||
+          (hovered != null && hovered !== key)
+            ? " opacity-30"
+            : "";
+        return tooltipRow({
+          indicatorHtml: tooltipIndicatorHtml(key, colorsCount),
+          labelText,
+          valueText: formatTooltipValue(p.value),
+          suffix: tooltipSlot.suffix,
+          dimmed,
+        });
+      })
+      .join("");
+
+    return tooltipShell({
+      label,
+      body,
+      roundness: tooltipSlot.roundness,
+      variant: tooltipSlot.variant,
+    });
+  };
+}
+
+function buildTooltipOption(ctx: OptionBuildContext): TooltipComponentOption {
+  const { tooltipSlot, isLoading } = ctx;
+  const { tokens } = ctx.resolved;
+
+  return {
+    ...tooltipBaseOption({
+      present: tooltipSlot.present && !isLoading,
+      cursor: tooltipSlot.cursor,
+      tokens,
+      position: tooltipSlot.position,
+      axisPointerColor: withAlpha(tokens.border, AXIS_POINTER_OPACITY),
+      strokeWidth: STROKE_WIDTH,
+    }),
+    formatter: createTooltipFormatter(ctx),
+  };
+}
+
+// ── Brush — the evil-brush "line" look, canvas-style: a real mini chart of the
+// full data (strokes only, no fill, like EvilBrush variant="line") in a second
+// grid, with a transparent slider dataZoom laid over it. Both zoom entries target
+// only the MAIN x-axis, so the mini chart never filters itself. Only called when
+// `showBrush` is set.
+function buildBrushOption(
+  ctx: OptionBuildContext,
+  brushBottom: number,
+): {
+  miniGrid: GridComponentOption;
+  miniXAxis: XAxisOption;
+  miniYAxis: YAxisOption;
+  miniSeries: LineSeriesOption[];
+  dataZoom: DataZoomComponentOption[];
+} {
+  const { data, lines, curveType, selectedDataKey, brushHeight, categories } = ctx;
+  const { tokens } = ctx.resolved;
+
+  const miniGrid: GridComponentOption = {
+    left: 8,
+    right: 8,
+    bottom: brushBottom,
+    height: brushHeight,
+    // No visible axes here — opt out of label containment so the mini chart
+    // spans the full brush frame.
+    outerBoundsMode: "none",
+  };
+
+  const miniXAxis: XAxisOption = {
+    type: "category",
+    gridIndex: 1,
+    boundaryGap: false,
+    show: false,
+    data: categories,
+    axisPointer: { show: false },
+  };
+
+  const miniYAxis: YAxisOption = { type: "value", gridIndex: 1, show: false };
+
+  const miniSeries: LineSeriesOption[] = lines.map((line) => {
+    const key = line.dataKey;
+    const base = (ctx.resolved.series[key] ?? [])[0] ?? "rgba(120, 120, 120, 1)";
+    const curve = curveConfig(line.curveType ?? curveType);
+
+    // The mini chart mirrors the click selection: unselected series recede
+    // by the same ratio as the main plot.
+    const strokeDim = getOpacity(selectedDataKey, key).stroke;
+
+    return {
+      id: `__mini-${key}`,
+      type: "line",
+      xAxisIndex: 1,
+      yAxisIndex: 1,
+      data: data.map((row) => Number(row[key]) || 0),
+      smooth: curve.smooth,
+      step: curve.step,
+      connectNulls: line.connectNulls,
+      silent: true,
+      showSymbol: false,
+      emphasis: { disabled: true },
+      tooltip: { show: false },
+      lineStyle: { color: base, width: 1, opacity: BRUSH_STROKE_OPACITY * strokeDim },
+      z: 0,
+    };
+  });
+
+  const dataZoom = buildBrushDataZoom({
+    brushBottom,
+    brushHeight,
+    brushRange: ctx.brushRange,
+    fillerColor: withAlpha(tokens.foreground, BRUSH_FILLER_OPACITY),
+  });
+
+  return { miniGrid, miniXAxis, miniYAxis, miniSeries, dataZoom };
+}
+
+// Loading skeleton — ONE gray wave regardless of declared lines (Recharts
+// parity: its skeleton is a single stroke-only LoadingLine), swept by the
+// shimmer rAF. No fill: a <Line> has no area, so the skeleton is stroke-only too.
+function buildLoadingOption(
+  ctx: OptionBuildContext,
+  frame: { grid: GridComponentOption; xAxis: XAxisOption; yAxis: YAxisOption },
+): EChartsOption {
+  const { tokens } = ctx.resolved;
+  const curve = curveConfig(ctx.curveType);
+
+  return {
+    animation: false,
+    grid: frame.grid,
+    xAxis: frame.xAxis,
+    yAxis: frame.yAxis,
+    tooltip: { show: false },
+    series: [
+      {
+        id: "__loading",
+        type: "line",
+        data: ctx.loadingData(),
+        smooth: curve.smooth,
+        step: curve.step,
+        showSymbol: false,
+        silent: true,
+        // Invisible until the first shimmer tick positions the clip window.
+        lineStyle: { color: withAlpha(tokens.foreground, 0), width: 1 },
+        z: 1,
+      },
+    ],
+  };
+}
+
+// The plotted values for a line, optionally decorated per-datum. Multi-color
+// lines tint each symbol with the gradient's color at its own x-position (like
+// the Recharts dots); single-color lines return the raw numbers. `null` entries
+// pass through untouched — they carve the gap a buffer line's two parts leave.
+type LinePoint =
+  | number
+  | null
+  | {
+      value: number | null;
+      itemStyle: DotItemStyleOption;
+      emphasis: { itemStyle: DotItemStyleOption };
+    };
+
+function buildLineSeries(ctx: OptionBuildContext): LineSeriesOption[] {
+  const {
+    data,
+    config,
+    lines,
+    curveType,
+    selectedDataKey,
+    hasSelection,
+    enableHoverHighlight,
+    enableHoverReveal,
+    revealIndex,
+    revealSink,
+    resolved,
+    rendererSize,
+  } = ctx;
+  const background = resolved.tokens.background;
+
+  return lines.flatMap((line): LineSeriesOption[] => {
+    const key = line.dataKey;
+    const slots = resolved.series[key] ?? ["rgba(120, 120, 120, 1)"];
+    const paint = seriesPaint(slots);
+    const isSelected = selectedDataKey === key;
+    const opacity = getOpacity(selectedDataKey, key);
+    const curve = curveConfig(line.curveType ?? curveType);
+    const multiColor = slots.length > 1;
+
+    const restingDot = dotStyle(line.dotVariant, paint, background);
+    const activeDot = dotStyle(line.activeDotVariant, paint, background);
+    const restingVisible = line.dotVariant !== "none";
+    const dotOpacity = opacity.dot;
+
+    const values = data.map((row) => Number(row[key]) || 0);
+    const n = values.length;
+    // Hover-reveal is a root-level mode and owns the whole line rendering, so it
+    // takes precedence over a per-line buffer tail (and the glow overlay) when
+    // both are set.
+    const reveal = enableHoverReveal;
+    const buffer = !reveal && line.enableBufferLine && n >= 2;
+    const revealActive = reveal && revealIndex !== null;
+
+    // The dash pattern for the MAIN line. A buffer line keeps its body solid and
+    // dashes only the tail overlay, so its main part is always solid regardless
+    // of strokeVariant (matches the Recharts twin, which suppresses the base
+    // dasharray while the buffer shape manages its own).
+    const mainDash: "solid" | [number, number] =
+      buffer || line.strokeVariant === "solid" ? "solid" : [3, 3];
+
+    // The reveal truncates the line to the cursor, which would COMPRESS a
+    // bbox-relative stroke gradient into the shorter span — misaligning it from
+    // the index-sampled dots. Anchor the stroke to the plot in absolute pixels so
+    // every x keeps its own color even when the line stops short.
+    const strokePaint =
+      reveal && multiColor
+        ? new echarts.graphic.LinearGradient(
+            8,
+            0,
+            Math.max(rendererSize.width - 8, 9),
+            0,
+            slots.map((color, i) => ({ offset: i / (slots.length - 1), color })),
+            true,
+          )
+        : paint;
+
+    // Turn a value list into ECharts data — attaching per-datum symbol colors
+    // for multi-color lines, and passing `null` gaps through so a buffer line's
+    // two parts each draw only their own segment.
+    const toPoints = (vals: (number | null)[]): LinePoint[] =>
+      !multiColor
+        ? vals
+        : vals.map((value, i): LinePoint => {
+            if (value === null) return null;
+            const t = vals.length > 1 ? i / (vals.length - 1) : 0;
+            const pointColor = sampleGradient(slots, t);
+            return {
+              value,
+              itemStyle: {
+                ...dotItemStyle(
+                  restingVisible ? line.dotVariant : line.activeDotVariant,
+                  pointColor,
+                  background,
+                ),
+                opacity: dotOpacity,
+              },
+              emphasis: {
+                itemStyle: {
+                  ...dotItemStyle(
+                    line.activeDotVariant === "none" ? "default" : line.activeDotVariant,
+                    pointColor,
+                    background,
+                  ),
+                  opacity: 1,
+                },
+              },
+            };
+          });
+
+    // Snapshot the FULL per-datum points (with the multi-color dot itemStyle) so
+    // the reveal hover handler can slice them without losing each dot's sampled
+    // gradient color — plain values would fall back to the default palette.
+    if (reveal) revealSink[key] = toPoints(values);
+
+    // Buffer line: the solid MAIN part drops the last point (its final segment
+    // becomes the dashed overlay). Reveal instead TRUNCATES the real series at the
+    // cursor's x-index (points beyond it null'd), so its line stops there and the
+    // muted base layer shows through past it. When idle (revealIndex null) the
+    // real series carries its full data — the chart looks completely normal.
+    const mainValues: (number | null)[] = buffer
+      ? values.map((v, i) => (i === n - 1 ? null : v))
+      : revealActive
+        ? sliceToNull(values, revealIndex as number)
+        : values;
+
+    const z = isSelected ? 3 : hasSelection ? 1 : 2;
+
+    // Glow overlays sit UNDER the real line (built first, same z; equal-z series
+    // paint in array order). They follow the FULL solid path so the halo stays
+    // continuous even beneath a dashed or buffer tail. Suppressed under reveal:
+    // a full-length colored halo would bleed past the cursor and defeat the mute.
+    const glowSeries =
+      line.glowing && !reveal
+        ? buildGlowSeries({
+            key,
+            paint,
+            slots,
+            values,
+            curve,
+            connectNulls: line.connectNulls,
+            z,
+            selectionDim: opacity.stroke,
+            dotSize: restingVisible ? restingDot.size : 0,
+          })
+        : [];
+
+    const mainSeries: LineSeriesOption = {
+      id: key,
+      name: typeof config[key]?.label === "string" ? config[key]?.label : key,
+      type: "line",
+      data: toPoints(mainValues),
+      smooth: curve.smooth,
+      step: curve.step,
+      connectNulls: line.connectNulls,
+      cursor: line.isClickable ? "pointer" : "default",
+      // By default ECharts only fires mouse events on the symbols — this makes
+      // the line itself clickable too, like the Recharts <Line>.
+      // (`true` covers both; the deprecated `triggerLineEvent` did the same.)
+      triggerEvent: line.isClickable,
+      showSymbol: restingVisible,
+      symbol: "circle",
+      symbolSize: restingVisible ? restingDot.size : activeDot.size,
+      z,
+      lineStyle: {
+        // Anchored plot-wide gradient while revealing a multi-color line (see
+        // strokePaint), the normal series paint otherwise.
+        color: strokePaint,
+        width: line.strokeWidth,
+        opacity: opacity.stroke,
+        type: mainDash,
+        dashOffset: 0,
+      },
+      itemStyle: multiColor
+        ? { opacity: dotOpacity }
+        : {
+            ...(restingVisible ? restingDot.itemStyle : activeDot.itemStyle),
+            opacity: dotOpacity,
+          },
+      emphasis: {
+        // focus "series" blurs every other series in this grid while one is
+        // hovered — the hover twin of the click selection (opt-in via
+        // enableHoverHighlight). Suppressed entirely while a series is
+        // click-selected: the selection dim owns the canvas, so hover
+        // highlighting stops until the selection clears (the option rebuilds on
+        // selection change, making this a build-time conditional). Reveal owns the
+        // hover visual, so native focus-blur stands down when it is on (they must
+        // not blend). Otherwise the active dot is the only emphasis.
+        focus: enableHoverHighlight && !enableHoverReveal && !hasSelection ? "series" : "none",
+        scale: restingVisible ? activeDot.size / Math.max(restingDot.size, 1) : 1,
+        ...(multiColor ? {} : { itemStyle: { ...activeDot.itemStyle, opacity: 1 } }),
+      },
+      // Blur styling mirrors the click-selection dim (stroke 0.3 / dot 0.3);
+      // inert unless a series is focused via enableHoverHighlight.
+      blur: {
+        lineStyle: { opacity: 0.3 },
+        itemStyle: { opacity: 0.3 },
+      },
+    };
+
+    // Hover-reveal: a muted gray BASE line of the FULL series sits one z below the
+    // real one. It is invisible while idle (opacity 0 → the chart looks normal)
+    // and fades in only while hovering, so the region PAST the cursor — where the
+    // truncated real line has stopped — shows as neutral gray. Lines have no fill,
+    // so the base is a line only (no areaStyle) and needs no stack mirror.
+    if (reveal) {
+      const muted = resolved.tokens.mutedForeground;
+      const revealBase: LineSeriesOption = {
+        id: `${REVEAL_PREFIX}${key}`,
+        type: "line",
+        // Only the region FROM the cursor onward (null before it), so the gray
+        // never sits under the colored part — the two meet exactly at the pointer
+        // and their colors can't mix.
+        data: revealActive ? sliceFrom(values, revealIndex as number) : values,
+        smooth: curve.smooth,
+        step: curve.step,
+        connectNulls: false,
+        silent: true,
+        showSymbol: false,
+        symbol: "circle",
+        z: z - 1,
+        // Neutral gray, SAME dash pattern as the colored line, no fill.
+        lineStyle: {
+          color: muted,
+          width: line.strokeWidth,
+          type: mainDash,
+          opacity: revealActive ? 0.3 : 0,
+        },
+        emphasis: { disabled: true },
+        blur: { lineStyle: { opacity: revealActive ? 0.3 : 0 } },
+        tooltip: { show: false },
+      };
+      return [revealBase, mainSeries];
+    }
+
+    if (!buffer) return [...glowSeries, mainSeries];
+
+    // Dashed forecast overlay — draws ONLY the last segment. Silent, so it never
+    // intercepts clicks/hover; it still feeds the axis tooltip (silent series
+    // are aggregated by axis), which is why the last point keeps its number.
+    const bufferValues: (number | null)[] = values.map((v, i) => (i >= n - 2 ? v : null));
+    const bufferSeries: LineSeriesOption = {
+      id: `${BUFFER_PREFIX}${key}`,
+      type: "line",
+      data: toPoints(bufferValues),
+      smooth: curve.smooth,
+      step: curve.step,
+      connectNulls: true,
+      silent: true,
+      showSymbol: restingVisible,
+      symbol: "circle",
+      symbolSize: restingVisible ? restingDot.size : activeDot.size,
+      z,
+      lineStyle: {
+        color: paint,
+        width: line.strokeWidth,
+        opacity: opacity.stroke,
+        type: BUFFER_DASH,
+      },
+      itemStyle: multiColor
+        ? { opacity: dotOpacity }
+        : {
+            ...(restingVisible ? restingDot.itemStyle : activeDot.itemStyle),
+            opacity: dotOpacity,
+          },
+      // The dashed tail is a separate silent series, so focus:"series" on its
+      // parent would blur it apart from the line it belongs to. The root
+      // dispatch-links this id (see companionIdsByKey) so it focuses WITH its
+      // parent; these styles give it the parent's look while focused and the
+      // click-selection dim while another series is hovered.
+      emphasis: {
+        focus: "none",
+        scale: false,
+        lineStyle: { opacity: opacity.stroke },
+        itemStyle: { opacity: dotOpacity },
+      },
+      blur: { lineStyle: { opacity: 0.3 }, itemStyle: { opacity: 0.3 } },
+    };
+
+    return [...glowSeries, mainSeries, bufferSeries];
+  });
+}
+
+// Copy a value list with everything AFTER `idx` nulled — the hover-reveal cut:
+// the colored real line keeps its data up to the cursor and drops the rest, so
+// (with connectNulls false) its stroke stops dead at the pointer.
+function sliceToNull<T>(vals: readonly T[], idx: number): (T | null)[] {
+  return vals.map((v, i) => (i > idx ? null : v));
+}
+
+// Copy a value list with everything BEFORE `idx` nulled — the reveal's gray tail.
+// The muted base keeps only the region from the cursor onward, so it never sits
+// under the colored part; both include `idx` so they meet at the pointer.
+// Generic so it preserves per-datum point objects (multi-color dot itemStyle).
+function sliceFrom<T>(vals: readonly T[], idx: number): (T | null)[] {
+  return vals.map((v, i) => (i < idx ? null : v));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live imperative state — everything the ECharts event handlers, rAF loops, and
+// theme/resize repushes read or write OUTSIDE the React render cycle, grouped in
+// one ref-stable object so the whole imperative surface is visible at a glance.
+// None of it is render output, which is exactly why it is not React state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LiveState = {
+  resolved: ResolvedColors | null; // colors read off the live DOM — feeds builds and rAF loops
+  hoveredKey: string | null; // tooltip's view of hover — the legend's twin lives in React state
+  hasRevealed: boolean; // the intro draw-in already played on this chart instance
+  revealEndsAt: number; // performance.now() timestamp when the entrance settles
+  loadingRows: number[] | null; // skeleton data, lazily rolled and re-rolled per shimmer sweep
+  categories: string[]; // x labels of the last build, for the brush label pills
+  dataLength: number; // row count, for the datazoom index math
+  brushRange: BrushRange; // live zoom window — carried through every rebuild
+  brushGeom: BrushGeometry | null; // brush footer layout of the last build
+  brushOverlay: BrushOverlayElements | null; // zrender elements, owned by syncBrushOverlay
+  brushHover: { inside: boolean; left: boolean; right: boolean };
+  // seriesIndex → clickable key for the last build, `undefined` for internal
+  // series. A line-body click (triggerEvent) reports only a seriesIndex, and
+  // buffer lines add a second (`__buffer-`) series per key — so the index no
+  // longer equals the key's position in seriesKeys and must be mapped explicitly.
+  seriesKeyByIndex: (string | undefined)[];
+  // key → its silent companion series ids (glow overlays + buffer tail) in the
+  // main grid. Under enableHoverHighlight the root highlights/downplays these
+  // together with the hovered parent, so focus:"series" can't strand a line's own
+  // glow or forecast tail apart from it.
+  companionIdsByKey: Map<string, string[]>;
+  revealIndex: number | null; // hover-reveal pointer x-index (null = idle); read by builds and the reveal hover handler
+  revealValues: Record<string, unknown[]>; // per-line FULL per-datum points (with dot itemStyle), sliced to the cursor on hover without a rebuild
+  // Latest callbacks/flags for the imperative ECharts event handlers.
+  handlers: {
+    onBrushChange?: (range: { startIndex: number; endIndex: number }) => void;
+    onSelectionChange?: (key: string | null) => void;
+    clickableKeys: Set<string>;
+    selectedDataKey: string | null;
+    brushFormatLabel?: (value: string, index: number) => string;
+    seriesKeys: string[];
+    enableHoverHighlight: boolean;
+    enableHoverReveal: boolean;
+  };
+  // Update-style re-push for paths that bypass React entirely (theme flips,
+  // resizes) — set by the sync effect.
+  repush: () => void;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Apache ECharts port of the EvilCharts line chart, exposing a compound-as-config
+ * API so its JSX reads identically to the Recharts twin. The root owns the data,
+ * config, selection state, loading skeleton, intro reveal, and optional zoom
+ * brush; every visual part — `<Line>`, `<XAxis>`, `<YAxis>`, `<Grid>`,
+ * `<Tooltip>`, `<Legend>` — is composed as a declarative child that renders
+ * nothing. The root walks those children by reference and drives a single
+ * imperative ECharts instance. Fully self-contained: its only dependencies are
+ * `react`, `echarts`, and `motion`.
+ */
+export function EChartsLineChart<TData extends Record<string, unknown>>({
+  data,
+  config,
+  xDataKey,
+  className,
+  curveType = "linear",
+  animation = true,
+  animationType = "left-to-right",
+  enableHoverHighlight = false,
+  enableHoverReveal = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+  isLoading = false,
+  loadingPoints = LOADING_DEFAULT_POINTS,
+  chartOptions,
+  children,
+}: EChartsLineChartProps<TData>) {
+  const rawId = useId();
+  const chartId = `chart-${rawId.replace(/:/g, "")}`;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<HTMLDivElement>(null);
+  const echartsRef = useRef<EChartsInstance | null>(null);
+
+  // The single imperative surface (see LiveState). `resolved` lives here rather
+  // than in state: as state it forced an extra render pass and an effect whose
+  // only job was to trigger the option push — the "chain of computations"
+  // react.dev/learn/you-might-not-need-an-effect warns about. The object
+  // identity is stable for the component's lifetime.
+  const live = useRef<LiveState>({
+    resolved: null,
+    hoveredKey: null,
+    hasRevealed: false,
+    revealEndsAt: 0,
+    loadingRows: null,
+    categories: [],
+    dataLength: 0,
+    brushRange: { start: 0, end: 100 },
+    brushGeom: null,
+    brushOverlay: null,
+    brushHover: { inside: false, left: false, right: false },
+    seriesKeyByIndex: [],
+    companionIdsByKey: new Map(),
+    revealIndex: null,
+    revealValues: {},
+    handlers: {
+      onBrushChange: undefined, // set per-render from the <Brush> child's onChange
+      onSelectionChange,
+      clickableKeys: new Set<string>(),
+      selectedDataKey: defaultSelectedDataKey,
+      brushFormatLabel: undefined, // set per-render from the <Brush> child's formatLabel
+      seriesKeys: [],
+      enableHoverHighlight,
+      enableHoverReveal,
+    },
+    repush: () => {},
+  }).current;
+
+  // Skeleton rows roll lazily on first use — an impure useRef initializer would
+  // re-roll Math.random() on every render.
+  const loadingData = useCallback(
+    () => (live.loadingRows ??= getLoadingData(loadingPoints)),
+    [live, loadingPoints],
+  );
+  const shouldReduceMotion = useReducedMotion();
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(defaultSelectedDataKey);
+
+  // Hover-highlight mirrors into the legend (React state) and tooltip
+  // (live.hoveredKey — its formatter runs on every hover, and pushing an option
+  // to sync it would reset ECharts' native blur state mid-hover).
+  const [hoveredDataKey, setHoveredDataKey] = useState<string | null>(null);
+
+  // ── Declarative config, collected from children by reference ─────────────────
+  const collected = useMemo(() => collectConfig(children), [children]);
+  const {
+    lines,
+    xAxis: xAxisSlot,
+    yAxis: yAxisSlot,
+    showGrid,
+    tooltip: tooltipSlot,
+    legend: legendSlot,
+    brush: brushSlot,
+  } = collected;
+  // Brush is a <Brush> child now (not props): presence turns it on, its props
+  // carry height/formatLabel/onChange.
+  const showBrush = brushSlot.present;
+  const brushHeight = brushSlot.height ?? 56;
+
+  const seriesKeys = useMemo(() => lines.map((line) => line.dataKey), [lines]);
+
+  // x category key: <XAxis dataKey> → root xDataKey → first data column no <Line> claims.
+  const xCategoryKey = useMemo(() => {
+    if (xAxisSlot.dataKey) return xAxisSlot.dataKey;
+    if (xDataKey) return xDataKey as string;
+    const firstRow = data[0];
+    if (firstRow) {
+      const claimed = new Set(seriesKeys);
+      const found = Object.keys(firstRow).find((key) => !claimed.has(key));
+      if (found) return found;
+    }
+    return "";
+  }, [xAxisSlot.dataKey, xDataKey, data, seriesKeys]);
+
+  // The intro draw-in follows the first line's setting, falling back to the root default.
+  const effectiveAnimation = lines[0]?.animationType ?? animationType;
+
+  const css = useMemo(() => buildChartCss(chartId, config), [chartId, config]);
+
+  const hasSelection = selectedDataKey !== null;
+
+  // Which series may be clicked to toggle selection (consulted by the click handler).
+  const clickableKeys = useMemo(
+    () => new Set(lines.filter((line) => line.isClickable).map((line) => line.dataKey)),
+    [lines],
+  );
+
+  // Refresh the handlers' snapshot of the latest callbacks/flags every render.
+  live.handlers = {
+    onBrushChange: brushSlot.onChange,
+    onSelectionChange,
+    clickableKeys,
+    selectedDataKey,
+    brushFormatLabel: brushSlot.formatLabel,
+    seriesKeys,
+    enableHoverHighlight,
+    enableHoverReveal,
+  };
+  live.dataLength = data.length;
+
+  const toggleSelection = useCallback(
+    (key: string) => {
+      // A new click selection takes over the canvas dim, so any live hover
+      // highlight is torn down at this moment — the mouseover guard then keeps it
+      // from re-arming while the selection stands. Hover is only ever active
+      // while NO selection exists (see that guard), so a hovered key here always
+      // means this click is establishing a selection.
+      if (live.hoveredKey !== null) {
+        const chart = echartsRef.current;
+        const companions = chart ? live.companionIdsByKey.get(live.hoveredKey) : undefined;
+        if (chart && companions) {
+          for (const seriesId of companions) chart.dispatchAction({ type: "downplay", seriesId });
+        }
+        live.hoveredKey = null;
+        setHoveredDataKey(null);
+      }
+      setSelectedDataKey((prev) => {
+        const next = prev === key ? null : key;
+        onSelectionChange?.(next);
+        return next;
+      });
+    },
+    [live, onSelectionChange],
+  );
+
+  // Reposition the brush overlays from the live refs — safe to call from drag
+  // events, hover tracking, and pushes alike, since it never touches setOption.
+  const syncBrushOverlayNow = useCallback(() => {
+    const chart = echartsRef.current;
+    if (!chart) return;
+
+    const geom = live.brushGeom;
+    const tokens = live.resolved?.tokens;
+    if (!geom || !tokens) {
+      syncBrushOverlay(chart, live, null);
+      return;
+    }
+
+    const range = live.brushRange;
+    const categories = live.categories;
+    const format = live.handlers.brushFormatLabel;
+    const lastIndex = Math.max(categories.length - 1, 0);
+    const startIndex = Math.round((range.start / 100) * lastIndex);
+    const endIndex = Math.round((range.end / 100) * lastIndex);
+    const labels =
+      format && categories.length
+        ? {
+            start: format(categories[startIndex] ?? "", startIndex),
+            end: format(categories[endIndex] ?? "", endIndex),
+          }
+        : null;
+
+    syncBrushOverlay(chart, live, {
+      range,
+      geom,
+      size: { width: chart.getWidth(), height: chart.getHeight() },
+      tokens,
+      labels,
+      showLabels: live.brushHover.inside,
+      hover: live.brushHover,
+    });
+  }, [live]);
+
+  // ── Option builder ─────────────────────────────────────────────────────────
+  // Thin orchestrator over the pure builders above: snapshot the imperative
+  // surface (refs, renderer size) into an OptionBuildContext, then assemble.
+  const buildOption = useCallback((): EChartsOption => {
+    const resolved = live.resolved;
+    if (!resolved) return {};
+
+    const categories = data.map((row) => String(row[xCategoryKey]));
+    live.categories = categories;
+
+    // buildLineSeries fills this with each line's full per-datum points (with the
+    // multi-color dot itemStyle) so the reveal hover handler slices real data.
+    const revealSink: Record<string, unknown[]> = {};
+
+    const ctx: OptionBuildContext = {
+      data,
+      config,
+      lines,
+      curveType,
+      selectedDataKey,
+      hasSelection,
+      showGrid,
+      xAxisSlot,
+      yAxisSlot,
+      tooltipSlot,
+      legendSlot,
+      isLoading,
+      loadingData,
+      showBrush,
+      brushHeight,
+      enableHoverHighlight,
+      enableHoverReveal,
+      revealIndex: live.revealIndex,
+      revealSink,
+      resolved,
+      rendererSize: {
+        width: echartsRef.current?.getWidth() ?? mountRef.current?.clientWidth ?? 0,
+        height: echartsRef.current?.getHeight() ?? mountRef.current?.clientHeight ?? 0,
+      },
+      categories,
+      brushRange: live.brushRange,
+      getHoveredKey: () => live.hoveredKey,
+    };
+
+    const { grid, brushBottom } = buildChartLayout(ctx);
+    live.brushGeom = showBrush ? { bottom: brushBottom, height: brushHeight } : null;
+
+    const { xAxis, yAxis } = buildMainAxes(ctx);
+
+    if (isLoading) return buildLoadingOption(ctx, { grid, xAxis, yAxis });
+
+    const brush = showBrush ? buildBrushOption(ctx, brushBottom) : null;
+
+    const series = [...buildLineSeries(ctx), ...(brush?.miniSeries ?? [])];
+    // buildLineSeries has now filled revealSink with each line's full per-datum
+    // points — hand them to the hover handler for slicing.
+    if (enableHoverReveal) live.revealValues = revealSink;
+    // Record the exact series order so a line-body click (which reports only a
+    // seriesIndex) can recover its key — buffer/reveal/mini/loading series break
+    // the "index === key position" shortcut, so map each index to its id here.
+    live.seriesKeyByIndex = series.map((s) => {
+      const id = String(s.id ?? "");
+      return id && !id.startsWith("__") ? id : undefined;
+    });
+    // Map each key to its silent companion series ids (glow overlays, buffer tail,
+    // hover-reveal base), mirroring exactly what buildLineSeries emits — the hover
+    // handlers highlight/downplay these together with the parent so focus:"series"
+    // never strands a line's own glow or forecast tail apart from it.
+    const companionIdsByKey = new Map<string, string[]>();
+    for (const line of lines) {
+      const ids: string[] = [];
+      if (line.glowing) {
+        for (let i = 0; i < GLOW_LAYERS.length; i++) ids.push(`__glow-${i}-${line.dataKey}`);
+      }
+      if (line.enableBufferLine && data.length >= 2) ids.push(`${BUFFER_PREFIX}${line.dataKey}`);
+      if (enableHoverReveal) ids.push(`${REVEAL_PREFIX}${line.dataKey}`);
+      if (ids.length) companionIdsByKey.set(line.dataKey, ids);
+    }
+    live.companionIdsByKey = companionIdsByKey;
+
+    return {
+      animation: false,
+      grid: brush ? [grid, brush.miniGrid] : grid,
+      xAxis: brush ? [xAxis, brush.miniXAxis] : xAxis,
+      yAxis: brush ? [yAxis, brush.miniYAxis] : yAxis,
+      tooltip: buildTooltipOption(ctx),
+      dataZoom: brush?.dataZoom,
+      series,
+    };
+  }, [
+    live,
+    data,
+    config,
+    lines,
+    xCategoryKey,
+    curveType,
+    selectedDataKey,
+    hasSelection,
+    showGrid,
+    xAxisSlot,
+    yAxisSlot,
+    tooltipSlot,
+    legendSlot,
+    isLoading,
+    loadingData,
+    showBrush,
+    brushHeight,
+    enableHoverHighlight,
+    enableHoverReveal,
+  ]);
+
+  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  useEffect(() => {
+    const mount = mountRef.current;
+    const container = containerRef.current;
+    if (!mount || !container) return;
+
+    const chart = echarts.init(mount);
+    echartsRef.current = chart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Observers always fire once right after observe(). Repushing on that
+      // no-op fire would land one frame into the intro and stomp the line's
+      // reveal clip — only react when the renderer size actually changed.
+      if (mount.clientWidth === chart.getWidth() && mount.clientHeight === chart.getHeight()) {
+        return;
+      }
+      chart.resize();
+      live.repush();
+    });
+    resizeObserver.observe(mount);
+
+    // Light/dark flips change no React state — re-resolve and push directly.
+    const themeObserver = new MutationObserver(() => {
+      live.repush();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    chart.on("click", (params) => {
+      const { clickableKeys: clickable } = live.handlers;
+      const p = params as { seriesId?: string; seriesIndex?: number };
+      // Symbol clicks carry seriesId; line clicks (triggerEvent) only carry
+      // seriesIndex — recover the key from the last build's index map, which
+      // accounts for the extra `__buffer-`/`__mini-` series interleaved between
+      // the main ones (a raw seriesKeys lookup would land on the wrong key).
+      const id =
+        p.seriesId ??
+        (typeof p.seriesIndex === "number" ? live.seriesKeyByIndex[p.seriesIndex] : undefined);
+      if (typeof id === "string" && clickable.has(id)) toggleSelection(id);
+    });
+
+    // Hover-highlight bookkeeping — the canvas blur is ECharts-native
+    // (emphasis.focus:"series" + blur), but the HTML legend and tooltip need to
+    // know which series is hovered, and the silent glow/buffer overlays must be
+    // focus-linked to their parent (they are separate series, so focus:"series"
+    // would otherwise blur a line's own glow or forecast tail).
+    chart.on("mouseover", (params) => {
+      const { enableHoverHighlight: hoverOn, enableHoverReveal: revealOn } = live.handlers;
+      // Reveal owns the hover visual, so native highlight stands down while it is on.
+      if (!hoverOn || revealOn) return;
+      // While a series is click-selected, hover highlighting is disabled — the
+      // selection dim owns the canvas, so never arm hover emphasis/blur (or the
+      // legend/tooltip hover dimming) until the selection clears.
+      if (live.handlers.selectedDataKey !== null) return;
+      const p = params as { seriesId?: string; seriesIndex?: number; componentType?: string };
+      if (p.componentType !== "series") return;
+      const id =
+        p.seriesId ??
+        (typeof p.seriesIndex === "number" ? live.seriesKeyByIndex[p.seriesIndex] : undefined);
+      if (typeof id !== "string" || id.startsWith("__")) return;
+      live.hoveredKey = id;
+      setHoveredDataKey(id);
+      const companions = live.companionIdsByKey.get(id);
+      if (companions) {
+        for (const seriesId of companions) chart.dispatchAction({ type: "highlight", seriesId });
+      }
+    });
+    chart.on("mouseout", () => {
+      const prev = live.hoveredKey;
+      if (prev === null) return;
+      live.hoveredKey = null;
+      setHoveredDataKey(null);
+      const companions = live.companionIdsByKey.get(prev);
+      if (companions) {
+        for (const seriesId of companions) chart.dispatchAction({ type: "downplay", seriesId });
+      }
+    });
+
+    // Hover-reveal: color each line up to the pointer's x-index, mute the rest.
+    // Purely TARGETED series updates (real series data + muted base opacity) — we
+    // NEVER rebuild the whole option on mousemove, which would replay transitions
+    // and fight the tooltip's axis pointer.
+    const zrReveal = chart.getZr();
+    const pushReveal = (idx: number | null) => {
+      const keys = live.handlers.seriesKeys;
+      const on = idx !== null;
+      chart.setOption(
+        {
+          series: keys.flatMap((key) => [
+            {
+              id: key,
+              data: on
+                ? sliceToNull(live.revealValues[key] ?? [], idx)
+                : (live.revealValues[key] ?? []),
+            },
+            {
+              id: `${REVEAL_PREFIX}${key}`,
+              // Gray tail keeps only the region from the cursor onward.
+              data: on
+                ? sliceFrom(live.revealValues[key] ?? [], idx)
+                : (live.revealValues[key] ?? []),
+              lineStyle: { opacity: on ? 0.3 : 0 },
+            },
+          ]),
+        },
+        // NOT lazy: the highlight dispatched just below re-draws the active dot
+        // the setOption wipes, so the option must be committed first — a queued
+        // (lazy) update would land after the dispatch and erase the dot again.
+        { silent: true },
+      );
+      // The per-frame setOption above cancels the axis tooltip's transient hover
+      // symbol, so the <ActiveDot> never lands at the cursor. Re-assert it:
+      // highlighting a real series at the cursor index draws its emphasis symbol
+      // (the active dot) even with showSymbol:false; downplay clears it on exit.
+      for (const key of keys) {
+        chart.dispatchAction(
+          on
+            ? { type: "highlight", seriesId: key, dataIndex: idx as number }
+            : { type: "downplay", seriesId: key },
+        );
+      }
+    };
+    const clearReveal = () => {
+      if (live.revealIndex === null) return;
+      live.revealIndex = null;
+      pushReveal(null);
+    };
+    const applyReveal = (event: { offsetX?: number; offsetY?: number }) => {
+      const len = live.dataLength;
+      if (len < 1) return;
+      const x = event.offsetX ?? -1;
+      const y = event.offsetY ?? -1;
+      if (!chart.containPixel({ gridIndex: 0 }, [x, y])) {
+        clearReveal();
+        return;
+      }
+      const raw = chart.convertFromPixel({ gridIndex: 0 }, [x, y])[0]!;
+      const idx = Math.max(0, Math.min(len - 1, Math.round(raw)));
+      if (idx === live.revealIndex) return;
+      live.revealIndex = idx;
+      pushReveal(idx);
+    };
+    const onZrRevealMove = (event: { offsetX?: number; offsetY?: number }) => {
+      if (!live.handlers.enableHoverReveal) return;
+      applyReveal(event);
+    };
+    const onZrRevealOut = () => {
+      if (live.handlers.enableHoverReveal) clearReveal();
+    };
+    zrReveal.on("mousemove", onZrRevealMove);
+    zrReveal.on("globalout", onZrRevealOut);
+
+    chart.on("datazoom", () => {
+      const option = chart.getOption() as { dataZoom?: { start?: number; end?: number }[] };
+      const zoom = option.dataZoom?.[0];
+      if (!zoom) return;
+
+      // Ride the selection — pure zrender updates, so the drag stays 1:1.
+      live.brushRange = { start: zoom.start ?? 0, end: zoom.end ?? 100 };
+      syncBrushOverlayNow();
+
+      const { onBrushChange: onChange } = live.handlers;
+      if (!onChange) return;
+      const len = live.dataLength;
+      const startIndex = Math.round(((zoom.start ?? 0) / 100) * (len - 1));
+      const endIndex = Math.round(((zoom.end ?? 100) / 100) * (len - 1));
+      onChange({ startIndex, endIndex });
+    });
+
+    // Hover tracking for the overlay: labels show while the pointer is over the
+    // brush, and each pill brightens when the pointer is near its edge.
+    const zr = chart.getZr();
+    const applyHover = (next: { inside: boolean; left: boolean; right: boolean }) => {
+      const prev = live.brushHover;
+      if (prev.inside === next.inside && prev.left === next.left && prev.right === next.right) {
+        return;
+      }
+      live.brushHover = next;
+      syncBrushOverlayNow();
+    };
+    const onZrMove = (event: { offsetX?: number; offsetY?: number }) => {
+      const geom = live.brushGeom;
+      if (!geom) return;
+      const x = event.offsetX ?? -1;
+      const y = event.offsetY ?? -1;
+      const top = chart.getHeight() - geom.bottom - geom.height;
+      const inside = y >= top - 4 && y <= top + geom.height + 4;
+      const trackLeft = 8;
+      const trackWidth = Math.max(chart.getWidth() - 16, 1);
+      const { start, end } = live.brushRange;
+      const selectionLeft = trackLeft + (trackWidth * start) / 100;
+      const selectionRight = trackLeft + (trackWidth * end) / 100;
+      applyHover({
+        inside,
+        left: inside && Math.abs(x - selectionLeft) <= 8,
+        right: inside && Math.abs(x - selectionRight) <= 8,
+      });
+    };
+    const onZrOut = () => applyHover({ inside: false, left: false, right: false });
+    zr.on("mousemove", onZrMove);
+    zr.on("globalout", onZrOut);
+
+    return () => {
+      zrReveal.off("mousemove", onZrRevealMove);
+      zrReveal.off("globalout", onZrRevealOut);
+      zr.off("mousemove", onZrMove);
+      zr.off("globalout", onZrOut);
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      chart.dispose();
+      echartsRef.current = null;
+      // The overlay elements died with the zrender instance.
+      live.brushOverlay = null;
+      // The reveal guard belongs to the chart instance it guarded. Without this
+      // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
+      // the throwaway instance and the surviving one renders without it.
+      live.hasRevealed = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    const container = containerRef.current;
+    if (!chart || !container) return;
+
+    // Colors come from the <style> committed just before this effect ran — read
+    // them here, right before the push, rather than round-tripping through state.
+    live.resolved = resolveColors(container, config, seriesKeys);
+
+    const push = (withEntrance: boolean) => {
+      const option = buildOption();
+      const merged = chartOptions ? { ...option, ...chartOptions } : option;
+      Object.assign(merged, {
+        animation: withEntrance,
+        animationDuration: REVEAL_DURATION,
+        animationDurationUpdate: 0,
+      });
+      // chartOptions is an untyped escape hatch — the spread erases the option's
+      // shape, so re-assert it. The only cast in the file.
+      chart.setOption(merged as EChartsOption, { notMerge: true });
+      // Overlays live outside the option — reposition them after every push.
+      syncBrushOverlayNow();
+    };
+
+    // Intro reveal — ECharts' native progressive draw, enabled only for the first
+    // real render: the line traces in, dots pop up as its front passes. Every
+    // later push (selection, theme, zoom) applies instantly, since notMerge would
+    // otherwise replay the entrance on each of them. A loading cycle re-arms it:
+    // the Recharts twin unmounts its <Line>s while loading and replays the intro
+    // on remount, so data → loading → data draws in again here too.
+    if (isLoading) live.hasRevealed = false;
+    const shouldReveal = !live.hasRevealed && !isLoading;
+    if (shouldReveal) live.hasRevealed = true;
+    const revealEnabled =
+      animation && shouldReveal && effectiveAnimation !== "none" && !shouldReduceMotion;
+    if (revealEnabled) live.revealEndsAt = performance.now() + REVEAL_DURATION;
+    push(revealEnabled);
+
+    // Theme flips and resizes re-enter here without touching React: re-read the
+    // tokens (the .dark class changed, or the renderer resized) and push an
+    // update-style option.
+    live.repush = () => {
+      live.resolved = resolveColors(container, config, seriesKeys);
+      push(false);
+    };
+  }, [
+    live,
+    buildOption,
+    chartOptions,
+    isLoading,
+    animation,
+    effectiveAnimation,
+    shouldReduceMotion,
+    config,
+    seriesKeys,
+    syncBrushOverlayNow,
+  ]);
+
+  // ── Animated dashed stroke — rAF sweeps the dash offset while unselected ─────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || isLoading) return;
+    const animatedKeys = lines
+      // A buffer line's body is solid (only its tail dashes), so the sweep skips it.
+      .filter((line) => line.strokeVariant === "animated-dashed" && !line.enableBufferLine)
+      .map((line) => line.dataKey);
+    if (animatedKeys.length === 0 || hasSelection) return;
+
+    let raf = 0;
+    let delayTimer: ReturnType<typeof setTimeout> | undefined;
+    const begin = () => {
+      const loopStart = performance.now();
+      const tick = (now: number) => {
+        const offset = -(((now - loopStart) / 1000) % 1) * 6; // 0 → -6 per second
+        chart.setOption(
+          { series: animatedKeys.map((id) => ({ id, lineStyle: { dashOffset: offset } })) },
+          { silent: true, lazyUpdate: true },
+        );
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    };
+
+    // Per-frame setOption churn fights the intro draw-in (each update pass
+    // recomputes the reveal clip, crawling it to a standstill) — hold the dash
+    // sweep until the entrance has finished.
+    const delay = Math.max(0, live.revealEndsAt - performance.now());
+    if (delay > 0) delayTimer = setTimeout(begin, delay + 50);
+    else begin();
+
+    return () => {
+      if (delayTimer !== undefined) clearTimeout(delayTimer);
+      cancelAnimationFrame(raf);
+    };
+  }, [live, lines, hasSelection, isLoading]);
+
+  // ── Loading shimmer — rAF sweeps a bright band, regenerating data off-screen ─
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || !isLoading) return;
+
+    let raf = 0;
+    let lastPhase = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const phase = ((((now - start) / LOADING_ANIMATION_DURATION) % 1) + 1) % 1;
+      // Wrapped past 1 → the band is off-screen; swap in fresh random data.
+      if (phase < lastPhase) live.loadingRows = getLoadingData(loadingPoints);
+      lastPhase = phase;
+
+      // Read tokens per frame, so a theme flip mid-loading retints the shimmer.
+      const foreground = live.resolved?.tokens.foreground ?? "rgba(120, 120, 120, 1)";
+      // Sweep the clip window from fully off-screen left to fully off-screen
+      // right, leaned 45°. The gradient uses ABSOLUTE pixel coordinates so the
+      // window lands at the same place along the stroke regardless of the wave's
+      // bounding box.
+      const w = chart.getWidth();
+      const h = chart.getHeight();
+      if (!w || !h) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      // Farthest plot corner projected onto the 45° axis — keeps the sweep
+      // tight instead of dawdling off-plot at the end of each loop.
+      const maxT = (w + h) / (2 * w);
+      const center = phase * (maxT + 2 * LOADING_SHIMMER_BAND) - LOADING_SHIMMER_BAND;
+      const clip = (peak: number) =>
+        new echarts.graphic.LinearGradient(
+          0,
+          0,
+          w,
+          w,
+          shimmerWindowStops(center, foreground, peak),
+          true,
+        );
+      chart.setOption(
+        {
+          series: [
+            {
+              id: "__loading",
+              data: loadingData(),
+              lineStyle: { color: clip(LOADING_STROKE_OPACITY), width: 1 },
+            },
+          ],
+        },
+        { silent: true, lazyUpdate: true },
+      );
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [live, isLoading, loadingPoints, loadingData]);
+
+  // ── Legend overlay position ──────────────────────────────────────────────────
+  // Insets match the Recharts legend's breathing room inside the plot frame.
+  const legendStyle: CSSProperties = {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    pointerEvents: "auto",
+    ...(legendSlot.verticalAlign === "top"
+      ? { top: 12 }
+      : legendSlot.verticalAlign === "bottom"
+        ? { bottom: showBrush ? brushHeight + 16 : 12 }
+        : { top: "50%", transform: "translateY(-50%)" }),
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      data-chart={chartId}
+      className={`relative flex flex-col text-xs ${className ?? ""}`}
+    >
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+
+      <div className="relative min-h-0 w-full flex-1">
+        <div ref={mountRef} className="h-full min-h-0 w-full" />
+      </div>
+
+      {legendSlot.present && !isLoading && (
+        <LegendOverlay
+          seriesKeys={seriesKeys}
+          config={config}
+          variant={legendSlot.variant}
+          align={legendSlot.align}
+          verticalAlign={legendSlot.verticalAlign}
+          selectedKey={selectedDataKey}
+          hoveredKey={hoveredDataKey}
+          isClickable={legendSlot.isClickable}
+          onToggle={toggleSelection}
+          style={legendStyle}
+        />
+      )}
+
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+          <motion.div
+            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+            className="flex items-center justify-center gap-2 rounded-md border bg-background px-2 py-0.5 text-sm text-primary"
+          >
+            <div className="h-3 w-3 animate-spin rounded-full border border-border border-t-primary" />
+            <span>Loading</span>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Compound API: every part hangs off the root as a static member, so a consumer
+// writes <EChartsLineChart.Line/>, <EChartsLineChart.Tooltip/>, … from a single
+// import — no colliding named marker exports when several charts share one file.
+EChartsLineChart.Line = Line;
+EChartsLineChart.Dot = Dot;
+EChartsLineChart.ActiveDot = ActiveDot;
+EChartsLineChart.XAxis = XAxis;
+EChartsLineChart.YAxis = YAxis;
+EChartsLineChart.Grid = Grid;
+EChartsLineChart.Tooltip = Tooltip;
+EChartsLineChart.Legend = Legend;
+EChartsLineChart.Brush = Brush;

--- a/packages/charts/src/components/evilcharts/charts/echarts-pie-chart.tsx
+++ b/packages/charts/src/components/evilcharts/charts/echarts-pie-chart.tsx
@@ -1,0 +1,1227 @@
+"use client";
+
+import type { ComposeOption } from "echarts/core";
+
+import {
+  buildChartCss,
+  getColorsCount,
+  resolveColors,
+  withAlpha,
+  type ChartConfig,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+import {
+  LegendOverlay,
+  type LegendVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-legend";
+import {
+  formatTooltipValue,
+  resolveTooltipPosition,
+  roundnessClass,
+  tooltipIndicatorHtml,
+  tooltipRow,
+  tooltipVariantClass,
+  type TooltipPosition,
+  type TooltipRoundness,
+  type TooltipVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-tooltip";
+import { PieChart, type PieSeriesOption } from "echarts/charts";
+import { TooltipComponent, type TooltipComponentOption } from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { motion, useReducedMotion } from "motion/react";
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FC,
+  type ReactNode,
+} from "react";
+
+// Re-export the shared types that were previously declared inline here, so
+// existing consumers/examples keep importing them from the chart module.
+export type { ChartConfig, LegendVariant, TooltipPosition, TooltipRoundness, TooltipVariant };
+
+// Modular registration keeps the bundle lean — only the pieces this chart needs.
+// A pie has no coordinate system, so there is no GridComponent and no axes; the
+// tooltip is item-triggered. Never register GraphicComponent: the loading shimmer
+// and selection dim are per-sector itemStyle updates, not graphic overlays.
+echarts.use([PieChart, TooltipComponent, CanvasRenderer]);
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+// The exact option surface this chart uses — a pie series plus the tooltip
+// component. Narrower than echarts' full EChartsOption, so a misspelled key fails
+// the compile instead of silently reaching setOption.
+type EChartsOption = ComposeOption<PieSeriesOption | TooltipComponentOption>;
+
+// Sector paint — structurally assignable to a pie datum's itemStyle. `color`
+// accepts the same solid-or-gradient value sectorPaint returns, and the optional
+// border fields carry the constant-width gap / overlap separator.
+type PieItemStyle = {
+  color: string | echarts.graphic.LinearGradient;
+  opacity: number;
+  borderRadius: number;
+  borderColor?: string;
+  borderWidth?: number;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REVEAL_DURATION = 1000; // intro draw-in length, in milliseconds (ECharts' default)
+// NOTE: the intro is ECharts' RAW default pie entrance (`animationType: "expansion"`
+// — sectors sweep out from the start angle). We only gate whether it plays; we do
+// not customize its easing, matching the area chart's "raw default" policy.
+const LOADING_ANIMATION_DURATION = 2000; // shimmer loop, in milliseconds
+const LOADING_SECTORS = 5; // skeleton sector count — Recharts twin uses 5 equal sectors
+
+const DEFAULT_INNER_RADIUS: number | string = 0;
+const DEFAULT_OUTER_RADIUS: number | string = "80%";
+const DEFAULT_CORNER_RADIUS = 0;
+const DEFAULT_PADDING_ANGLE = 0;
+const DEFAULT_START_ANGLE = 0;
+const DEFAULT_END_ANGLE = 360;
+
+const FALLBACK_COLOR = "rgba(120, 120, 120, 1)";
+
+// Overlapping sectors (negative paddingAngle) get a background-colored border to
+// separate the petals — the canvas analogue of the Recharts twin's
+// `stroke="var(--background)" strokeWidth={5}`.
+const OVERLAP_BORDER_WIDTH = 5;
+
+// Selecting a sector pops it radially OUTWARD from the center — the offset-slice
+// look from the official ECharts pie-pattern example. This is the pixel distance
+// the chosen sector translates along its own bisector; deselecting returns it.
+const SELECTED_OFFSET = 12;
+
+// The selected sector stays fully opaque; the others recede to this dimmed
+// opacity. Tuned to ~half the former 0.3 so the selected sector reads with more
+// contrast against the dimmed ones — the analogue of the area chart's dim-fill
+// halving (its dimmed fill went 0.2 → 0.1 while the selected state stays full).
+const DIMMED_OPACITY = 0.15;
+
+// Positive gaps between sectors are drawn as a CONSTANT-WIDTH background-colored
+// border (px), NOT an angular padAngle. An angular pad tapers to a wedge toward
+// the center; a border keeps every gap parallel-edged all the way from the rim to
+// the center. The px width tracks the requested `paddingAngle` for familiar sizing.
+function gapBorderWidth(paddingAngle: number): number {
+  return Math.max(paddingAngle, 0);
+}
+
+// Resolves each sector's separator border. Negative paddingAngle keeps the
+// overlapping-petal look (a real angular overlap plus a wide separator); positive
+// paddingAngle becomes a constant-width gap; zero draws no border at all.
+function sectorBorder(
+  paddingAngle: number,
+  background: string,
+): { borderColor: string; borderWidth: number } | null {
+  if (paddingAngle < 0) return { borderColor: background, borderWidth: OVERLAP_BORDER_WIDTH };
+  const width = gapBorderWidth(paddingAngle);
+  if (width > 0) return { borderColor: background, borderWidth: width };
+  return null;
+}
+
+// Loading shimmer opacities (× the foreground token's own alpha). A sine-feathered
+// window sweeps around the ring, brightening each sector from base → peak as it
+// passes — the angular twin of the area chart's swept clip window, and a match for
+// the Recharts twin's staggered sector pulse.
+const LOADING_BASE_OPACITY = 0.15; // resting sector fill, × foreground alpha
+const LOADING_PEAK_OPACITY = 0.5; // fill inside the sweep window, × foreground alpha
+const LOADING_SHIMMER_BAND = 0.28; // window half-width, fraction of the ring (0..1)
+const LOADING_SHIMMER_FEATHER = 0.22; // sine-eased edge softening of the window
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The pie has a single fill style — a per-sector color gradient. Kept as a named
+// union for API parity with the Recharts twin (and room to grow).
+export type PieVariant = "gradient";
+// Where sector labels sit: "inside" draws value text on the sector (the default),
+// "outside" moves the sector's name past the rim with a leader line, matching the
+// classic ECharts pie (echarts.apache.org/examples/en/editor.html?c=pie-simple).
+export type LabelPosition = "inside" | "outside";
+// TooltipVariant, TooltipRoundness, TooltipPosition, LegendVariant, and ChartConfig
+// now live in the shared @/registry/ui/echarts/* modules and are imported +
+// re-exported at the top of this file.
+export type BackgroundVariant =
+  | "dots"
+  | "grid"
+  | "cross-hatch"
+  | "diagonal-lines"
+  | "plus"
+  | "falling-triangles"
+  | "4-pointed-star"
+  | "tiny-checkers"
+  | "overlapping-circles"
+  | "wiggle-lines"
+  | "bubbles";
+
+export interface EChartsPieChartProps<TData extends Record<string, unknown>> {
+  data: TData[]; // rows rendered by the chart — one sector each
+  config: ChartConfig; // sector colors + labels, keyed by the sector name
+  dataKey: keyof TData & string; // key holding each sector's numeric value
+  nameKey: keyof TData & string; // key holding each sector's name
+  className?: string; // extra classes for the chart container
+  // Master switch for the intro draw-in. Not present on the Recharts twin (which
+  // hardcodes its animation); added here as the canvas off-switch, mirroring the
+  // ECharts area chart's `animation` prop. OS reduce-motion also disables it.
+  animation?: boolean;
+  defaultSelectedSector?: string | null; // sector selected on first render
+  selectedSector?: string | null; // controlled selection — overrides internal state when set
+  onSelectionChange?: (selection: { dataKey: string; value: number } | null) => void; // fires when the selected sector changes
+  isLoading?: boolean; // shows the animated loading skeleton
+  chartOptions?: Record<string, unknown>; // escape hatch merged over the built ECharts option
+  children?: ReactNode; // declarative config — <Pie>, <Tooltip>, <Legend>, <Background>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Composible parts — DECLARATIVE CONFIG. Every part renders `null`; the root
+// walks `children` by reference (child.type === Pie, …) to collect its props.
+// Presence semantics mirror the Recharts twin: omit a child and that part does
+// not render. These are never mounted into the tree — they only carry props.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PieProps {
+  variant?: PieVariant; // fill style for the pie's sectors
+  innerRadius?: number | string; // inner radius — set above 0 for a donut
+  outerRadius?: number | string; // outer radius of the pie
+  cornerRadius?: number; // border-radius of each sector in pixels
+  paddingAngle?: number; // gap between sectors in degrees — negative overlaps them
+  startAngle?: number; // angle the pie starts drawing from
+  endAngle?: number; // angle the pie stops drawing at
+  isClickable?: boolean; // lets sectors be selected by clicking them — the selected sector pops outward
+  children?: ReactNode; // optional <Label> composition for sector labels
+}
+
+/**
+ * The pie series. Declares its own shape (radii, angles, corner rounding,
+ * padding) and clickability. Renders nothing — the root reads these props to
+ * build the ECharts pie. When clickable, the selected sector pops radially
+ * outward. Compose a <Label> inside it to draw labels on each sector.
+ */
+const Pie: FC<PieProps> = () => null;
+
+export interface LabelProps {
+  dataKey?: string; // data key for the label text — defaults to the pie's value key
+  position?: LabelPosition; // "inside" (value on the sector) or "outside" (name past the rim, with a leader line)
+}
+
+/** Declares per-sector labels for the enclosing <Pie>. Renders nothing. */
+const Label: FC<LabelProps> = () => null;
+
+export interface TooltipProps {
+  variant?: TooltipVariant; // visual style of the tooltip surface
+  roundness?: TooltipRoundness; // border-radius of the tooltip
+  defaultIndex?: number; // sector index shown by default with no hover
+  position?: TooltipPosition; // "variable" follows the pointer (default); "fixed" pins the tooltip near the top and tracks the pointer's X
+}
+
+/** Presence enables the hover tooltip. Renders nothing. */
+const Tooltip: FC<TooltipProps> = () => null;
+
+export interface LegendProps {
+  variant?: LegendVariant; // visual style of the legend indicators
+  align?: "left" | "center" | "right"; // horizontal placement
+  verticalAlign?: "top" | "middle" | "bottom"; // vertical placement
+  isClickable?: boolean; // lets each entry toggle selection of its sector
+}
+
+/** Presence enables the HTML legend overlay. Renders nothing. */
+const Legend: FC<LegendProps> = () => null;
+
+export interface BackgroundProps {
+  variant?: BackgroundVariant; // background pattern style
+}
+
+/** Presence draws a decorative SVG pattern behind the pie. Renders nothing. */
+const Background: FC<BackgroundProps> = () => null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Children collection — walk the declarative config into plain objects the
+// option builder consumes. <Label> is read from the <Pie>'s own children; a
+// missing <Label> means sector labels do not render.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type PieSlot = {
+  variant: PieVariant;
+  innerRadius: number | string;
+  outerRadius: number | string;
+  cornerRadius: number;
+  paddingAngle: number;
+  startAngle: number;
+  endAngle: number;
+  isClickable: boolean;
+  labelDataKey: string | null; // null when no <Label> child is present
+  labelPosition: LabelPosition; // where the <Label> sits — only meaningful when labelDataKey !== null
+};
+
+type TooltipSlot = {
+  present: boolean;
+  variant: TooltipVariant;
+  roundness: TooltipRoundness;
+  defaultIndex?: number;
+  position: TooltipPosition;
+};
+type LegendSlot = {
+  present: boolean;
+  variant: LegendVariant;
+  align: "left" | "center" | "right";
+  verticalAlign: "top" | "middle" | "bottom";
+  isClickable: boolean;
+};
+type BackgroundSlot = { present: boolean; variant: BackgroundVariant };
+
+type CollectedConfig = {
+  pie: PieSlot | null;
+  tooltip: TooltipSlot;
+  legend: LegendSlot;
+  background: BackgroundSlot;
+};
+
+function collectConfig(children: ReactNode): CollectedConfig {
+  let pie: PieSlot | null = null;
+  let tooltip: TooltipSlot = {
+    present: false,
+    variant: "default",
+    roundness: "lg",
+    position: "variable",
+  };
+  // Pie legend defaults differ from the area chart's: centered along the bottom.
+  let legend: LegendSlot = {
+    present: false,
+    variant: "rounded-square",
+    align: "center",
+    verticalAlign: "bottom",
+    isClickable: false,
+  };
+  let background: BackgroundSlot = { present: false, variant: "dots" };
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const type = child.type;
+
+    if (type === Pie) {
+      const props = child.props as PieProps;
+      // A <Label> child (if any) declares per-sector labels.
+      let labelDataKey: string | null = null;
+      let labelPosition: LabelPosition = "inside";
+      Children.forEach(props.children, (labelChild) => {
+        if (!isValidElement(labelChild) || labelChild.type !== Label) return;
+        const labelProps = labelChild.props as LabelProps;
+        labelDataKey = labelProps.dataKey ?? "";
+        labelPosition = labelProps.position ?? "inside";
+      });
+      pie = {
+        variant: props.variant ?? "gradient",
+        innerRadius: props.innerRadius ?? DEFAULT_INNER_RADIUS,
+        outerRadius: props.outerRadius ?? DEFAULT_OUTER_RADIUS,
+        cornerRadius: props.cornerRadius ?? DEFAULT_CORNER_RADIUS,
+        paddingAngle: props.paddingAngle ?? DEFAULT_PADDING_ANGLE,
+        startAngle: props.startAngle ?? DEFAULT_START_ANGLE,
+        endAngle: props.endAngle ?? DEFAULT_END_ANGLE,
+        isClickable: props.isClickable ?? false,
+        labelDataKey,
+        labelPosition,
+      };
+    } else if (type === Tooltip) {
+      const props = child.props as TooltipProps;
+      tooltip = {
+        present: true,
+        variant: props.variant ?? "default",
+        roundness: props.roundness ?? "lg",
+        defaultIndex: props.defaultIndex,
+        position: props.position ?? "variable",
+      };
+    } else if (type === Legend) {
+      const props = child.props as LegendProps;
+      legend = {
+        present: true,
+        variant: props.variant ?? "rounded-square",
+        align: props.align ?? "center",
+        verticalAlign: props.verticalAlign ?? "bottom",
+        isClickable: props.isClickable ?? false,
+      };
+    } else if (type === Background) {
+      const props = child.props as BackgroundProps;
+      background = { present: true, variant: props.variant ?? "dots" };
+    }
+  });
+
+  return { pie, tooltip, legend, background };
+}
+
+// Color plumbing (ChartConfig, getColorsCount, buildChartCss, withAlpha,
+// ResolvedColors, resolveColors) now lives in @/registry/ui/echarts-chart and is
+// imported at the top of this file. The pie keeps its own DIAGONAL sectorPaint
+// below (the shared seriesPaint is a horizontal gradient).
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sector fill
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Per-sector fill: a solid color for a single-color config, else a diagonal
+// top-left → bottom-right gradient across the sector's own bounding box. This
+// mirrors the Recharts twin's `RadialColorGradient` (a `linearGradient` with
+// x1/y1 = 0 and x2/y2 = 1). ECharts gradients are bbox-relative by default —
+// exactly what a per-sector gradient wants — so no `global` override is needed.
+function sectorPaint(slots: string[]): string | echarts.graphic.LinearGradient {
+  if (slots.length <= 1) return slots[0] ?? FALLBACK_COLOR;
+  const stops = slots.map((color, i) => ({ offset: i / (slots.length - 1), color }));
+  return new echarts.graphic.LinearGradient(0, 0, 1, 1, stops);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loading skeleton helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Per-sector shimmer alpha: a sine-feathered window centered on `center` (both
+// values are ring fractions in [0, 1)). Sectors inside the window read at
+// `LOADING_PEAK_OPACITY`, outside at `LOADING_BASE_OPACITY`, with a sine falloff
+// across the feather so the sweep edge isn't a hard cut. Distance wraps around
+// the ring — the highlight travels continuously, like the Recharts twin's pulse.
+function loadingSectorAlpha(pos: number, center: number): number {
+  const raw = Math.abs(pos - center);
+  const dist = Math.min(raw, 1 - raw); // shortest way around the ring
+  const half = LOADING_SHIMMER_BAND;
+  const feather = LOADING_SHIMMER_FEATHER;
+
+  if (dist >= half) return LOADING_BASE_OPACITY;
+  if (dist <= half - feather) return LOADING_PEAK_OPACITY;
+  // Sine-eased ramp — a linear one still reads as a hard cut.
+  const t = 1 - (dist - (half - feather)) / feather;
+  const eased = Math.sin((t * Math.PI) / 2);
+  return LOADING_BASE_OPACITY + (LOADING_PEAK_OPACITY - LOADING_BASE_OPACITY) * eased;
+}
+
+// Tooltip styling (roundnessClass, tooltipVariantClass, tooltipRow,
+// tooltipIndicatorHtml) and the legend overlay (LegendOverlay + its indicators)
+// now live in @/registry/ui/echarts/{tooltip,legend} and are imported at the top
+// of this file.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Background overlay (SVG) — the Recharts twin renders its decorative pattern in
+// SVG, so we render the SAME SVG patterns as a layer BEHIND the transparent
+// ECharts canvas. Copied verbatim from the repo's <ChartBackground> so this file
+// depends on nothing outside `react`, `echarts`, and `motion`. The Tailwind
+// `text-border` classes resolve in the DOM; the blur-masked rect fades the edges.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type PatternProps = { id: string };
+
+const BACKGROUND_PATTERNS: Record<BackgroundVariant, FC<PatternProps>> = {
+  dots: ({ id }) => (
+    <pattern id={id} x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <circle className="text-border" cx="2" cy="2" r="1" fill="currentColor" />
+    </pattern>
+  ),
+  grid: ({ id }) => (
+    <pattern id={id} x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        d="M 20 0 L 0 0 0 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  ),
+  "cross-hatch": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border/60 dark:text-border/50"
+        d="M 0 0 L 20 20 M 20 0 L 0 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  ),
+  "diagonal-lines": ({ id }) => (
+    <pattern
+      id={id}
+      x="0"
+      y="0"
+      width="6"
+      height="6"
+      patternUnits="userSpaceOnUse"
+      patternTransform="rotate(45)"
+    >
+      <line
+        className="text-border"
+        x1="0"
+        y1="0"
+        x2="0"
+        y2="6"
+        stroke="currentColor"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  ),
+  plus: ({ id }) => (
+    <pattern id={id} x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        d="M 8 4 L 8 12 M 4 8 L 12 8"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.5"
+        strokeLinecap="round"
+      />
+    </pattern>
+  ),
+  "falling-triangles": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="18" height="36" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        d="M2 6h12L8 18 2 6zm18 36h12l-6 12-6-12z"
+        transform="scale(0.5)"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  ),
+  "4-pointed-star": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <polygon
+        className="text-border"
+        fillRule="evenodd"
+        points="5 3 8 4 5 5 4 8 3 5 0 4 3 3 4 0 5 3"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  ),
+  "tiny-checkers": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="8" height="8" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        fillRule="evenodd"
+        d="M0 0h4v4H0V0zm4 4h4v4H4V4z"
+        fill="currentColor"
+        fillOpacity="0.2"
+      />
+    </pattern>
+  ),
+  "overlapping-circles": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        fillRule="evenodd"
+        d="M25 25c0-2.762 2.238-5 5-5s5 2.238 5 5-2.238 5-5 5c0 2.762-2.238 5-5 5s-5-2.238-5-5 2.238-5 5-5zM5 5c0-2.762 2.238-5 5-5s5 2.238 5 5-2.238 5-5 5c0 2.762-2.238 5-5 5S0 12.762 0 10s2.238-5 5-5zm5 4c2.209 0 4-1.791 4-4s-1.791-4-4-4-4 1.791-4 4 1.791 4 4 4zm20 20c2.209 0 4-1.791 4-4s-1.791-4-4-4-4 1.791-4 4 1.791 4 4 4z"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  ),
+  "wiggle-lines": ({ id }) => (
+    <pattern
+      id={id}
+      x="0"
+      y="0"
+      width="52"
+      height="26"
+      patternUnits="userSpaceOnUse"
+      patternTransform="scale(0.6)"
+    >
+      <path
+        className="text-border"
+        d="M10 10c0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6h2c0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4v2c-3.314 0-6-2.686-6-6 0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6zm25.464-1.95l8.486 8.486-1.414 1.414-8.486-8.486 1.414-1.414z"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  ),
+  bubbles: ({ id }) => (
+    <pattern
+      id={id}
+      x="0"
+      y="0"
+      width="100"
+      height="100"
+      patternUnits="userSpaceOnUse"
+      patternTransform="scale(0.6667)"
+    >
+      <path
+        className="text-border"
+        d="M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM12 86c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm28-65c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm23-11c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-6 60c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm29 22c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zM32 63c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm57-13c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-9-21c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM60 91c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM35 41c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM12 60c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2z"
+        fill="currentColor"
+        fillOpacity="0.4"
+        fillRule="evenodd"
+      />
+    </pattern>
+  ),
+};
+
+function BackgroundLayer({ variant }: { variant: BackgroundVariant }) {
+  const baseId = useId().replace(/:/g, "");
+  const patternId = `${baseId}-bg-${variant}`;
+  const maskId = `${baseId}-bg-edge-fade`;
+  const filterId = `${baseId}-bg-blur`;
+  const PatternComponent = BACKGROUND_PATTERNS[variant];
+
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 h-full w-full"
+      aria-hidden
+      preserveAspectRatio="none"
+    >
+      <defs>
+        <PatternComponent id={patternId} />
+        {/* Gaussian blur for a soft edge fade — a slightly inset white rect blurred
+            into a mask leaves smooth transparent edges. */}
+        <filter id={filterId}>
+          <feGaussianBlur stdDeviation="25" />
+        </filter>
+        <mask id={maskId} maskUnits="userSpaceOnUse">
+          <rect x="8%" y="20%" width="85%" height="60%" fill="white" filter={`url(#${filterId})`} />
+        </mask>
+      </defs>
+      <rect width="100%" height="100%" fill={`url(#${patternId})`} mask={`url(#${maskId})`} />
+    </svg>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option builders — pure functions from a snapshot context to ECharts option
+// fragments. The component reads its refs ONCE per build into this context;
+// nothing below touches React state or the chart instance.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OptionBuildContext = {
+  data: Record<string, unknown>[];
+  config: ChartConfig;
+  nameKey: string;
+  dataKey: string;
+  pie: PieSlot | null;
+  selectedSector: string | null;
+  tooltipSlot: TooltipSlot;
+  legendSlot: LegendSlot;
+  isLoading: boolean;
+  resolved: ResolvedColors;
+};
+
+// The pie's vertical centre reserves room for the HTML legend overlay: a legend
+// along the bottom nudges the pie up, one along the top nudges it down. Kept as a
+// percentage so it tracks the container size (the legend is fixed-height text).
+function pieCenterY(legendSlot: LegendSlot): string {
+  if (!legendSlot.present) return "50%";
+  if (legendSlot.verticalAlign === "bottom") return "45%";
+  if (legendSlot.verticalAlign === "top") return "55%";
+  return "50%";
+}
+
+// Tooltip HTML builder, closed over the build context. The pie tooltip is
+// item-triggered, so each hover surfaces exactly one sector — its indicator,
+// label, and value, matching ChartTooltipContent with `hideLabel` (no header).
+function createTooltipFormatter(ctx: OptionBuildContext) {
+  const { config, selectedSector, tooltipSlot } = ctx;
+
+  return (params: unknown): string => {
+    const p = (Array.isArray(params) ? params[0] : params) as {
+      name?: string;
+      value?: number | string;
+      seriesId?: string;
+    } | null;
+    // The loading skeleton is a `__`-prefixed series and never surfaces a tooltip.
+    if (!p || String(p.seriesId ?? "").startsWith("__")) return "";
+
+    const name = String(p.name ?? "");
+    const item = config[name];
+    const colorsCount = item ? getColorsCount(item) : 1;
+    const labelText = typeof item?.label === "string" ? item.label : name;
+    const dimmed = selectedSector != null && selectedSector !== name ? " opacity-30" : "";
+
+    // The row shape matches the area chart's indicator + label + value, so it
+    // reuses the shared tooltipRow/tooltipIndicatorHtml. The pie tooltip is
+    // item-triggered with NO header (hideLabel), so it keeps its own no-header
+    // shell — built from the shared roundnessClass/tooltipVariantClass — rather
+    // than the header-carrying tooltipShell.
+    const row = tooltipRow({
+      indicatorHtml: tooltipIndicatorHtml(name, colorsCount),
+      labelText,
+      valueText: formatTooltipValue(p.value),
+      dimmed,
+    });
+
+    return `<div class="grid min-w-32 items-start gap-1.5 border border-border/50 px-2.5 py-1.5 text-xs shadow-xl ${roundnessClass[tooltipSlot.roundness]} ${tooltipVariantClass[tooltipSlot.variant]}">
+      <div class="grid gap-1.5">${row}</div>
+    </div>`;
+  };
+}
+
+function buildTooltipOption(ctx: OptionBuildContext): TooltipComponentOption {
+  const { tooltipSlot, isLoading } = ctx;
+  // The pie tooltip is item-triggered (no axis, no cursor line), so it can't use
+  // the shared tooltipBaseOption (which is trigger:"axis" with an axisPointer).
+  // It keeps its own item-tooltip fields and wires the position prop directly
+  // through the shared resolveTooltipPosition — "variable" → undefined (default
+  // follow-the-pointer behavior), "fixed" → pinned near the top, tracking X.
+  return {
+    show: tooltipSlot.present && !isLoading,
+    trigger: "item",
+    confine: true,
+    backgroundColor: "transparent",
+    borderWidth: 0,
+    padding: 0,
+    extraCssText: "box-shadow:none;",
+    position: resolveTooltipPosition(tooltipSlot.position),
+    formatter: createTooltipFormatter(ctx),
+  };
+}
+
+// The pie series. Each row becomes a sector whose fill is its own color gradient,
+// dimmed when another sector is selected, and separated from its neighbors by a
+// constant-width background border (see sectorBorder). The selected sector pops
+// radially outward via ECharts' native select state (selectedOffset).
+function buildPieSeries(ctx: OptionBuildContext): PieSeriesOption[] {
+  const { data, config, nameKey, dataKey, pie, selectedSector, legendSlot, resolved } = ctx;
+  if (!pie) return [];
+  const { tokens } = resolved;
+  const hasSelection = selectedSector !== null;
+  // Selection (dim + pop-out) is only meaningful on a clickable pie.
+  const border = sectorBorder(pie.paddingAngle, tokens.background);
+
+  const sectors = data.map((row) => {
+    const name = String(row[nameKey]);
+    const slots = resolved.series[name] ?? [FALLBACK_COLOR];
+    // Only a clickable pie dims — a static one never has a selection to dim from.
+    const isSelected = pie.isClickable && selectedSector === name;
+    const isDimmed = pie.isClickable && hasSelection && selectedSector !== name;
+
+    const itemStyle: PieItemStyle = {
+      color: sectorPaint(slots),
+      opacity: isDimmed ? DIMMED_OPACITY : 1,
+      borderRadius: pie.cornerRadius,
+    };
+    // Constant-width background gap (positive paddingAngle) or overlap separator
+    // (negative). Parallel-edged from rim to center — no wedge-shaped taper.
+    if (border) {
+      itemStyle.borderColor = border.borderColor;
+      itemStyle.borderWidth = border.borderWidth;
+    }
+
+    // The `selected` flag drives the native offset — React selection is the single
+    // source of truth, re-applied on every notMerge push so it survives rebuilds.
+    return { name, value: Number(row[dataKey]) || 0, itemStyle, selected: isSelected };
+  });
+
+  const showLabel = pie.labelDataKey !== null;
+  const isOutside = pie.labelPosition === "outside";
+  // An explicit <Label dataKey> always wins. Otherwise inside labels show the
+  // sector's value (Recharts parity) and outside labels show the sector's name/
+  // config label — matching the classic ECharts pie-simple outer labels.
+  const explicitKey = pie.labelDataKey ? pie.labelDataKey : null;
+  const labelFormatter = (labelParams: { dataIndex: number; name?: string; value?: unknown }) => {
+    if (explicitKey) return String(data[labelParams.dataIndex]?.[explicitKey] ?? "");
+    if (isOutside) {
+      const item = config[String(labelParams.name ?? "")];
+      return typeof item?.label === "string" ? item.label : String(labelParams.name ?? "");
+    }
+    return String(data[labelParams.dataIndex]?.[dataKey] ?? labelParams.value ?? "");
+  };
+
+  const label = {
+    show: showLabel,
+    // Inner value labels sit on the colored sector (background-colored text);
+    // outer name labels sit past the rim in muted-foreground with a leader.
+    position: (isOutside ? "outside" : "inner") as "outside" | "inner",
+    color: isOutside ? tokens.mutedForeground : tokens.background,
+    fontSize: 12,
+    fontWeight: 500,
+    formatter: labelFormatter,
+  };
+
+  return [
+    {
+      id: "pie",
+      type: "pie",
+      center: ["50%", pieCenterY(legendSlot)],
+      radius: [pie.innerRadius, pie.outerRadius],
+      startAngle: pie.startAngle,
+      endAngle: pie.endAngle,
+      // Recharts sweeps counterclockwise from 3 o'clock; ECharts angles share that
+      // orientation, so `clockwise: false` reproduces the twin's sector order.
+      clockwise: false,
+      // Only a NEGATIVE paddingAngle reaches padAngle (petal overlap). Positive
+      // gaps are drawn as constant-width borders instead — an angular pad would
+      // taper to a wedge toward the center.
+      padAngle: Math.min(pie.paddingAngle, 0),
+      cursor: pie.isClickable ? "pointer" : "default",
+      // No hover scale on ANY variant — hovering only surfaces the tooltip. The
+      // pop-out below is the sole selection affordance, never a hover effect.
+      emphasis: { scale: false },
+      // Native select state: the chosen sector translates SELECTED_OFFSET px along
+      // its bisector, away from the center (the offset-slice pie-pattern look).
+      // Driven by each datum's `selected` flag; deselecting returns it.
+      selectedMode: pie.isClickable ? "single" : false,
+      selectedOffset: SELECTED_OFFSET,
+      // Neutralize any default select styling — the selected sector keeps its
+      // normal paint (inherited via state merge) and only its position moves.
+      select: { itemStyle: {} },
+      label,
+      labelLine: isOutside
+        ? {
+            show: true,
+            length: 14,
+            length2: 14,
+            smooth: false,
+            // Leader lines drawn in a muted token, matching the docs aesthetic.
+            lineStyle: { color: withAlpha(tokens.mutedForeground, 0.45), width: 1 },
+          }
+        : { show: false },
+      data: sectors,
+    },
+  ];
+}
+
+// Loading skeleton — ONE gray ring of equal sectors regardless of the real data
+// (Recharts parity), swept by the shimmer rAF. Respects the pie's shape so a
+// donut skeleton stays a donut. The per-sector color is a placeholder; the rAF
+// loop retints each sector every frame.
+function buildLoadingOption(ctx: OptionBuildContext): EChartsOption {
+  const { pie, legendSlot, resolved } = ctx;
+  const { tokens } = resolved;
+
+  const innerRadius = pie?.innerRadius ?? DEFAULT_INNER_RADIUS;
+  const outerRadius = pie?.outerRadius ?? DEFAULT_OUTER_RADIUS;
+  const cornerRadius = pie?.cornerRadius ?? DEFAULT_CORNER_RADIUS;
+  const paddingAngle = pie?.paddingAngle ?? DEFAULT_PADDING_ANGLE;
+  const startAngle = pie?.startAngle ?? DEFAULT_START_ANGLE;
+  const endAngle = pie?.endAngle ?? DEFAULT_END_ANGLE;
+
+  const border = sectorBorder(paddingAngle, tokens.background);
+  const sectors = Array.from({ length: LOADING_SECTORS }, (_, i) => {
+    const itemStyle: PieItemStyle = {
+      color: withAlpha(tokens.foreground, LOADING_BASE_OPACITY),
+      opacity: 1,
+      borderRadius: cornerRadius,
+    };
+    // Same constant-width gap / overlap separator as the real pie.
+    if (border) {
+      itemStyle.borderColor = border.borderColor;
+      itemStyle.borderWidth = border.borderWidth;
+    }
+    return { name: `__loading-${i}`, value: 1, itemStyle };
+  });
+
+  return {
+    animation: false,
+    tooltip: { show: false },
+    series: [
+      {
+        id: "__loading",
+        type: "pie",
+        center: ["50%", pieCenterY(legendSlot)],
+        radius: [innerRadius, outerRadius],
+        startAngle,
+        endAngle,
+        clockwise: false,
+        padAngle: Math.min(paddingAngle, 0),
+        silent: true,
+        emphasis: { scale: false },
+        label: { show: false },
+        labelLine: { show: false },
+        data: sectors,
+      },
+    ],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live imperative state — everything the ECharts event handlers and rAF loops
+// read or write OUTSIDE the React render cycle, grouped in one ref-stable object
+// so the whole imperative surface is visible at a glance. None of it is render
+// output, which is exactly why it is not React state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LiveState = {
+  resolved: ResolvedColors | null; // colors read off the live DOM — feeds builds and rAF loops
+  hasRevealed: boolean; // the intro draw-in already played on this chart instance
+  // Latest callbacks/flags for the imperative ECharts click handler.
+  handlers: {
+    isClickable: boolean;
+    selectedSector: string | null;
+    selectSector: (name: string | null) => void;
+  };
+  // Update-style re-push for paths that bypass React entirely (theme flips) —
+  // set by the sync effect.
+  repush: () => void;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Apache ECharts port of the EvilCharts pie chart, exposing a compound-as-config
+ * API so its JSX reads identically to the Recharts twin. The root owns the data,
+ * config, selection state, loading skeleton, and intro reveal; every visual part —
+ * `<Pie>`, `<Tooltip>`, `<Legend>`, `<Background>` — is composed as a declarative
+ * child that renders nothing. The root walks those children by reference and
+ * drives a single imperative ECharts instance. Fully self-contained: its only
+ * dependencies are `react`, `echarts`, and `motion`.
+ */
+export function EChartsPieChart<TData extends Record<string, unknown>>({
+  data,
+  config,
+  dataKey,
+  nameKey,
+  className,
+  animation = true,
+  defaultSelectedSector = null,
+  selectedSector: selectedSectorProp,
+  onSelectionChange,
+  isLoading = false,
+  chartOptions,
+  children,
+}: EChartsPieChartProps<TData>) {
+  const rawId = useId();
+  const chartId = `chart-${rawId.replace(/:/g, "")}`;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<HTMLDivElement>(null);
+  const echartsRef = useRef<EChartsInstance | null>(null);
+
+  // The single imperative surface (see LiveState). `resolved` lives here rather
+  // than in state: as state it would force an extra render pass and an effect
+  // whose only job is to trigger the option push. The object identity is stable
+  // for the component's lifetime.
+  const live = useRef<LiveState>({
+    resolved: null,
+    hasRevealed: false,
+    handlers: {
+      isClickable: false,
+      selectedSector: defaultSelectedSector,
+      selectSector: () => {},
+    },
+    repush: () => {},
+  }).current;
+
+  const shouldReduceMotion = useReducedMotion();
+
+  // Selection is controlled when the `selectedSector` prop is provided; otherwise
+  // the internal state (seeded by defaultSelectedSector) drives it.
+  const [internalSelectedSector, setSelectedSector] = useState<string | null>(
+    defaultSelectedSector,
+  );
+  const selectedSector =
+    selectedSectorProp !== undefined ? selectedSectorProp : internalSelectedSector;
+
+  // ── Declarative config, collected from children by reference ─────────────────
+  const collected = useMemo(() => collectConfig(children), [children]);
+  const { pie, tooltip: tooltipSlot, legend: legendSlot, background: backgroundSlot } = collected;
+
+  // Sector names in data order — the keys color resolution, the legend, and the
+  // click handler all agree on. Config is keyed by these same names.
+  const sectorKeys = useMemo(
+    () => data.map((row) => String(row[nameKey as string])),
+    [data, nameKey],
+  );
+
+  const css = useMemo(() => buildChartCss(chartId, config), [chartId, config]);
+
+  // Sets selection state and notifies the parent with the sector's value.
+  const selectSector = useCallback(
+    (name: string | null) => {
+      setSelectedSector(name);
+      if (name === null) {
+        onSelectionChange?.(null);
+        return;
+      }
+      const item = data.find((row) => String(row[nameKey as string]) === name);
+      onSelectionChange?.(
+        item ? { dataKey: name, value: Number(item[dataKey as string]) || 0 } : null,
+      );
+    },
+    [data, dataKey, nameKey, onSelectionChange],
+  );
+
+  // Refresh the click handler's snapshot of the latest callbacks/flags every render.
+  live.handlers = {
+    isClickable: pie?.isClickable ?? false,
+    selectedSector,
+    selectSector,
+  };
+
+  // ── Option builder ───────────────────────────────────────────────────────────
+  // Thin orchestrator over the pure builders above: snapshot the resolved colors
+  // into an OptionBuildContext, then assemble.
+  const buildOption = useCallback((): EChartsOption => {
+    const resolved = live.resolved;
+    if (!resolved) return {};
+
+    const ctx: OptionBuildContext = {
+      data,
+      config,
+      nameKey: nameKey as string,
+      dataKey: dataKey as string,
+      pie,
+      selectedSector,
+      tooltipSlot,
+      legendSlot,
+      isLoading,
+      resolved,
+    };
+
+    if (isLoading) return buildLoadingOption(ctx);
+
+    return {
+      animation: false,
+      tooltip: buildTooltipOption(ctx),
+      series: buildPieSeries(ctx),
+    };
+  }, [
+    live,
+    data,
+    config,
+    nameKey,
+    dataKey,
+    pie,
+    selectedSector,
+    tooltipSlot,
+    legendSlot,
+    isLoading,
+  ]);
+
+  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  useEffect(() => {
+    const mount = mountRef.current;
+    const container = containerRef.current;
+    if (!mount || !container) return;
+
+    const chart = echarts.init(mount);
+    echartsRef.current = chart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Observers always fire once right after observe(). Repushing on that no-op
+      // fire would land one frame into the intro and stomp the reveal — only
+      // react when the renderer size actually changed. The pie has no
+      // renderer-sized textures, so a plain resize() (which re-lays the
+      // percentage geometry) is all a size change needs.
+      if (mount.clientWidth === chart.getWidth() && mount.clientHeight === chart.getHeight()) {
+        return;
+      }
+      chart.resize();
+    });
+    resizeObserver.observe(mount);
+
+    // Light/dark flips change no React state — re-resolve and push directly.
+    const themeObserver = new MutationObserver(() => {
+      live.repush();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    chart.on("click", (params) => {
+      const { isClickable, selectedSector: selected, selectSector: select } = live.handlers;
+      if (!isClickable) return;
+      const p = params as { name?: string; seriesId?: string };
+      // Ignore the loading skeleton's `__`-prefixed series.
+      if (String(p.seriesId ?? "").startsWith("__")) return;
+      const name = p.name;
+      if (typeof name !== "string") return;
+      // Clicking the selected sector clears the selection, otherwise selects it.
+      select(selected === name ? null : name);
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      chart.dispose();
+      echartsRef.current = null;
+      // The reveal guard belongs to the chart instance it guarded. Without this
+      // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
+      // the throwaway instance and the surviving one renders without it.
+      live.hasRevealed = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    const container = containerRef.current;
+    if (!chart || !container) return;
+
+    // Colors come from the <style> committed just before this effect ran — read
+    // them here, right before the push, rather than round-tripping through state.
+    live.resolved = resolveColors(container, config, sectorKeys);
+
+    const push = (withEntrance: boolean) => {
+      const option = buildOption();
+      const merged = chartOptions ? { ...option, ...chartOptions } : option;
+      Object.assign(merged, {
+        animation: withEntrance,
+        animationDuration: REVEAL_DURATION,
+        animationDurationUpdate: 0,
+      });
+      // chartOptions is an untyped escape hatch — the spread erases the option's
+      // shape, so re-assert it. The only cast in the file.
+      chart.setOption(merged as EChartsOption, { notMerge: true });
+    };
+
+    // Intro reveal — ECharts' native pie expansion, enabled only for the first
+    // real render. Every later push (selection, theme) applies instantly, since
+    // notMerge would otherwise replay the entrance on each. A loading cycle
+    // re-arms it: the Recharts twin remounts its sectors after loading and
+    // replays the intro, so data → loading → data draws in again here too.
+    if (isLoading) live.hasRevealed = false;
+    const shouldReveal = !live.hasRevealed && !isLoading;
+    if (shouldReveal) live.hasRevealed = true;
+    const revealEnabled = animation && shouldReveal && !shouldReduceMotion;
+    push(revealEnabled);
+
+    // Theme flips re-enter here without touching React: re-read the tokens (the
+    // .dark class changed) and push an update-style option.
+    live.repush = () => {
+      live.resolved = resolveColors(container, config, sectorKeys);
+      push(false);
+    };
+  }, [
+    live,
+    buildOption,
+    chartOptions,
+    isLoading,
+    animation,
+    shouldReduceMotion,
+    config,
+    sectorKeys,
+  ]);
+
+  // ── Default tooltip index — show a sector's tooltip with no hover ─────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || isLoading || !tooltipSlot.present || tooltipSlot.defaultIndex == null) return;
+    // Dispatch after paint so the sector geometry exists to anchor the tooltip.
+    const raf = requestAnimationFrame(() => {
+      chart.dispatchAction({
+        type: "showTip",
+        seriesIndex: 0,
+        dataIndex: tooltipSlot.defaultIndex,
+      });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isLoading, tooltipSlot.present, tooltipSlot.defaultIndex]);
+
+  // ── Loading shimmer — rAF sweeps a bright window around the ring ──────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || !isLoading) return;
+
+    const cornerRadius = pie?.cornerRadius ?? DEFAULT_CORNER_RADIUS;
+    const paddingAngle = pie?.paddingAngle ?? DEFAULT_PADDING_ANGLE;
+
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const phase = ((((now - start) / LOADING_ANIMATION_DURATION) % 1) + 1) % 1;
+      // Read tokens per frame, so a theme flip mid-loading retints the shimmer.
+      const foreground = live.resolved?.tokens.foreground ?? FALLBACK_COLOR;
+      const background = live.resolved?.tokens.background ?? FALLBACK_COLOR;
+
+      // Rebuild the full itemStyle for each sector — setOption replaces a series'
+      // data array wholesale, so a partial datum would drop the border/rounding.
+      const border = sectorBorder(paddingAngle, background);
+      const sectors = Array.from({ length: LOADING_SECTORS }, (_, i) => {
+        const pos = (i + 0.5) / LOADING_SECTORS;
+        const itemStyle: PieItemStyle = {
+          color: withAlpha(foreground, loadingSectorAlpha(pos, phase)),
+          opacity: 1,
+          borderRadius: cornerRadius,
+        };
+        if (border) {
+          itemStyle.borderColor = border.borderColor;
+          itemStyle.borderWidth = border.borderWidth;
+        }
+        return { value: 1, itemStyle };
+      });
+
+      chart.setOption(
+        { series: [{ id: "__loading", data: sectors }] },
+        { silent: true, lazyUpdate: true },
+      );
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [live, isLoading, pie]);
+
+  // ── Legend overlay position ──────────────────────────────────────────────────
+  const legendStyle: CSSProperties = {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    pointerEvents: "auto",
+    ...(legendSlot.verticalAlign === "top"
+      ? { top: 12 }
+      : legendSlot.verticalAlign === "bottom"
+        ? { bottom: 12 }
+        : { top: "50%", transform: "translateY(-50%)" }),
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      data-chart={chartId}
+      className={`relative flex flex-col text-xs ${className ?? ""}`}
+    >
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+
+      <div className="relative min-h-0 w-full flex-1">
+        {backgroundSlot.present && !isLoading && (
+          <BackgroundLayer variant={backgroundSlot.variant} />
+        )}
+        <div ref={mountRef} className="relative h-full min-h-0 w-full" />
+      </div>
+
+      {legendSlot.present && !isLoading && (
+        <LegendOverlay
+          seriesKeys={sectorKeys}
+          config={config}
+          variant={legendSlot.variant}
+          align={legendSlot.align}
+          verticalAlign={legendSlot.verticalAlign}
+          selectedKey={selectedSector}
+          hoveredKey={null}
+          isClickable={legendSlot.isClickable}
+          onToggle={(key) => selectSector(selectedSector === key ? null : key)}
+          style={legendStyle}
+        />
+      )}
+
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+          <motion.div
+            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+            className="flex items-center justify-center gap-2 rounded-md border bg-background px-2 py-0.5 text-sm text-primary"
+          >
+            <div className="h-3 w-3 animate-spin rounded-full border border-border border-t-primary" />
+            <span>Loading</span>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Compound API: every part hangs off the root as a static member, so a consumer
+// writes <EChartsPieChart.Pie/>, <EChartsPieChart.Tooltip/>, … from a single
+// import — no colliding named marker exports when several charts share one file.
+EChartsPieChart.Pie = Pie;
+EChartsPieChart.Label = Label;
+EChartsPieChart.Tooltip = Tooltip;
+EChartsPieChart.Legend = Legend;
+EChartsPieChart.Background = Background;

--- a/packages/charts/src/components/evilcharts/charts/echarts-radar-chart.tsx
+++ b/packages/charts/src/components/evilcharts/charts/echarts-radar-chart.tsx
@@ -1,0 +1,1248 @@
+"use client";
+
+import {
+  resolveTooltipPosition,
+  roundnessClass,
+  tooltipIndicatorHtml,
+  tooltipRow,
+  tooltipVariantClass,
+  type TooltipPosition,
+  type TooltipRoundness,
+  type TooltipVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-tooltip";
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FC,
+  type ReactNode,
+} from "react";
+import {
+  buildChartCss,
+  getColorsCount,
+  resolveColors,
+  withAlpha,
+  type ChartConfig,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+import {
+  RadarComponent,
+  TooltipComponent,
+  type RadarComponentOption,
+  type TooltipComponentOption,
+} from "echarts/components";
+import { dotStyle, sampleGradient, type DotVariant } from "@harmony/charts/components/evilcharts/ui/echarts-dot";
+import { LegendOverlay, type LegendVariant } from "@harmony/charts/components/evilcharts/ui/echarts-legend";
+import { RadarChart, type RadarSeriesOption } from "echarts/charts";
+import { motion, useReducedMotion } from "motion/react";
+import { CanvasRenderer } from "echarts/renderers";
+import type { ComposeOption } from "echarts/core";
+import * as echarts from "echarts/core";
+
+// Re-export the shared types that were previously declared inline here, so
+// existing consumers/examples keep importing them from the chart module.
+export type {
+  ChartConfig,
+  DotVariant,
+  LegendVariant,
+  TooltipPosition,
+  TooltipRoundness,
+  TooltipVariant,
+};
+
+// Modular registration keeps the bundle lean — only the pieces this chart needs.
+// `RadarComponent` is the polar coordinate system (indicators, rings, spokes);
+// `RadarChart` is the series that draws polygons inside it. No GraphicComponent —
+// this chart has no zrender overlays (the recharts twin has no brush).
+echarts.use([RadarChart, RadarComponent, TooltipComponent, CanvasRenderer]);
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+// The exact option surface this chart uses — radar series, the radar coordinate
+// component, and the tooltip. Narrower than echarts' full EChartsOption, so a
+// misspelled key fails the compile instead of silently reaching setOption. Radar
+// has no cartesian axes, so unlike the area chart there are no derived x/y types.
+type EChartsOption = ComposeOption<
+  RadarSeriesOption | RadarComponentOption | TooltipComponentOption
+>;
+
+// Single-item view of the radar component's array-or-single field, used where a
+// single radar coordinate system is built.
+type ArrayItem<T> = T extends readonly (infer U)[] ? U : T;
+type RadarOption = ArrayItem<NonNullable<EChartsOption["radar"]>>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STROKE_WIDTH = 1;
+const DEFAULT_FILL_OPACITY = 0.3; // resting fill opacity for a filled radar (twin default)
+const LOADING_ANIMATION_DURATION = 2000; // shimmer loop, in milliseconds
+const REVEAL_DURATION = 1000; // intro draw-in length, in milliseconds
+// NOTE: the intro draw-in is DRIVEN BY DATA, not ECharts' native radar entrance.
+// ECharts grows the polygon from the center but SNAPS the vertex symbols straight
+// to their final positions (its RadarView reads `oldPoints` from the polyline
+// AFTER `initProps` has already committed the target points, so every symbol
+// starts and ends at the same place and never moves — verified empirically). That
+// left the dots detached from the still-collapsing shape. Instead we disable the
+// native entrance and ramp every series' VALUES from 0 (all vertices at the center)
+// to their final magnitude over REVEAL_DURATION, re-pushing the data each frame.
+// Because the symbols track their datum, they ride the polygon vertices out from
+// the center and stay glued to the shape at every frame. Radar has no directional
+// wipe like the area chart, so `animation` is the single master switch.
+const LOADING_DEFAULT_POINTS = 6; // matches the recharts twin's LOADING_POINTS
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Theme knobs — every neutral line in the chart draws from these. Base colors
+// come from the consumer's CSS tokens (resolved from the live DOM), so only the
+// opacity factors live here. Factors MULTIPLY the token's own alpha — a border
+// token that is already 10%-white stays subtle. Tune here, not in the builder.
+// ─────────────────────────────────────────────────────────────────────────────
+// Recharts draws the polar grid at ~border/20, but SVG dashes render pixel-crisp
+// while canvas at 2× DPR spreads a 1px line across device pixels — roughly halving
+// perceived intensity. Using the border token's full alpha lands both engines at
+// the same apparent brightness.
+const GRID_LINE_OPACITY = 1; // dashed rings + radial spokes, × border alpha
+// The skeleton is CLIPPED to a small sweeping window — only the polygon section
+// inside it exists (stroke + fill), everything outside is fully transparent, like
+// a clip-path sliding across the chart.
+const LOADING_STROKE_OPACITY = 0.5; // outline inside the window, × foreground alpha
+const LOADING_SHIMMER_MAX_OPACITY = 0.05; // fill inside the window, × foreground alpha
+const LOADING_SHIMMER_BAND = 0.2; // window half-width, fraction of chart width
+const LOADING_SHIMMER_FEATHER = 0.2; // eased edge softening of the clip window
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type RadarVariant = "filled" | "lines";
+export type GridType = "polygon" | "circle";
+// DotVariant, TooltipVariant, TooltipRoundness, TooltipPosition, LegendVariant,
+// and ChartConfig now live in the shared @/registry/ui/echarts/* modules and are
+// imported + re-exported at the top of this file.
+
+export interface EChartsRadarChartProps<TData extends Record<string, unknown>> {
+  data: TData[]; // rows rendered by the chart — each row is one angle-axis category
+  config: ChartConfig; // series colors + labels
+  className?: string; // extra classes for the chart container
+  animation?: boolean; // master switch for the intro draw-in — false renders instantly
+  defaultSelectedDataKey?: string | null; // series selected on first render
+  onSelectionChange?: (key: string | null) => void; // fires when the selected series changes
+  isLoading?: boolean; // shows the animated loading skeleton
+  loadingPoints?: number; // number of points in the loading skeleton
+  chartOptions?: Record<string, unknown>; // escape hatch merged over the built ECharts option
+  children?: ReactNode; // declarative config — <Radar>, <PolarGrid>, <PolarAngleAxis>, …
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Composible parts — DECLARATIVE CONFIG. Every part renders `null`; the root
+// walks `children` by reference (child.type === Radar, …) to collect its props.
+// Presence semantics mirror the Recharts twin: omit a child and that part does
+// not render. These are never mounted into the tree — they only carry props.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RadarProps {
+  dataKey: string; // series key — must exist on the data + config
+  variant?: RadarVariant; // "filled" shows the fill, "lines" only the outline
+  fillOpacity?: number; // opacity of the filled area when variant="filled"
+  isClickable?: boolean; // lets this radar be selected by clicking it
+  children?: ReactNode; // optional <Dot> and <ActiveDot> config
+}
+
+/**
+ * A single radar series — one polygon over all angle-axis categories. Declares
+ * its own fill/clickability and, optionally, resting/active vertex markers
+ * via composed <Dot> / <ActiveDot>. Renders nothing — the root reads these props
+ * to build the ECharts radar series.
+ */
+const Radar: FC<RadarProps> = () => null;
+
+export interface DotProps {
+  variant?: DotVariant; // visual style of the vertex marker
+}
+
+/** Declares the resting vertex marker for the enclosing <Radar>. Renders nothing. */
+const Dot: FC<DotProps> = () => null;
+
+/** Declares the hovered/active vertex marker for the enclosing <Radar>. Renders nothing. */
+const ActiveDot: FC<DotProps> = () => null;
+
+export interface PolarGridProps {
+  gridType?: GridType; // "polygon" (angular rings) or "circle" (circular rings)
+}
+
+/**
+ * Presence draws the polar grid — the concentric rings and the radial spokes.
+ * `gridType` picks the ring shape. Renders nothing.
+ */
+const PolarGrid: FC<PolarGridProps> = () => null;
+
+export interface PolarAngleAxisProps {
+  dataKey?: string; // data key whose values label the perimeter — overrides auto-detect
+}
+
+/** Presence shows the angle-axis category labels around the perimeter. Renders nothing. */
+const PolarAngleAxis: FC<PolarAngleAxisProps> = () => null;
+
+/** Presence shows the radial value scale running from the center outward. Renders nothing. */
+const PolarRadiusAxis: FC = () => null;
+
+export interface TooltipProps {
+  variant?: TooltipVariant; // visual style of the tooltip surface
+  roundness?: TooltipRoundness; // border-radius of the tooltip
+  position?: TooltipPosition; // "variable" follows the pointer (default); "fixed" pins the tooltip near the top and tracks the pointer's X
+  // Data index shown by default with no hover. On canvas the radar tooltip is
+  // item-triggered (per polygon), so this selects the DEFAULT SERIES to reveal
+  // — see the note in the sync effect.
+  defaultIndex?: number;
+}
+
+/** Presence enables the hover tooltip. Renders nothing. */
+const Tooltip: FC<TooltipProps> = () => null;
+
+export interface LegendProps {
+  variant?: LegendVariant; // visual style of the legend indicators
+  align?: "left" | "center" | "right"; // horizontal placement
+  verticalAlign?: "top" | "middle" | "bottom"; // vertical placement
+  isClickable?: boolean; // lets each entry toggle selection of its series
+}
+
+/** Presence enables the HTML legend overlay. Renders nothing. */
+const Legend: FC<LegendProps> = () => null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Children collection — walk the declarative config into plain objects the
+// option builder consumes. <Dot> / <ActiveDot> are read from each <Radar>'s own
+// children; a missing dot child means that marker does not render.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type RadarSeriesConfig = {
+  dataKey: string;
+  variant: RadarVariant;
+  fillOpacity: number;
+  isClickable: boolean;
+  dotVariant: DotVariant; // "none" when no <Dot> child is present
+  activeDotVariant: DotVariant; // "none" when no <ActiveDot> child is present
+};
+
+type PolarGridSlot = { present: boolean; gridType: GridType };
+type PolarAngleAxisSlot = { present: boolean; dataKey?: string };
+type PolarRadiusAxisSlot = { present: boolean };
+type TooltipSlot = {
+  present: boolean;
+  variant: TooltipVariant;
+  roundness: TooltipRoundness;
+  position: TooltipPosition;
+  defaultIndex?: number;
+};
+type LegendSlot = {
+  present: boolean;
+  variant: LegendVariant;
+  align: "left" | "center" | "right";
+  verticalAlign: "top" | "middle" | "bottom";
+  isClickable: boolean;
+};
+
+type CollectedConfig = {
+  radars: RadarSeriesConfig[];
+  grid: PolarGridSlot;
+  angleAxis: PolarAngleAxisSlot;
+  radiusAxis: PolarRadiusAxisSlot;
+  tooltip: TooltipSlot;
+  legend: LegendSlot;
+};
+
+function collectConfig(children: ReactNode): CollectedConfig {
+  const radars: RadarSeriesConfig[] = [];
+  let grid: PolarGridSlot = { present: false, gridType: "polygon" };
+  let angleAxis: PolarAngleAxisSlot = { present: false };
+  let radiusAxis: PolarRadiusAxisSlot = { present: false };
+  let tooltip: TooltipSlot = {
+    present: false,
+    variant: "default",
+    roundness: "lg",
+    position: "variable",
+  };
+  let legend: LegendSlot = {
+    present: false,
+    variant: "rounded-square",
+    align: "center",
+    verticalAlign: "bottom",
+    isClickable: false,
+  };
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const type = child.type;
+
+    if (type === Radar) {
+      const props = child.props as RadarProps;
+      let dotVariant: DotVariant = "none";
+      let activeDotVariant: DotVariant = "none";
+      Children.forEach(props.children, (dotChild) => {
+        if (!isValidElement(dotChild)) return;
+        if (dotChild.type === Dot) {
+          dotVariant = (dotChild.props as DotProps).variant ?? "default";
+        } else if (dotChild.type === ActiveDot) {
+          activeDotVariant = (dotChild.props as DotProps).variant ?? "default";
+        }
+      });
+      radars.push({
+        dataKey: props.dataKey,
+        variant: props.variant ?? "filled",
+        fillOpacity: props.fillOpacity ?? DEFAULT_FILL_OPACITY,
+        isClickable: props.isClickable ?? false,
+        dotVariant,
+        activeDotVariant,
+      });
+    } else if (type === PolarGrid) {
+      const props = child.props as PolarGridProps;
+      grid = { present: true, gridType: props.gridType ?? "polygon" };
+    } else if (type === PolarAngleAxis) {
+      const props = child.props as PolarAngleAxisProps;
+      angleAxis = { present: true, dataKey: props.dataKey };
+    } else if (type === PolarRadiusAxis) {
+      radiusAxis = { present: true };
+    } else if (type === Tooltip) {
+      const props = child.props as TooltipProps;
+      tooltip = {
+        present: true,
+        variant: props.variant ?? "default",
+        roundness: props.roundness ?? "lg",
+        position: props.position ?? "variable",
+        defaultIndex: props.defaultIndex,
+      };
+    } else if (type === Legend) {
+      const props = child.props as LegendProps;
+      legend = {
+        present: true,
+        variant: props.variant ?? "rounded-square",
+        align: props.align ?? "center",
+        verticalAlign: props.verticalAlign ?? "bottom",
+        isClickable: props.isClickable ?? false,
+      };
+    }
+  });
+
+  return { radars, grid, angleAxis, radiusAxis, tooltip, legend };
+}
+
+// Color plumbing (ChartConfig, getColorsCount, distributeColors, buildChartCss,
+// normalizeColor, withAlpha, ResolvedColors, resolveColors) now lives in the shared
+// @/registry/ui/echarts-chart module, imported at the top of this file.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Radar paints — the ECharts analogue of the twin's SVG gradients.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GRAY = "rgba(120, 120, 120, 1)";
+
+// Diagonal multi-stop stroke, mirroring the twin's StrokeGradient (x1,y1 → x2,y2
+// = 0,0 → 1,1). A solid string when there is only one color. The gradient is
+// bbox-relative, so each polygon vertex takes the color at its position — the
+// canvas echo of the SVG stroke gradient clipping the polygon path.
+function radarStrokePaint(slots: string[]): string | echarts.graphic.LinearGradient {
+  if (slots.length <= 1) return slots[0] ?? GRAY;
+  const stops = slots.map((color, i) => ({ offset: i / (slots.length - 1), color }));
+  return new echarts.graphic.LinearGradient(0, 0, 1, 1, stops);
+}
+
+// Radial center→edge fill, mirroring the twin's FillGradient: first color at 0.8
+// alpha in the middle fading to 0.3 at the rim. bbox-relative (global: false), so
+// the gradient's center lands on the radar's center. The consumer's `fillOpacity`
+// multiplies this via areaStyle.opacity, exactly like the twin's fillOpacity prop.
+function radarFillPaint(slots: string[]): echarts.graphic.RadialGradient {
+  if (slots.length <= 1) {
+    const base = slots[0] ?? GRAY;
+    return new echarts.graphic.RadialGradient(0.5, 0.5, 0.5, [
+      { offset: 0, color: withAlpha(base, 0.8) },
+      { offset: 1, color: withAlpha(base, 0.3) },
+    ]);
+  }
+  return new echarts.graphic.RadialGradient(
+    0.5,
+    0.5,
+    0.5,
+    slots.map((color, i) => ({
+      offset: i / (slots.length - 1),
+      color: withAlpha(color, i === 0 ? 0.8 : 0.3),
+    })),
+  );
+}
+
+// Vertex dots (dotStyle/dotItemStyle/DOT_SIZES) and gradient sampling (sampleGradient)
+// now live in the shared @/registry/ui/echarts-dot module, imported at the top of this
+// file. A radar series is a SINGLE data item, so every vertex shares one itemStyle:
+// multi-color radars give all dots one representative color via sampleGradient(slots,
+// 0.5) rather than tinting each vertex individually.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Selection opacity — the twin only dims a CLICKABLE radar that isn't selected;
+// a non-clickable radar keeps full opacity even when a sibling is selected.
+// Split into stroke/fill/dot factors (mirroring the area chart's getOpacity): the
+// base state keeps stroke and dots at full, and a dimmed radar's fill drops twice
+// as far as its stroke/dots so the receding outline still reads.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function selectionOpacity(
+  selected: string | null,
+  key: string,
+  isClickable: boolean,
+): { fill: number; stroke: number; dot: number } {
+  const isSelected = selected === null || selected === key;
+  if (!isClickable || isSelected) return { fill: 1, stroke: 1, dot: 1 };
+  return { fill: 0.1, stroke: 0.2, dot: 0.2 };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loading skeleton helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Skeleton polygon as a smooth random walk in a comfortable band — reads like a
+// resting radar instead of raw noise spikes. Values live in [0, LOADING_MAX].
+const LOADING_MAX = 100;
+function getLoadingData(points: number): number[] {
+  const rows: number[] = [];
+  let value = 45 + Math.random() * 25;
+  for (let i = 0; i < points; i++) {
+    value = Math.min(90, Math.max(35, value + (Math.random() - 0.5) * 35));
+    rows.push(Math.round(value));
+  }
+  return rows;
+}
+
+// Gradient stops forming a hard clip window around `center`: full `peak` alpha
+// inside, zero outside, with a small feather so the edge isn't aliased.
+// `center` may run outside [0, 1] so the window fully enters and exits the frame.
+function shimmerWindowStops(center: number, color: string, peak: number) {
+  const half = LOADING_SHIMMER_BAND;
+  const feather = LOADING_SHIMMER_FEATHER;
+
+  const alphaAt = (x: number) => {
+    const dist = Math.abs(x - center);
+    if (dist <= half - feather) return peak;
+    if (dist >= half) return 0;
+    // Sine-eased falloff — a linear ramp still reads as a hard cut.
+    return peak * Math.sin(((1 - (dist - (half - feather)) / feather) * Math.PI) / 2);
+  };
+
+  const offsets = [
+    0,
+    center - half,
+    center - half + feather,
+    center,
+    center + half - feather,
+    center + half,
+    1,
+  ]
+    .filter((x) => x >= 0 && x <= 1)
+    .sort((a, b) => a - b);
+
+  const stops: { offset: number; color: string }[] = [];
+  for (const offset of offsets) {
+    if (stops.length === 0 || offset - stops[stops.length - 1]!.offset > 1e-4) {
+      stops.push({ offset, color: withAlpha(color, alphaAt(offset)) });
+    }
+  }
+  return stops;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tooltip + legend HTML — the tooltip shell styling (roundnessClass,
+// tooltipVariantClass, tooltipRow, tooltipIndicatorHtml) and the legend overlay
+// (LegendOverlay + its indicators) now live in the shared
+// @/registry/ui/echarts/{tooltip,legend} modules, imported at the top of this file.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option builders — pure functions from a snapshot context to ECharts option
+// fragments. The component reads its refs and props ONCE per build into this
+// context; nothing below touches React state or the chart instance, so each
+// fragment can be reasoned about (and tested) in isolation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OptionBuildContext = {
+  data: Record<string, unknown>[];
+  config: ChartConfig;
+  radars: RadarSeriesConfig[];
+  seriesKeys: string[];
+  selectedDataKey: string | null;
+  hasSelection: boolean;
+  gridSlot: PolarGridSlot;
+  angleAxisSlot: PolarAngleAxisSlot;
+  radiusAxisSlot: PolarRadiusAxisSlot;
+  tooltipSlot: TooltipSlot;
+  legendSlot: LegendSlot;
+  isLoading: boolean;
+  loadingData: () => number[];
+  loadingPoints: number;
+  resolved: ResolvedColors;
+  categories: string[]; // angle-axis labels (indicator names)
+  indicatorMax: number; // shared radius-axis max across every spoke
+};
+
+// The radar's vertical placement. When a legend rides the bottom (the default)
+// the coordinate system floats up to leave room, mirroring the Recharts layout.
+function radarCenterY(legendSlot: LegendSlot): string {
+  if (!legendSlot.present) return "50%";
+  if (legendSlot.verticalAlign === "bottom") return "46%";
+  if (legendSlot.verticalAlign === "top") return "54%";
+  return "50%";
+}
+
+// The radar coordinate system — indicators (one per category), rings, spokes, and
+// the two label sets. Grid visibility is gated on <PolarGrid>, perimeter labels
+// on <PolarAngleAxis>, and the radial scale on <PolarRadiusAxis>, matching the
+// twin's presence semantics.
+function buildRadarComponent(ctx: OptionBuildContext): RadarOption {
+  const { gridSlot, angleAxisSlot, radiusAxisSlot, isLoading, categories, indicatorMax } = ctx;
+  const { tokens } = ctx.resolved;
+  const gridColor = withAlpha(tokens.border, GRID_LINE_OPACITY);
+
+  return {
+    center: ["50%", radarCenterY(ctx.legendSlot)],
+    radius: "68%",
+    // Recharts starts the first category at the top and reads clockwise; startAngle
+    // 90 places the first indicator at the top to match.
+    startAngle: 90,
+    shape: gridSlot.gridType,
+    splitNumber: 4,
+    indicator: categories.map((name) => ({ name, max: indicatorMax })),
+    // Perimeter category labels — the twin's <PolarAngleAxis>.
+    axisName: {
+      show: angleAxisSlot.present && !isLoading,
+      color: tokens.mutedForeground,
+      fontSize: 10,
+    },
+    // Radial spokes from the center — part of the twin's <PolarGrid>.
+    axisLine: {
+      show: gridSlot.present && !isLoading,
+      lineStyle: { color: gridColor },
+    },
+    axisTick: { show: false },
+    // Concentric rings — the other half of <PolarGrid>. Dashed [3, 4] mirrors the
+    // twin's strokeDasharray. Hidden while loading so the skeleton floats clean.
+    splitLine: {
+      show: gridSlot.present && !isLoading,
+      lineStyle: { color: gridColor, type: [3, 4] as [number, number] },
+    },
+    splitArea: { show: false },
+    // Radial value scale — the twin's <PolarRadiusAxis>. Hidden while loading.
+    axisLabel: {
+      show: radiusAxisSlot.present && !isLoading,
+      color: tokens.mutedForeground,
+      fontSize: 10,
+      showMinLabel: false, // the 0 at the dead center reads as clutter
+    },
+  };
+}
+
+// Tooltip HTML builder, closed over the build context. Radar tooltips are
+// item-triggered (one polygon at a time), so — unlike the axis-triggered area
+// chart — the hovered series is the header and its per-category values are the
+// rows. Accepted deviation from the Recharts twin, which anchors on a category.
+function createTooltipFormatter(ctx: OptionBuildContext) {
+  const { config, selectedDataKey, tooltipSlot, categories } = ctx;
+
+  return (params: unknown): string => {
+    const param = (Array.isArray(params) ? params[0] : params) as {
+      seriesId?: string;
+      seriesName?: string;
+      value?: number[];
+    } | null;
+    if (!param) return "";
+
+    const key = param.seriesId ?? "";
+    // The loading skeleton never surfaces in the tooltip.
+    if (key.startsWith("__")) return "";
+
+    const item = config[key];
+    const colorsCount = item ? getColorsCount(item) : 1;
+    const labelText = typeof item?.label === "string" ? item.label : (param.seriesName ?? key);
+    const values = Array.isArray(param.value) ? param.value : [];
+    const dimmed = selectedDataKey != null && selectedDataKey !== key ? " opacity-30" : "";
+
+    // One row per angle-axis category. Radar rows share the area chart's
+    // indicator + label + value shape, so they reuse the shared tooltipRow +
+    // tooltipIndicatorHtml. dimmed is "" per row because a radar tooltip is a
+    // single series — the dim is applied to the whole shell below instead.
+    const body = categories
+      .map((category, i) => {
+        const raw = values[i];
+        const value = typeof raw === "number" ? raw.toLocaleString() : String(raw ?? "");
+        return tooltipRow({
+          indicatorHtml: tooltipIndicatorHtml(key, colorsCount),
+          labelText: category,
+          valueText: value,
+          dimmed: "",
+        });
+      })
+      .join("");
+
+    // Custom shell (not the shared tooltipShell): a radar tooltip dims the WHOLE
+    // surface for a non-selected series and keeps a foreground-colored header (no
+    // text-primary) — both byte-identical to the pre-refactor markup.
+    return `<div class="grid min-w-32 items-start gap-1.5 border border-border/50 px-2.5 py-1.5 text-xs shadow-xl${dimmed} ${roundnessClass[tooltipSlot.roundness]} ${tooltipVariantClass[tooltipSlot.variant]}">
+      <div class="font-medium">${labelText}</div>
+      <div class="grid gap-1.5">${body}</div>
+    </div>`;
+  };
+}
+
+function buildTooltipOption(ctx: OptionBuildContext): TooltipComponentOption {
+  const { tooltipSlot, isLoading } = ctx;
+
+  return {
+    show: tooltipSlot.present && !isLoading,
+    // Radar tooltips are item-triggered (per polygon), so this chart does NOT use
+    // the shared tooltipBaseOption (which builds an axis-triggered tooltip with an
+    // axis pointer). It shares only resolveTooltipPosition to wire the position
+    // prop: "variable" → default follow behavior, "fixed" → pinned near the top.
+    trigger: "item",
+    confine: true,
+    backgroundColor: "transparent",
+    borderWidth: 0,
+    padding: 0,
+    extraCssText: "box-shadow:none;",
+    position: resolveTooltipPosition(tooltipSlot.position),
+    formatter: createTooltipFormatter(ctx),
+  };
+}
+
+// One radar series per <Radar> — each carries a single polygon (one data item)
+// over every category, so all of its styling lives at the series level.
+function buildRadarSeries(ctx: OptionBuildContext): RadarSeriesOption[] {
+  const { data, config, radars, selectedDataKey, hasSelection, categories, resolved } = ctx;
+
+  return radars.map((radar) => {
+    const key = radar.dataKey;
+    const slots = resolved.series[key] ?? [GRAY];
+    const strokePaint = radarStrokePaint(slots);
+    // A radar series is one data item — every vertex shares one dot color (§sampleGradient).
+    const dotColor = sampleGradient(slots, 0.5);
+    const isSelected = selectedDataKey === null || selectedDataKey === key;
+    const opacity = selectionOpacity(selectedDataKey, key, radar.isClickable);
+    const isFilled = radar.variant === "filled";
+
+    const restingVisible = radar.dotVariant !== "none";
+    const activeVisible = radar.activeDotVariant !== "none";
+    const restingDot = dotStyle(radar.dotVariant, dotColor, resolved.tokens.background);
+    // The active marker falls back to "default" when only a resting dot is declared,
+    // so hover always has a marker to promote to.
+    const activeDot = dotStyle(
+      radar.activeDotVariant === "none" ? "default" : radar.activeDotVariant,
+      dotColor,
+      resolved.tokens.background,
+    );
+
+    const value = categories.map((_, i) => Number(data[i]?.[key]) || 0);
+
+    // ECharts radar has no per-state symbolSize and no numeric emphasis scale, so
+    // the hover marker swaps STYLE (e.g. colored-border → solid) at the resting
+    // size rather than growing — the twin's r3→r3 markers already match sizes.
+    const symbol = restingVisible || activeVisible ? "circle" : "none";
+
+    return {
+      id: key,
+      name: typeof config[key]?.label === "string" ? (config[key]?.label as string) : key,
+      type: "radar",
+      radarIndex: 0,
+      data: [{ value }],
+      symbol,
+      symbolSize: restingVisible ? restingDot.size : activeDot.size,
+      cursor: radar.isClickable ? "pointer" : "default",
+      // The selected radar rides on top; while a selection is active the rest sink.
+      z: isSelected ? 3 : hasSelection ? 1 : 2,
+      lineStyle: { color: strokePaint, width: STROKE_WIDTH, opacity: opacity.stroke },
+      areaStyle: isFilled
+        ? { color: radarFillPaint(slots), opacity: radar.fillOpacity * opacity.fill }
+        : undefined,
+      // Resting dots invisible when only an <ActiveDot> is declared.
+      itemStyle: restingVisible
+        ? { ...restingDot.itemStyle, opacity: opacity.dot }
+        : { ...activeDot.itemStyle, opacity: 0 },
+      // While a click selection is active it owns the canvas: native hover
+      // emphasis (the dot promotion) forces a dimmed radar's dot back to full
+      // opacity, fighting the selection dim — so hover highlighting stops entirely
+      // until the selection clears. The option rebuilds on every selection change,
+      // so this is a build-time switch.
+      emphasis: hasSelection
+        ? { disabled: true }
+        : {
+            // Promote the resting marker to the active variant on hover; keep the
+            // line and fill exactly as they rest so only the dot changes (twin parity).
+            itemStyle: { ...activeDot.itemStyle, opacity: 1 },
+            lineStyle: { color: strokePaint, width: STROKE_WIDTH, opacity: opacity.stroke },
+            ...(isFilled
+              ? {
+                  areaStyle: {
+                    color: radarFillPaint(slots),
+                    opacity: radar.fillOpacity * opacity.fill,
+                  },
+                }
+              : {}),
+          },
+    };
+  });
+}
+
+// Loading skeleton — ONE gray polygon regardless of declared radars (Recharts
+// parity: its skeleton is a single LoadingRadar), swept by the shimmer rAF. The
+// radar coordinate system exists but every visual axis element is hidden, so the
+// polygon floats on a clean canvas exactly like the twin (all its axis parts
+// return null while loading).
+function buildLoadingOption(ctx: OptionBuildContext): EChartsOption {
+  const { tokens } = ctx.resolved;
+  const points = ctx.loadingPoints;
+
+  return {
+    animation: false,
+    radar: {
+      center: ["50%", radarCenterY(ctx.legendSlot)],
+      radius: "68%",
+      startAngle: 90,
+      shape: ctx.gridSlot.gridType,
+      splitNumber: 4,
+      indicator: Array.from({ length: points }, (_, i) => ({ name: `${i}`, max: LOADING_MAX })),
+      axisName: { show: false },
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: { show: false },
+      splitArea: { show: false },
+      axisLabel: { show: false },
+    },
+    tooltip: { show: false },
+    series: [
+      {
+        id: "__loading",
+        type: "radar",
+        radarIndex: 0,
+        silent: true,
+        symbol: "none",
+        data: [{ value: ctx.loadingData() }],
+        // Invisible until the first shimmer tick positions the clip window.
+        lineStyle: { color: withAlpha(tokens.foreground, 0), width: 2 },
+        areaStyle: { color: withAlpha(tokens.foreground, 0) },
+        z: 1,
+      },
+    ],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live imperative state — everything the ECharts event handlers, rAF loops, and
+// theme/resize repushes read or write OUTSIDE the React render cycle, grouped in
+// one ref-stable object so the whole imperative surface is visible at a glance.
+// None of it is render output, which is exactly why it is not React state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LiveState = {
+  resolved: ResolvedColors | null; // colors read off the live DOM — feeds builds and rAF loops
+  hasRevealed: boolean; // the intro draw-in already played on this chart instance
+  revealRaf: number; // rAF handle of the data-driven entrance ramp (0 when idle)
+  loadingRows: number[] | null; // skeleton data, lazily rolled and re-rolled per shimmer sweep
+  categories: string[]; // angle-axis labels of the last build, for the tooltip
+  // Latest callbacks/flags for the imperative ECharts click handler.
+  handlers: {
+    onSelectionChange?: (key: string | null) => void;
+    clickableKeys: Set<string>;
+    selectedDataKey: string | null;
+    seriesKeys: string[];
+  };
+  // Update-style re-push for paths that bypass React entirely (theme flips,
+  // resizes) — set by the sync effect.
+  repush: () => void;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Apache ECharts port of the EvilCharts radar chart, exposing a compound-as-config
+ * API so its JSX reads identically to the Recharts twin. The root owns the data,
+ * config, selection state, loading skeleton, and intro reveal; every visual part
+ * — `<Radar>`, `<PolarGrid>`, `<PolarAngleAxis>`, `<PolarRadiusAxis>`,
+ * `<Tooltip>`, `<Legend>` — is composed as a declarative child that renders
+ * nothing. The root walks those children by reference and drives a single
+ * imperative ECharts instance. Fully self-contained: its only dependencies are
+ * `react`, `echarts`, and `motion`.
+ */
+export function EChartsRadarChart<TData extends Record<string, unknown>>({
+  data,
+  config,
+  className,
+  animation = true,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+  isLoading = false,
+  loadingPoints = LOADING_DEFAULT_POINTS,
+  chartOptions,
+  children,
+}: EChartsRadarChartProps<TData>) {
+  const rawId = useId();
+  const chartId = `chart-${rawId.replace(/:/g, "")}`;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<HTMLDivElement>(null);
+  const echartsRef = useRef<EChartsInstance | null>(null);
+
+  // The single imperative surface (see LiveState). `resolved` lives here rather
+  // than in state: as state it forced an extra render pass and an effect whose
+  // only job was to trigger the option push — the "chain of computations"
+  // react.dev/learn/you-might-not-need-an-effect warns about. The object
+  // identity is stable for the component's lifetime.
+  const live = useRef<LiveState>({
+    resolved: null,
+    hasRevealed: false,
+    revealRaf: 0,
+    loadingRows: null,
+    categories: [],
+    handlers: {
+      onSelectionChange,
+      clickableKeys: new Set<string>(),
+      selectedDataKey: defaultSelectedDataKey,
+      seriesKeys: [],
+    },
+    repush: () => {},
+  }).current;
+
+  // Skeleton rows roll lazily on first use — an impure useRef initializer would
+  // re-roll Math.random() on every render.
+  const loadingData = useCallback(
+    () => (live.loadingRows ??= getLoadingData(loadingPoints)),
+    [live, loadingPoints],
+  );
+  const shouldReduceMotion = useReducedMotion();
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(defaultSelectedDataKey);
+
+  // ── Declarative config, collected from children by reference ─────────────────
+  const collected = useMemo(() => collectConfig(children), [children]);
+  const {
+    radars,
+    grid: gridSlot,
+    angleAxis: angleAxisSlot,
+    radiusAxis: radiusAxisSlot,
+    tooltip: tooltipSlot,
+    legend: legendSlot,
+  } = collected;
+
+  const seriesKeys = useMemo(() => radars.map((radar) => radar.dataKey), [radars]);
+
+  // angle category key: <PolarAngleAxis dataKey> → first data column no <Radar> claims.
+  const angleKey = useMemo(() => {
+    if (angleAxisSlot.dataKey) return angleAxisSlot.dataKey;
+    const firstRow = data[0];
+    if (firstRow) {
+      const claimed = new Set(seriesKeys);
+      const found = Object.keys(firstRow).find((key) => !claimed.has(key));
+      if (found) return found;
+    }
+    return "";
+  }, [angleAxisSlot.dataKey, data, seriesKeys]);
+
+  const css = useMemo(() => buildChartCss(chartId, config), [chartId, config]);
+
+  const hasSelection = selectedDataKey !== null;
+
+  // Which series may be clicked to toggle selection (consulted by the click handler).
+  const clickableKeys = useMemo(
+    () => new Set(radars.filter((radar) => radar.isClickable).map((radar) => radar.dataKey)),
+    [radars],
+  );
+
+  // Refresh the handlers' snapshot of the latest callbacks/flags every render.
+  live.handlers = {
+    onSelectionChange,
+    clickableKeys,
+    selectedDataKey,
+    seriesKeys,
+  };
+
+  const toggleSelection = useCallback(
+    (key: string) => {
+      setSelectedDataKey((prev) => {
+        const next = prev === key ? null : key;
+        onSelectionChange?.(next);
+        return next;
+      });
+    },
+    [onSelectionChange],
+  );
+
+  // ── Option builder ─────────────────────────────────────────────────────────
+  // Thin orchestrator over the pure builders above: snapshot the imperative
+  // surface (refs) into an OptionBuildContext, then assemble.
+  const buildOption = useCallback((): EChartsOption => {
+    const resolved = live.resolved;
+    if (!resolved) return {};
+
+    const categories = data.map((row) => String(row[angleKey]));
+    live.categories = categories;
+
+    // Every spoke shares one radius scale, so the largest value across all series
+    // touches the outer ring — the recharts default domain.
+    let indicatorMax = 0;
+    for (const key of seriesKeys) {
+      for (const row of data) indicatorMax = Math.max(indicatorMax, Number(row[key]) || 0);
+    }
+    indicatorMax = indicatorMax || 1;
+
+    const ctx: OptionBuildContext = {
+      data,
+      config,
+      radars,
+      seriesKeys,
+      selectedDataKey,
+      hasSelection,
+      gridSlot,
+      angleAxisSlot,
+      radiusAxisSlot,
+      tooltipSlot,
+      legendSlot,
+      isLoading,
+      loadingData,
+      loadingPoints,
+      resolved,
+      categories,
+      indicatorMax,
+    };
+
+    if (isLoading) return buildLoadingOption(ctx);
+
+    return {
+      animation: false,
+      radar: buildRadarComponent(ctx),
+      tooltip: buildTooltipOption(ctx),
+      // The radar polygons — their seriesIndex feeds the click handler.
+      series: buildRadarSeries(ctx),
+    };
+  }, [
+    live,
+    data,
+    config,
+    radars,
+    seriesKeys,
+    angleKey,
+    selectedDataKey,
+    hasSelection,
+    gridSlot,
+    angleAxisSlot,
+    radiusAxisSlot,
+    tooltipSlot,
+    legendSlot,
+    isLoading,
+    loadingData,
+    loadingPoints,
+  ]);
+
+  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  useEffect(() => {
+    const mount = mountRef.current;
+    const container = containerRef.current;
+    if (!mount || !container) return;
+
+    const chart = echarts.init(mount);
+    echartsRef.current = chart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Observers always fire once right after observe(). Repushing on that
+      // no-op fire would land one frame into the intro and stomp the radar's
+      // reveal — only react when the renderer size actually changed.
+      if (mount.clientWidth === chart.getWidth() && mount.clientHeight === chart.getHeight()) {
+        return;
+      }
+      chart.resize();
+      live.repush();
+    });
+    resizeObserver.observe(mount);
+
+    // Light/dark flips change no React state — re-resolve and push directly.
+    const themeObserver = new MutationObserver(() => {
+      live.repush();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    chart.on("click", (params) => {
+      const { clickableKeys: clickable, seriesKeys: keys } = live.handlers;
+      const p = params as { seriesId?: string; seriesIndex?: number };
+      // Symbol clicks carry seriesId; polygon clicks may only carry seriesIndex —
+      // recover the key by position. Main radar series come first in the series
+      // array (the loading skeleton is silent), so the index maps directly.
+      const id =
+        p.seriesId ?? (typeof p.seriesIndex === "number" ? keys[p.seriesIndex] : undefined);
+      if (typeof id === "string" && clickable.has(id)) toggleSelection(id);
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      if (live.revealRaf) {
+        cancelAnimationFrame(live.revealRaf);
+        live.revealRaf = 0;
+      }
+      chart.dispose();
+      echartsRef.current = null;
+      // The reveal guard belongs to the chart instance it guarded. Without this
+      // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
+      // the throwaway instance and the surviving one renders without it.
+      live.hasRevealed = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    const container = containerRef.current;
+    if (!chart || !container) return;
+
+    // Colors come from the <style> committed just before this effect ran — read
+    // them here, right before the push, rather than round-tripping through state.
+    live.resolved = resolveColors(container, config, seriesKeys);
+
+    // A radar series carries one data item: `{ value: number[] }`. The entrance
+    // ramp reads and rewrites just those magnitudes each frame.
+    type RevealSeries = { id?: string; data?: { value?: number[] }[] };
+
+    const cancelReveal = () => {
+      if (live.revealRaf) {
+        cancelAnimationFrame(live.revealRaf);
+        live.revealRaf = 0;
+      }
+    };
+
+    const buildMerged = (): EChartsOption => {
+      const option = buildOption();
+      const merged = chartOptions ? { ...option, ...chartOptions } : option;
+      // Native animation stays off — the entrance is data-driven (see below), and
+      // notMerge would otherwise replay a native entrance on every repush.
+      Object.assign(merged, { animation: false, animationDurationUpdate: 0 });
+      // chartOptions is an untyped escape hatch — the spread erases the option's
+      // shape, so re-assert it.
+      return merged as EChartsOption;
+    };
+
+    // Settled push — full-magnitude data, no entrance. Every non-first render
+    // (selection, theme, resize) and the animation-off path lands here.
+    const pushStatic = () => {
+      cancelReveal();
+      chart.setOption(buildMerged(), { notMerge: true });
+    };
+
+    // Entrance push — collapse every radar series to the center, then ramp the
+    // values back out to full magnitude. Because each
+    // vertex symbol tracks its datum, the dots ride the polygon out from the center
+    // and stay glued to the shape at every frame — the fix for ECharts snapping
+    // radar symbols straight to their final positions during its native entrance.
+    const pushReveal = () => {
+      cancelReveal();
+      const merged = buildMerged();
+      const series = (merged.series as unknown as RevealSeries[] | undefined) ?? [];
+      const finals = series.map((s) => s.data?.[0]?.value ?? []);
+
+      // First paint fully collapsed — no flash of the final shape before the ramp.
+      chart.setOption(
+        {
+          ...merged,
+          series: series.map((s, i) => ({ ...s, data: [{ value: finals[i]!.map(() => 0) }] })),
+        } as EChartsOption,
+        { notMerge: true },
+      );
+
+      const start = performance.now();
+      const frame = (now: number) => {
+        const t = Math.min((now - start) / REVEAL_DURATION, 1);
+        const eased = 1 - Math.pow(1 - t, 3); // easeOutCubic — decelerate into place
+        chart.setOption(
+          {
+            series: series.map((s, i) => ({
+              id: s.id,
+              data: [{ value: finals[i]!.map((v) => v * eased) }],
+            })),
+          },
+          { silent: true, lazyUpdate: true },
+        );
+        live.revealRaf = t < 1 ? requestAnimationFrame(frame) : 0;
+      };
+      live.revealRaf = requestAnimationFrame(frame);
+    };
+
+    // Intro reveal — plays only on the first real render. A loading cycle re-arms
+    // it: the Recharts twin remounts its <Radar>s while loading and replays the
+    // intro on remount, so data → loading → data draws in again here too.
+    if (isLoading) live.hasRevealed = false;
+    const shouldReveal = !live.hasRevealed && !isLoading;
+    if (shouldReveal) live.hasRevealed = true;
+    const revealEnabled = animation && shouldReveal && !shouldReduceMotion;
+    if (revealEnabled) pushReveal();
+    else pushStatic();
+
+    // Default tooltip. On canvas the radar tooltip is item-triggered per polygon,
+    // so the twin's `defaultIndex` (a category index) is remapped to the DEFAULT
+    // SERIES whose tooltip shows on load. Only fired on the reveal push, never on
+    // theme/resize repushes (that would re-pop the tooltip on every flip).
+    if (
+      !isLoading &&
+      tooltipSlot.present &&
+      tooltipSlot.defaultIndex != null &&
+      seriesKeys.length
+    ) {
+      const idx = Math.min(Math.max(tooltipSlot.defaultIndex, 0), seriesKeys.length - 1);
+      chart.dispatchAction({ type: "showTip", seriesIndex: idx, dataIndex: 0 });
+    }
+
+    // Theme flips and resizes re-enter here without touching React: re-read the
+    // tokens (the .dark class changed) and push a settled option, cancelling any
+    // in-flight entrance ramp.
+    live.repush = () => {
+      live.resolved = resolveColors(container, config, seriesKeys);
+      pushStatic();
+    };
+  }, [
+    live,
+    buildOption,
+    chartOptions,
+    isLoading,
+    animation,
+    shouldReduceMotion,
+    config,
+    seriesKeys,
+    tooltipSlot.present,
+    tooltipSlot.defaultIndex,
+  ]);
+
+  // ── Loading shimmer — rAF sweeps a bright band, regenerating data off-screen ─
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || !isLoading) return;
+
+    let raf = 0;
+    let lastPhase = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const phase = ((((now - start) / LOADING_ANIMATION_DURATION) % 1) + 1) % 1;
+      // Wrapped past 1 → the band is off-screen; swap in fresh random data.
+      if (phase < lastPhase) live.loadingRows = getLoadingData(loadingPoints);
+      lastPhase = phase;
+
+      // Read tokens per frame, so a theme flip mid-loading retints the shimmer.
+      const foreground = live.resolved?.tokens.foreground ?? GRAY;
+      const w = chart.getWidth();
+      const h = chart.getHeight();
+      if (!w || !h) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      // Sweep the clip window from fully off-screen left to fully off-screen
+      // right, leaned 45°. The gradient uses ABSOLUTE pixel coordinates shared by
+      // stroke and fill so both reveal the same slice of the polygon at once.
+      const maxT = (w + h) / (2 * w);
+      const center = phase * (maxT + 2 * LOADING_SHIMMER_BAND) - LOADING_SHIMMER_BAND;
+      const clip = (peak: number) =>
+        new echarts.graphic.LinearGradient(
+          0,
+          0,
+          w,
+          w,
+          shimmerWindowStops(center, foreground, peak),
+          true,
+        );
+      chart.setOption(
+        {
+          series: [
+            {
+              id: "__loading",
+              data: [{ value: loadingData() }],
+              lineStyle: { color: clip(LOADING_STROKE_OPACITY), width: 2 },
+              areaStyle: { color: clip(LOADING_SHIMMER_MAX_OPACITY) },
+            },
+          ],
+        },
+        { silent: true, lazyUpdate: true },
+      );
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [live, isLoading, loadingPoints, loadingData]);
+
+  // ── Legend overlay position ──────────────────────────────────────────────────
+  // Insets match the Recharts legend's breathing room inside the plot frame.
+  const legendStyle: CSSProperties = {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    pointerEvents: "auto",
+    ...(legendSlot.verticalAlign === "top"
+      ? { top: 12 }
+      : legendSlot.verticalAlign === "bottom"
+        ? { bottom: 12 }
+        : { top: "50%", transform: "translateY(-50%)" }),
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      data-chart={chartId}
+      className={`relative flex flex-col text-xs ${className ?? ""}`}
+    >
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+
+      <div className="relative min-h-0 w-full flex-1">
+        <div ref={mountRef} className="h-full min-h-0 w-full" />
+      </div>
+
+      {legendSlot.present && !isLoading && (
+        <LegendOverlay
+          seriesKeys={seriesKeys}
+          config={config}
+          variant={legendSlot.variant}
+          align={legendSlot.align}
+          verticalAlign={legendSlot.verticalAlign}
+          selectedKey={selectedDataKey}
+          hoveredKey={null}
+          isClickable={legendSlot.isClickable}
+          onToggle={toggleSelection}
+          style={legendStyle}
+        />
+      )}
+
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+          <motion.div
+            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+            className="text-primary bg-background flex items-center justify-center gap-2 rounded-md border px-2 py-0.5 text-sm"
+          >
+            <div className="border-border border-t-primary h-3 w-3 animate-spin rounded-full border" />
+            <span>Loading</span>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Compound API: every part hangs off the root as a static member, so a consumer
+// writes <EChartsRadarChart.Radar/>, <EChartsRadarChart.Tooltip/>, … from a single
+// import — no colliding named marker exports when several charts share one file.
+EChartsRadarChart.Radar = Radar;
+EChartsRadarChart.Dot = Dot;
+EChartsRadarChart.ActiveDot = ActiveDot;
+EChartsRadarChart.PolarGrid = PolarGrid;
+EChartsRadarChart.PolarAngleAxis = PolarAngleAxis;
+EChartsRadarChart.PolarRadiusAxis = PolarRadiusAxis;
+EChartsRadarChart.Tooltip = Tooltip;
+EChartsRadarChart.Legend = Legend;

--- a/packages/charts/src/components/evilcharts/charts/echarts-radial-chart.tsx
+++ b/packages/charts/src/components/evilcharts/charts/echarts-radial-chart.tsx
@@ -1,0 +1,1274 @@
+"use client";
+
+import type { ComposeOption } from "echarts/core";
+
+import {
+  buildChartCss,
+  getColorsCount,
+  resolveColors,
+  withAlpha,
+  type ChartConfig,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+import {
+  LegendIndicator,
+  type LegendVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-legend";
+import {
+  formatTooltipValue,
+  resolveTooltipPosition,
+  roundnessClass,
+  tooltipIndicatorHtml,
+  tooltipRow,
+  tooltipVariantClass,
+  type TooltipPosition,
+  type TooltipRoundness,
+  type TooltipVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-tooltip";
+import { BarChart, type BarSeriesOption } from "echarts/charts";
+import {
+  PolarComponent,
+  TooltipComponent,
+  type PolarComponentOption,
+  type TooltipComponentOption,
+} from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { motion, useReducedMotion } from "motion/react";
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+  type ReactNode,
+} from "react";
+
+// Re-export the shared types that were previously declared inline here, so
+// existing consumers/examples keep importing them from the chart module.
+export type { ChartConfig, LegendVariant, TooltipPosition, TooltipRoundness, TooltipVariant };
+
+// Modular registration keeps the bundle lean — only the pieces this chart needs.
+// `PolarComponent` bundles the polar coordinate system together with its
+// `angleAxis` + `radiusAxis` (concentric rings are a polar `bar` series whose
+// value drives the sweep angle). No GraphicComponent: unlike the area chart's
+// brush, nothing here draws raw zrender overlays — selection is per-datum
+// opacity, and the skeleton shimmer is a swept gradient.
+echarts.use([BarChart, PolarComponent, TooltipComponent, CanvasRenderer]);
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+// The exact option surface this chart uses — a polar bar series plus the polar
+// component (which carries angle/radius axes as dependencies) and the tooltip.
+// Narrower than echarts' full EChartsOption, so a misspelled key fails the
+// compile instead of silently reaching setOption.
+type EChartsOption = ComposeOption<BarSeriesOption | TooltipComponentOption | PolarComponentOption>;
+
+// Single-entry views of the composed option's array-or-single fields — the
+// modular entry points don't export the polar/axis option types directly, so
+// they are recovered from the composed option (angleAxis/radiusAxis enter it as
+// dependencies of the polar component).
+type ArrayItem<T> = T extends readonly (infer U)[] ? U : T;
+type PolarOption = ArrayItem<NonNullable<EChartsOption["polar"]>>;
+type AngleAxisOption = ArrayItem<NonNullable<EChartsOption["angleAxis"]>>;
+type RadiusAxisOption = ArrayItem<NonNullable<EChartsOption["radiusAxis"]>>;
+
+// Per-datum bar paint — structurally assignable to the per-datum itemStyle. A
+// gradient `color` reproduces each bar's diagonal fill.
+type BarItemStyle = {
+  color?: string | echarts.graphic.LinearGradient;
+  opacity?: number;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_INNER_RADIUS = "30%";
+const DEFAULT_OUTER_RADIUS = "100%";
+const DEFAULT_CORNER_RADIUS = 5;
+const DEFAULT_BAR_SIZE = 14;
+const LOADING_BARS = 5; // skeleton ring count — matches the Recharts twin
+const LOADING_MAX = 100; // fixed angle-axis extent while loading (values roll in a 40–100 band)
+const LOADING_ANIMATION_DURATION = 2000; // shimmer sweep loop, in milliseconds
+const REVEAL_DURATION = 1000; // intro sweep-in length, in milliseconds
+// NOTE: the intro draw-in runs ECharts' RAW default bar entrance (each ring
+// sweeps out from the start angle). Like the area twin, it plays on the FIRST
+// real push only; every later push (selection, theme) sends animation:false
+// because notMerge would otherwise replay the entrance on each change.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Theme knobs — every neutral tone draws from these. Base colors come from the
+// consumer's CSS tokens (resolved off the live DOM), so only the opacity factors
+// live here. Factors MULTIPLY the token's own alpha — a border token that is
+// already 10%-white stays subtle. Tune here, not in the builder.
+// ─────────────────────────────────────────────────────────────────────────────
+const TRACK_OPACITY = 0.15; // unfilled background ring, × muted-foreground alpha
+const SELECTED_DIM_OPACITY = 0.15; // unselected bars while a selection is active
+// The skeleton track stays faintly visible; a bright band is CLIPPED to a small
+// sweeping window (only the arc slice inside it exists) and swept diagonally
+// across the rings, like a clip-path sliding over the chart.
+const LOADING_SHIMMER_MAX_OPACITY = 0.4; // shimmer arc peak, × foreground alpha
+const LOADING_SHIMMER_BAND = 0.2; // window half-width, fraction of the sweep axis
+const LOADING_SHIMMER_FEATHER = 0.2; // eased edge softening of the clip window
+
+// Stable series ids. `__`-prefixed ids are internal (background track, skeleton)
+// and stay silent; the main ring series is the only one that reports clicks and
+// feeds the tooltip.
+const MAIN_SERIES_ID = "radial-bars";
+const TRACK_SERIES_ID = "__track";
+// The track rides a second, identical polar so it never shares a bar band with
+// the data rings — see buildTrackSeries for why that matters.
+const TRACK_POLAR_INDEX = 1;
+const LOADING_SERIES_ID = "__loading";
+const LOADING_TRACK_ID = "__loading-track";
+
+const FALLBACK_COLOR = "rgba(120, 120, 120, 1)";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type RadialVariant = "full" | "semi";
+// TooltipVariant, TooltipRoundness, TooltipPosition, LegendVariant, and
+// ChartConfig now live in the shared @/registry/ui/echarts/* modules and are
+// imported + re-exported at the top of this file.
+
+export interface EChartsRadialChartProps<TData extends Record<string, unknown>> {
+  data: TData[]; // rows rendered by the chart — one bar (ring) per row
+  config: ChartConfig; // bar colors + labels, keyed by each bar's name
+  nameKey: keyof TData & string; // data key holding each bar's name
+  className?: string; // extra classes for the chart container
+  variant?: RadialVariant; // arc shape — full circle or half circle
+  // Value a full sweep represents. Without it the scale is derived from the data,
+  // so the largest bar always fills the arc — set it (e.g. 100) for gauges, where
+  // a single value has to read against a fixed total.
+  max?: number;
+  innerRadius?: number | string; // inner radius of the radial bars
+  outerRadius?: number | string; // outer radius of the radial bars
+  defaultSelectedDataKey?: string | null; // bar selected on first render
+  onSelectionChange?: (selection: { dataKey: string; value: number } | null) => void; // fires when the selected bar changes
+  isLoading?: boolean; // shows the animated loading skeleton
+  backgroundVariant?: BackgroundVariant; // decorative pattern behind the chart
+  chartOptions?: Record<string, unknown>; // escape hatch merged over the built ECharts option
+  children?: ReactNode; // declarative config — <RadialBar>, <Tooltip>, <Legend>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Composible parts — DECLARATIVE CONFIG. Every part renders `null`; the root
+// walks `children` by reference (child.type === RadialBar, …) to collect its
+// props. Presence semantics mirror the Recharts twin: omit a child and that part
+// does not render. These are never mounted into the tree — they only carry props.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RadialBarProps {
+  dataKey: string; // value key — determines each bar's arc length
+  cornerRadius?: number; // rounding of each bar's ends (mapped to a rounded cap)
+  barSize?: number; // thickness of each radial bar in pixels
+  showBackground?: boolean; // renders the unfilled track behind each bar
+  isClickable?: boolean; // lets bars be selected by clicking them
+}
+
+/**
+ * The radial bar series. Each data row becomes one concentric ring. Pass
+ * `isClickable` to make bars selectable. Renders nothing — the root reads these
+ * props to build the series.
+ */
+const RadialBar: FC<RadialBarProps> = () => null;
+
+export interface TooltipProps {
+  variant?: TooltipVariant; // visual style of the tooltip surface
+  roundness?: TooltipRoundness; // border-radius of the tooltip
+  defaultIndex?: number; // data index shown by default with no hover
+  position?: TooltipPosition; // "variable" follows the pointer (default); "fixed" pins the tooltip near the top and tracks the pointer's X
+}
+
+/** Presence enables the hover tooltip. Renders nothing. */
+const Tooltip: FC<TooltipProps> = () => null;
+
+export interface LegendProps {
+  variant?: LegendVariant; // visual style of the legend indicators
+  align?: "left" | "center" | "right"; // horizontal placement
+  verticalAlign?: "top" | "middle" | "bottom"; // vertical placement
+  isClickable?: boolean; // lets each entry toggle selection of its bar
+}
+
+/** Presence enables the HTML legend overlay. Renders nothing. */
+const Legend: FC<LegendProps> = () => null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Children collection — walk the declarative config into plain objects the
+// option builder consumes. A missing part becomes an absent slot.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type RadialBarSlot = {
+  present: boolean;
+  dataKey: string;
+  cornerRadius: number;
+  barSize: number;
+  showBackground: boolean;
+  isClickable: boolean;
+};
+type TooltipSlot = {
+  present: boolean;
+  variant: TooltipVariant;
+  roundness: TooltipRoundness;
+  defaultIndex?: number;
+  position: TooltipPosition;
+};
+type LegendSlot = {
+  present: boolean;
+  variant: LegendVariant;
+  align: "left" | "center" | "right";
+  verticalAlign: "top" | "middle" | "bottom";
+  isClickable: boolean;
+};
+
+type CollectedConfig = {
+  radialBar: RadialBarSlot;
+  tooltip: TooltipSlot;
+  legend: LegendSlot;
+};
+
+function collectConfig(children: ReactNode): CollectedConfig {
+  // Defaults hold even when <RadialBar> is omitted, so the loading skeleton
+  // (which needs a bar size) always has sane geometry.
+  let radialBar: RadialBarSlot = {
+    present: false,
+    dataKey: "",
+    cornerRadius: DEFAULT_CORNER_RADIUS,
+    barSize: DEFAULT_BAR_SIZE,
+    showBackground: true,
+    isClickable: false,
+  };
+  let tooltip: TooltipSlot = {
+    present: false,
+    variant: "default",
+    roundness: "lg",
+    position: "variable",
+  };
+  let legend: LegendSlot = {
+    present: false,
+    variant: "rounded-square",
+    align: "center",
+    verticalAlign: "bottom",
+    isClickable: false,
+  };
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const type = child.type;
+
+    if (type === RadialBar) {
+      const props = child.props as RadialBarProps;
+      radialBar = {
+        present: true,
+        dataKey: props.dataKey,
+        cornerRadius: props.cornerRadius ?? DEFAULT_CORNER_RADIUS,
+        barSize: props.barSize ?? DEFAULT_BAR_SIZE,
+        showBackground: props.showBackground ?? true,
+        isClickable: props.isClickable ?? false,
+      };
+    } else if (type === Tooltip) {
+      const props = child.props as TooltipProps;
+      tooltip = {
+        present: true,
+        variant: props.variant ?? "default",
+        roundness: props.roundness ?? "lg",
+        defaultIndex: props.defaultIndex,
+        position: props.position ?? "variable",
+      };
+    } else if (type === Legend) {
+      const props = child.props as LegendProps;
+      legend = {
+        present: true,
+        variant: props.variant ?? "rounded-square",
+        align: props.align ?? "center",
+        verticalAlign: props.verticalAlign ?? "bottom",
+        isClickable: props.isClickable ?? false,
+      };
+    }
+  });
+
+  return { radialBar, tooltip, legend };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Color plumbing (ChartConfig, getColorsCount, distributeColors, buildChartCss,
+// normalizeColor, withAlpha, ResolvedColors, resolveColors, indicatorBackground)
+// now lives in @/registry/ui/echarts-chart and is imported at the top of this
+// file. Only barPaint below is chart-specific — see its note.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Diagonal multi-stop color for a bar — a solid string when there is only one
+// color, else a top-left→bottom-right LinearGradient across the bar's bounding
+// box. Mirrors the Recharts `<linearGradient x1=0 y1=0 x2=1 y2=1>` applied to
+// every sector.
+function barPaint(slots: string[]): string | echarts.graphic.LinearGradient {
+  if (slots.length <= 1) return slots[0] ?? FALLBACK_COLOR;
+  const stops = slots.map((color, i) => ({ offset: i / (slots.length - 1), color }));
+  return new echarts.graphic.LinearGradient(0, 0, 1, 1, stops);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Misc helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Angle + center configuration for the chart's arc shape. Angles follow the
+// Recharts twin: `full` sweeps a whole clockwise circle from the top; `semi`
+// domes over the top from left to right (center pushed low, like cy="70%").
+// ECharts' `clockwise: true` makes rising values rotate clockwise on screen.
+function getVariantGeometry(variant: RadialVariant): {
+  center: [string, string];
+  startAngle: number;
+  endAngle: number;
+} {
+  switch (variant) {
+    case "semi":
+      return { center: ["50%", "70%"], startAngle: 180, endAngle: 0 };
+    case "full":
+    default:
+      return { center: ["50%", "50%"], startAngle: 90, endAngle: -270 };
+  }
+}
+
+// A "nice" ceiling for the angle-axis max, so the largest ring stops just shy of
+// a full wrap (mirrors the auto-scaled domain the Recharts twin derives instead
+// of letting the biggest bar close into an ambiguous full circle). ~ECharts'
+// default value-axis nicing for a 5-way split.
+function niceCeil(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 1;
+  const rough = value / 5;
+  const power = Math.floor(Math.log10(rough));
+  const base = Math.pow(10, power);
+  const fraction = rough / base;
+  const niceFraction = fraction < 1.5 ? 1 : fraction < 3 ? 2 : fraction < 7 ? 5 : 10;
+  const interval = niceFraction * base;
+  return Math.ceil(value / interval) * interval;
+}
+
+// Skeleton ring values as a smooth random walk in a comfortable band — reads
+// like a resting chart instead of raw noise.
+function getLoadingData(count: number): number[] {
+  const rows: number[] = [];
+  let value = 55 + Math.random() * 30;
+  for (let i = 0; i < count; i++) {
+    value = Math.min(LOADING_MAX, Math.max(40, value + (Math.random() - 0.5) * 30));
+    rows.push(Math.round(value));
+  }
+  return rows;
+}
+
+// Gradient stops forming a hard clip window around `center`: full `peak` alpha
+// inside, zero outside, with a small sine feather so the edge isn't aliased.
+// `center` may run outside [0, 1] so the window fully enters and exits the frame.
+function shimmerWindowStops(center: number, color: string, peak: number) {
+  const half = LOADING_SHIMMER_BAND;
+  const feather = LOADING_SHIMMER_FEATHER;
+
+  const alphaAt = (x: number) => {
+    const dist = Math.abs(x - center);
+    if (dist <= half - feather) return peak;
+    if (dist >= half) return 0;
+    // Sine-eased falloff — a linear ramp still reads as a hard cut.
+    return peak * Math.sin(((1 - (dist - (half - feather)) / feather) * Math.PI) / 2);
+  };
+
+  const offsets = [
+    0,
+    center - half,
+    center - half + feather,
+    center,
+    center + half - feather,
+    center + half,
+    1,
+  ]
+    .filter((x) => x >= 0 && x <= 1)
+    .sort((a, b) => a - b);
+
+  const stops: { offset: number; color: string }[] = [];
+  for (const offset of offsets) {
+    if (stops.length === 0 || offset - stops[stops.length - 1]!.offset > 1e-4) {
+      stops.push({ offset, color: withAlpha(color, alphaAt(offset)) });
+    }
+  }
+  return stops;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tooltip / legend HTML primitives (roundnessClass, tooltipVariantClass,
+// indicatorBackground, legendFillStyle, legendOutlineStyle, LegendIndicator) now
+// live in the shared @/registry/ui/echarts/{tooltip,legend} modules and are
+// imported at the top of this file. The tooltip shell + item row below compose
+// those shared primitives; the legend overlay uses the shared LegendIndicator.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Background patterns — a self-contained port of <ChartBackground>. The Recharts
+// twin draws these inside a Recharts <ZIndexLayer>; canvas has no such layer, so
+// here they render as a plain SVG overlay sitting behind the transparent ECharts
+// canvas. Same patterns, same `text-border` tint, same soft edge-fade mask.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BackgroundVariant =
+  | "dots"
+  | "grid"
+  | "cross-hatch"
+  | "diagonal-lines"
+  | "plus"
+  | "falling-triangles"
+  | "4-pointed-star"
+  | "tiny-checkers"
+  | "overlapping-circles"
+  | "wiggle-lines"
+  | "bubbles";
+
+type PatternProps = { id: string };
+
+const BACKGROUND_PATTERNS: Record<BackgroundVariant, FC<PatternProps>> = {
+  dots: ({ id }) => (
+    <pattern id={id} x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <circle className="text-border" cx="2" cy="2" r="1" fill="currentColor" />
+    </pattern>
+  ),
+  grid: ({ id }) => (
+    <pattern id={id} x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        d="M 20 0 L 0 0 0 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  ),
+  "cross-hatch": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border/60 dark:text-border/50"
+        d="M 0 0 L 20 20 M 20 0 L 0 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  ),
+  "diagonal-lines": ({ id }) => (
+    <pattern
+      id={id}
+      x="0"
+      y="0"
+      width="6"
+      height="6"
+      patternUnits="userSpaceOnUse"
+      patternTransform="rotate(45)"
+    >
+      <line
+        className="text-border"
+        x1="0"
+        y1="0"
+        x2="0"
+        y2="6"
+        stroke="currentColor"
+        strokeWidth="0.5"
+      />
+    </pattern>
+  ),
+  plus: ({ id }) => (
+    <pattern id={id} x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        d="M 8 4 L 8 12 M 4 8 L 12 8"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.5"
+        strokeLinecap="round"
+      />
+    </pattern>
+  ),
+  "falling-triangles": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="18" height="36" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        d="M2 6h12L8 18 2 6zm18 36h12l-6 12-6-12z"
+        transform="scale(0.5)"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  ),
+  "4-pointed-star": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <polygon
+        className="text-border"
+        fillRule="evenodd"
+        points="5 3 8 4 5 5 4 8 3 5 0 4 3 3 4 0 5 3"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  ),
+  "tiny-checkers": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="8" height="8" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        fillRule="evenodd"
+        d="M0 0h4v4H0V0zm4 4h4v4H4V4z"
+        fill="currentColor"
+        fillOpacity="0.2"
+      />
+    </pattern>
+  ),
+  "overlapping-circles": ({ id }) => (
+    <pattern id={id} x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path
+        className="text-border"
+        fillRule="evenodd"
+        d="M25 25c0-2.762 2.238-5 5-5s5 2.238 5 5-2.238 5-5 5c0 2.762-2.238 5-5 5s-5-2.238-5-5 2.238-5 5-5zM5 5c0-2.762 2.238-5 5-5s5 2.238 5 5-2.238 5-5 5c0 2.762-2.238 5-5 5S0 12.762 0 10s2.238-5 5-5zm5 4c2.209 0 4-1.791 4-4s-1.791-4-4-4-4 1.791-4 4 1.791 4 4 4zm20 20c2.209 0 4-1.791 4-4s-1.791-4-4-4-4 1.791-4 4 1.791 4 4 4z"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  ),
+  "wiggle-lines": ({ id }) => (
+    <pattern
+      id={id}
+      x="0"
+      y="0"
+      width="52"
+      height="26"
+      patternUnits="userSpaceOnUse"
+      patternTransform="scale(0.6)"
+    >
+      <path
+        className="text-border"
+        d="M10 10c0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6h2c0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4v2c-3.314 0-6-2.686-6-6 0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6zm25.464-1.95l8.486 8.486-1.414 1.414-8.486-8.486 1.414-1.414z"
+        fill="currentColor"
+        fillOpacity="0.4"
+      />
+    </pattern>
+  ),
+  bubbles: ({ id }) => (
+    <pattern
+      id={id}
+      x="0"
+      y="0"
+      width="100"
+      height="100"
+      patternUnits="userSpaceOnUse"
+      patternTransform="scale(0.6667)"
+    >
+      <path
+        className="text-border"
+        d="M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM12 86c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm28-65c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm23-11c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-6 60c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm29 22c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zM32 63c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm57-13c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-9-21c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM60 91c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM35 41c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM12 60c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2z"
+        fill="currentColor"
+        fillOpacity="0.4"
+        fillRule="evenodd"
+      />
+    </pattern>
+  ),
+};
+
+function ChartBackground({ variant }: { variant: BackgroundVariant }) {
+  const baseId = useId().replace(/:/g, "");
+  const patternId = `${baseId}-bg-${variant}`;
+  const maskId = `${baseId}-bg-edge-fade`;
+  const filterId = `${baseId}-bg-blur`;
+  const Pattern = BACKGROUND_PATTERNS[variant];
+
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 z-0 h-full w-full"
+      width="100%"
+      height="100%"
+      aria-hidden
+    >
+      <defs>
+        <Pattern id={patternId} />
+        {/* Gaussian blur + inset white rect → soft transparent edges. */}
+        <filter id={filterId}>
+          <feGaussianBlur stdDeviation="25" />
+        </filter>
+        <mask id={maskId} maskUnits="userSpaceOnUse">
+          <rect x="8%" y="20%" width="85%" height="60%" fill="white" filter={`url(#${filterId})`} />
+        </mask>
+      </defs>
+      <rect width="100%" height="100%" fill={`url(#${patternId})`} mask={`url(#${maskId})`} />
+    </svg>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option builders — pure functions from a snapshot context to ECharts option
+// fragments. The component reads its refs ONCE per build into this context;
+// nothing below touches React state or the chart instance, so each fragment can
+// be reasoned about (and tested) in isolation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OptionBuildContext = {
+  categories: string[]; // bar names, in data order (inner → outer ring)
+  values: number[]; // bar values aligned with categories
+  config: ChartConfig;
+  radialBar: RadialBarSlot;
+  variant: RadialVariant;
+  innerRadius: number | string;
+  outerRadius: number | string;
+  angleMax: number;
+  selectedBar: string | null;
+  hasSelection: boolean;
+  tooltipSlot: TooltipSlot;
+  isLoading: boolean;
+  loadingData: () => number[];
+  resolved: ResolvedColors;
+};
+
+// The polar coordinate systems: concentric rings live between innerRadius and
+// outerRadius, centered per the arc variant. TWO identical systems are emitted —
+// index 0 carries the data rings, index 1 the background track, so neither can
+// eat into the other's bar band (see buildTrackSeries).
+function buildPolar(ctx: OptionBuildContext): PolarOption[] {
+  const geom = getVariantGeometry(ctx.variant);
+  const polar: PolarOption = {
+    center: geom.center,
+    radius: [ctx.innerRadius, ctx.outerRadius] as (number | string)[],
+  };
+  return [polar, { ...polar }];
+}
+
+// The VALUE axis: a bar's length is its arc sweep, so the value maps to the
+// angle. Fully hidden — the Recharts twin shows no angular ticks or gridlines.
+function buildAngleAxis(ctx: OptionBuildContext): AngleAxisOption[] {
+  const geom = getVariantGeometry(ctx.variant);
+  const axis: AngleAxisOption = {
+    type: "value",
+    min: 0,
+    max: ctx.angleMax,
+    startAngle: geom.startAngle,
+    endAngle: geom.endAngle,
+    clockwise: true,
+    show: false,
+    axisLine: { show: false },
+    axisTick: { show: false },
+    axisLabel: { show: false },
+    splitLine: { show: false },
+  };
+  // One per polar — an axis binds to its system through `polarIndex`.
+  return [
+    { ...axis, polarIndex: 0 },
+    { ...axis, polarIndex: TRACK_POLAR_INDEX },
+  ];
+}
+
+// The CATEGORY axis: one band per ring. Category index 0 sits innermost, which
+// matches the Recharts twin (first data row = innermost ring). Fully hidden.
+function buildRadiusAxis(ctx: OptionBuildContext): RadiusAxisOption[] {
+  const axis: RadiusAxisOption = {
+    type: "category",
+    data: ctx.categories,
+    show: false,
+    axisLine: { show: false },
+    axisTick: { show: false },
+    axisLabel: { show: false },
+    splitLine: { show: false },
+  };
+  // Identical bands on both polars, so a ring and its track land on the same radius.
+  return [
+    { ...axis, polarIndex: 0 },
+    { ...axis, polarIndex: TRACK_POLAR_INDEX },
+  ];
+}
+
+// The unfilled track behind each bar — a full-range ring drawn only when
+// `showBackground` is set. ECharts' native `showBackground` always spans a full
+// 360° ring even in the `semi` variant (createBackgroundShape hardcodes
+// startAngle 0 / endAngle 2π for tangential polar bars), so the track is a real
+// (silent) bar series at the axis max instead: it fills exactly the arc range.
+//
+// `polarIndex: 1` is load-bearing. Bar series on ONE polar share the radiusAxis
+// band, and ECharts hands out that band per stack id, first come first served:
+// `barWidth = min(remainedWidth, barWidth)` (layout/barPolar.js). Two series
+// each asking for the same barSize therefore split the band — the ring claims
+// its full width and the track is clamped to the leftover, rendering thinner
+// and hugging the ring's inner edge instead of underlaying it. `barGap: "-100%"`
+// does NOT fix this: it only overlaps their offsets, never their widths. Giving
+// the track its own (identical) polar means each series is alone in its band, so
+// both get the requested width and the same centered offset — concentric by
+// construction, in every variant and at any barSize.
+function buildTrackSeries(ctx: OptionBuildContext, loading: boolean): BarSeriesOption {
+  const { radialBar } = ctx;
+  const trackColor = withAlpha(ctx.resolved.tokens.mutedForeground, TRACK_OPACITY);
+  return {
+    id: loading ? LOADING_TRACK_ID : TRACK_SERIES_ID,
+    type: "bar",
+    coordinateSystem: "polar",
+    polarIndex: TRACK_POLAR_INDEX,
+    data: ctx.categories.map(() => ctx.angleMax),
+    barWidth: radialBar.barSize,
+    roundCap: radialBar.cornerRadius > 0,
+    silent: true,
+    // Static: the track is present from the first frame, only the data rings
+    // sweep in (Recharts parity — its background sectors don't animate).
+    animation: false,
+    emphasis: { disabled: true },
+    itemStyle: { color: trackColor },
+    z: 1,
+  };
+}
+
+// The data rings. Each datum carries its own diagonal color fill and selection dim.
+function buildBarSeries(ctx: OptionBuildContext): BarSeriesOption[] {
+  const { categories, values, radialBar, selectedBar, hasSelection, resolved } = ctx;
+
+  const data = categories.map((name, i) => {
+    const slots = resolved.series[name] ?? [FALLBACK_COLOR];
+    const isSelected = selectedBar === null || selectedBar === name;
+    // Selection only dims when the bar is actually clickable (Recharts twin).
+    const dimmed = radialBar.isClickable && hasSelection && !isSelected;
+
+    const itemStyle: BarItemStyle = {
+      color: barPaint(slots),
+      opacity: dimmed ? SELECTED_DIM_OPACITY : 1,
+    };
+
+    return { value: values[i] ?? 0, itemStyle };
+  });
+
+  const main: BarSeriesOption = {
+    id: MAIN_SERIES_ID,
+    type: "bar",
+    coordinateSystem: "polar",
+    // Sole series on polar 0 — the track rides its own polar (see buildTrackSeries).
+    polarIndex: 0,
+    data,
+    barWidth: radialBar.barSize,
+    roundCap: radialBar.cornerRadius > 0,
+    cursor: radialBar.isClickable ? "pointer" : "default",
+    // The radial twin has no hover-highlight, so bars don't emphasise on hover.
+    emphasis: { disabled: true },
+    z: 3, // above the track (z 1)
+  };
+
+  // Main first (index 0) so `showTip` can target it by a stable index; z keeps it
+  // above the track regardless of array order.
+  return [main, ...(radialBar.showBackground ? [buildTrackSeries(ctx, false)] : [])];
+}
+
+// Tooltip HTML builder, closed over the build context. `trigger: "item"` — each
+// ring is an item; hovering one shows that bar. Labels by name (hideLabel parity:
+// no separate header row).
+function buildTooltipOption(ctx: OptionBuildContext): TooltipComponentOption {
+  const { tooltipSlot, config, categories, isLoading } = ctx;
+
+  const formatter = (params: unknown): string => {
+    const p = (Array.isArray(params) ? params[0] : params) as {
+      dataIndex?: number;
+      value?: number | string;
+      seriesId?: string;
+    };
+    if (p == null || String(p.seriesId ?? "").startsWith("__")) return "";
+
+    const index = typeof p.dataIndex === "number" ? p.dataIndex : 0;
+    const key = categories[index] ?? "";
+    const item = config[key];
+    const colorsCount = item ? getColorsCount(item) : 1;
+    const labelText = typeof item?.label === "string" ? item.label : key;
+
+    // Item-trigger tooltip: one ring per hover, with no separate header row
+    // (hideLabel parity), so the shared tooltipShell — which always renders a
+    // label div — is intentionally NOT used. The row shape matches the shared
+    // indicator + label + value, so tooltipRow/tooltipIndicatorHtml build it.
+    const row = tooltipRow({
+      indicatorHtml: tooltipIndicatorHtml(key, colorsCount),
+      labelText,
+      valueText: formatTooltipValue(p.value),
+      dimmed: "",
+    });
+
+    return `<div class="grid min-w-32 items-start gap-1.5 border border-border/50 px-2.5 py-1.5 text-xs shadow-xl ${roundnessClass[tooltipSlot.roundness]} ${tooltipVariantClass[tooltipSlot.variant]}">
+      <div class="grid gap-1.5">${row}</div>
+    </div>`;
+  };
+
+  return {
+    show: tooltipSlot.present && !isLoading,
+    trigger: "item",
+    confine: true,
+    backgroundColor: "transparent",
+    borderWidth: 0,
+    padding: 0,
+    extraCssText: "box-shadow:none;",
+    // "variable" → undefined (ECharts default item anchoring, current behavior);
+    // "fixed" → pin near the top, tracking the pointer's X only.
+    position: resolveTooltipPosition(tooltipSlot.position),
+    formatter,
+  };
+}
+
+// Loading skeleton — a faint set of full rings (the always-visible track) with a
+// bright band CLIPPED to a sweeping window on top (the `__loading` rings). One
+// gray skeleton regardless of the real data, matching the area twin's approach.
+function buildLoadingOption(ctx: OptionBuildContext): EChartsOption {
+  const { tokens } = ctx.resolved;
+  const loadingCats = Array.from({ length: LOADING_BARS }, (_, i) => String(i));
+  const loadingCtx: OptionBuildContext = {
+    ...ctx,
+    categories: loadingCats,
+    angleMax: LOADING_MAX,
+  };
+
+  return {
+    animation: false,
+    polar: buildPolar(loadingCtx),
+    angleAxis: buildAngleAxis(loadingCtx),
+    radiusAxis: buildRadiusAxis(loadingCtx),
+    tooltip: { show: false },
+    series: [
+      buildTrackSeries(loadingCtx, true),
+      {
+        id: LOADING_SERIES_ID,
+        type: "bar",
+        coordinateSystem: "polar",
+        polarIndex: 0,
+        data: ctx.loadingData(),
+        barWidth: loadingCtx.radialBar.barSize,
+        roundCap: loadingCtx.radialBar.cornerRadius > 0,
+        silent: true,
+        emphasis: { disabled: true },
+        // Invisible until the first shimmer tick positions the clip window.
+        itemStyle: { color: withAlpha(tokens.foreground, 0) },
+        z: 2,
+      },
+    ],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live imperative state — everything the ECharts event handlers, rAF loop, and
+// theme/resize repushes read or write OUTSIDE the React render cycle, grouped in
+// one ref-stable object so the whole imperative surface is visible at a glance.
+// None of it is render output, which is exactly why it is not React state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LiveState = {
+  resolved: ResolvedColors | null; // colors read off the live DOM — feeds builds and the shimmer loop
+  hasRevealed: boolean; // the intro sweep already played on this chart instance
+  loadingRows: number[] | null; // skeleton data, lazily rolled and re-rolled per shimmer sweep
+  categories: string[]; // bar names of the last build (click → name lookup)
+  valueByName: Map<string, number>; // bar values (legend/click → selection value)
+  handlers: { clickable: boolean }; // latest flags for the imperative click handler
+  // Update-style re-push for paths that bypass React entirely (theme flips,
+  // resizes) — set by the sync effect.
+  repush: () => void;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Apache ECharts port of the EvilCharts radial chart, exposing a
+ * compound-as-config API so its JSX reads identically to the Recharts twin. The
+ * root owns the data, config, selection state, loading skeleton, and intro
+ * reveal; every visual part — `<RadialBar>`, `<Tooltip>`, `<Legend>` — is
+ * composed as a declarative child that renders nothing. The root walks those
+ * children by reference and drives a single imperative ECharts instance. Fully
+ * self-contained: its only dependencies are `react`, `echarts`, and `motion`.
+ */
+export function EChartsRadialChart<TData extends Record<string, unknown>>({
+  data,
+  config,
+  nameKey,
+  className,
+  variant = "full",
+  max,
+  innerRadius = DEFAULT_INNER_RADIUS,
+  outerRadius = DEFAULT_OUTER_RADIUS,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+  isLoading = false,
+  backgroundVariant,
+  chartOptions,
+  children,
+}: EChartsRadialChartProps<TData>) {
+  const rawId = useId();
+  const chartId = `chart-${rawId.replace(/:/g, "")}`;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<HTMLDivElement>(null);
+  const echartsRef = useRef<EChartsInstance | null>(null);
+
+  // The single imperative surface (see LiveState). `resolved` lives here rather
+  // than in state: as state it would force an extra render pass and an effect
+  // whose only job is to trigger the option push — the "chain of computations"
+  // react.dev/learn/you-might-not-need-an-effect warns about. The object
+  // identity is stable for the component's lifetime.
+  const live = useRef<LiveState>({
+    resolved: null,
+    hasRevealed: false,
+    loadingRows: null,
+    categories: [],
+    valueByName: new Map<string, number>(),
+    handlers: { clickable: false },
+    repush: () => {},
+  }).current;
+
+  // Skeleton rows roll lazily on first use — an impure useRef initializer would
+  // re-roll Math.random() on every render.
+  const loadingData = useCallback(
+    () => (live.loadingRows ??= getLoadingData(LOADING_BARS)),
+    [live],
+  );
+  const shouldReduceMotion = useReducedMotion();
+
+  const [selectedBar, setSelectedBar] = useState<string | null>(defaultSelectedDataKey);
+
+  // ── Declarative config, collected from children by reference ─────────────────
+  const collected = useMemo(() => collectConfig(children), [children]);
+  const { radialBar, tooltip: tooltipSlot, legend: legendSlot } = collected;
+
+  const configKeys = useMemo(() => Object.keys(config), [config]);
+
+  // Bar names + values, in data order (index 0 → innermost ring).
+  const categories = useMemo(() => data.map((row) => String(row[nameKey])), [data, nameKey]);
+  const values = useMemo(
+    () => data.map((row) => Number(row[radialBar.dataKey]) || 0),
+    [data, radialBar.dataKey],
+  );
+
+  // An explicit `max` pins what a full sweep means (gauges). Otherwise a nice
+  // ceiling over the data so the largest ring stops just shy of a full wrap
+  // (Recharts derives an auto-scaled domain; the exact niced max differs slightly
+  // but keeps the same look).
+  const angleMax = useMemo(
+    () => (max != null && max > 0 ? max : niceCeil(Math.max(0, ...values))),
+    [max, values],
+  );
+
+  const css = useMemo(() => buildChartCss(chartId, config), [chartId, config]);
+  const hasSelection = selectedBar !== null;
+
+  // Refresh the imperative snapshots every render so the click handler and the
+  // legend/click selection see current values.
+  live.categories = categories;
+  live.handlers = { clickable: radialBar.isClickable };
+  live.valueByName = useMemo(() => {
+    const map = new Map<string, number>();
+    categories.forEach((name, i) => map.set(name, values[i] ?? 0));
+    return map;
+  }, [categories, values]);
+
+  // Toggle selection and notify the parent with the bar's value (or null on
+  // deselect). Selecting the active bar clears the selection.
+  const toggleSelection = useCallback(
+    (name: string) => {
+      setSelectedBar((prev) => {
+        const next = prev === name ? null : name;
+        onSelectionChange?.(
+          next === null ? null : { dataKey: next, value: live.valueByName.get(next) ?? 0 },
+        );
+        return next;
+      });
+    },
+    [onSelectionChange, live],
+  );
+
+  // ── Option builder ───────────────────────────────────────────────────────────
+  // Thin orchestrator over the pure builders: snapshot the resolved colors into
+  // an OptionBuildContext, then assemble.
+  const buildOption = useCallback((): EChartsOption => {
+    const resolved = live.resolved;
+    if (!resolved) return {};
+
+    const ctx: OptionBuildContext = {
+      categories,
+      values,
+      config,
+      radialBar,
+      variant,
+      innerRadius,
+      outerRadius,
+      angleMax,
+      selectedBar,
+      hasSelection,
+      tooltipSlot,
+      isLoading,
+      loadingData,
+      resolved,
+    };
+
+    if (isLoading) return buildLoadingOption(ctx);
+
+    return {
+      animation: false,
+      polar: buildPolar(ctx),
+      angleAxis: buildAngleAxis(ctx),
+      radiusAxis: buildRadiusAxis(ctx),
+      tooltip: buildTooltipOption(ctx),
+      series: buildBarSeries(ctx),
+    };
+  }, [
+    live,
+    categories,
+    values,
+    config,
+    radialBar,
+    variant,
+    innerRadius,
+    outerRadius,
+    angleMax,
+    selectedBar,
+    hasSelection,
+    tooltipSlot,
+    isLoading,
+    loadingData,
+  ]);
+
+  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  useEffect(() => {
+    const mount = mountRef.current;
+    const container = containerRef.current;
+    if (!mount || !container) return;
+
+    const chart = echarts.init(mount);
+    echartsRef.current = chart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Observers always fire once right after observe(). Repushing on that
+      // no-op fire would land one frame into the intro and stomp the reveal —
+      // only react when the renderer size actually changed.
+      if (mount.clientWidth === chart.getWidth() && mount.clientHeight === chart.getHeight()) {
+        return;
+      }
+      chart.resize();
+      live.repush();
+    });
+    resizeObserver.observe(mount);
+
+    // Light/dark flips change no React state — re-resolve and push directly.
+    const themeObserver = new MutationObserver(() => live.repush());
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    chart.on("click", (params) => {
+      if (!live.handlers.clickable) return;
+      const p = params as { seriesId?: string; dataIndex?: number; componentType?: string };
+      // Only the main ring series is clickable; the track/skeleton are silent.
+      if (p.componentType !== "series" || p.seriesId !== MAIN_SERIES_ID) return;
+      if (typeof p.dataIndex !== "number") return;
+      const name = live.categories[p.dataIndex];
+      if (name != null) toggleSelection(name);
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      chart.dispose();
+      echartsRef.current = null;
+      // The reveal guard belongs to the chart instance it guarded. Without this
+      // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
+      // the throwaway instance and the surviving one renders without it.
+      live.hasRevealed = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    const container = containerRef.current;
+    if (!chart || !container) return;
+
+    // Colors come from the <style> committed just before this effect ran — read
+    // them here, right before the push, rather than round-tripping through state.
+    live.resolved = resolveColors(container, config, configKeys);
+
+    const push = (withEntrance: boolean) => {
+      const option = buildOption();
+      const merged = chartOptions ? { ...option, ...chartOptions } : option;
+      Object.assign(merged, {
+        animation: withEntrance,
+        animationDuration: REVEAL_DURATION,
+        animationDurationUpdate: 0,
+      });
+      // chartOptions is an untyped escape hatch — the spread erases the option's
+      // shape, so re-assert it. The only cast in the file.
+      chart.setOption(merged as EChartsOption, { notMerge: true });
+
+      // Show the default tooltip once the option is in place (item trigger →
+      // target the main series by its stable index).
+      if (!isLoading && tooltipSlot.present && tooltipSlot.defaultIndex != null) {
+        chart.dispatchAction({
+          type: "showTip",
+          seriesIndex: 0,
+          dataIndex: tooltipSlot.defaultIndex,
+        });
+      }
+    };
+
+    // Intro reveal — ECharts' native bar sweep, enabled only for the first real
+    // render. Every later push (selection, theme) applies instantly, since
+    // notMerge would otherwise replay the entrance on each of them. A loading
+    // cycle re-arms it: the Recharts twin remounts its <RadialBar> while loading
+    // and replays the intro, so data → loading → data sweeps in again here too.
+    if (isLoading) live.hasRevealed = false;
+    const shouldReveal = !live.hasRevealed && !isLoading;
+    if (shouldReveal) live.hasRevealed = true;
+    const revealEnabled = shouldReveal && !shouldReduceMotion;
+    push(revealEnabled);
+
+    // Theme flips and resizes re-enter here without touching React: re-read the
+    // tokens (the .dark class changed) and push an update-style option.
+    live.repush = () => {
+      live.resolved = resolveColors(container, config, configKeys);
+      push(false);
+    };
+  }, [
+    live,
+    buildOption,
+    chartOptions,
+    isLoading,
+    shouldReduceMotion,
+    config,
+    configKeys,
+    tooltipSlot,
+  ]);
+
+  // ── Loading shimmer — rAF sweeps a bright band, regenerating data off-screen ──
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || !isLoading) return;
+
+    let raf = 0;
+    let lastPhase = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const phase = ((((now - start) / LOADING_ANIMATION_DURATION) % 1) + 1) % 1;
+      // Wrapped past 1 → the band is off-screen; swap in fresh random data.
+      if (phase < lastPhase) live.loadingRows = getLoadingData(LOADING_BARS);
+      lastPhase = phase;
+
+      // Read tokens per frame, so a theme flip mid-loading retints the shimmer.
+      const foreground = live.resolved?.tokens.foreground ?? FALLBACK_COLOR;
+      const w = chart.getWidth();
+      const h = chart.getHeight();
+      if (!w || !h) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      // Sweep the clip window from fully off-screen to fully off-screen along a
+      // 45° axis (ABSOLUTE pixel coords via the gradient's `global` flag), so
+      // every ring is cut by the same diagonal band.
+      const maxT = (w + h) / (2 * w);
+      const center = phase * (maxT + 2 * LOADING_SHIMMER_BAND) - LOADING_SHIMMER_BAND;
+      const clip = new echarts.graphic.LinearGradient(
+        0,
+        0,
+        w,
+        w,
+        shimmerWindowStops(center, foreground, LOADING_SHIMMER_MAX_OPACITY),
+        true,
+      );
+      chart.setOption(
+        { series: [{ id: LOADING_SERIES_ID, data: loadingData(), itemStyle: { color: clip } }] },
+        { silent: true, lazyUpdate: true },
+      );
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [live, isLoading, loadingData]);
+
+  // ── Legend overlay (HTML) ─────────────────────────────────────────────────────
+  // One entry per ring. Unlike the area twin's absolutely-positioned legend, the
+  // top/bottom placements flow above/below the canvas so they RESERVE space —
+  // the polar plot shrinks to fit, matching how Recharts lays the legend out.
+  // `middle` overlays, centered.
+  const legendJustify =
+    legendSlot.align === "left"
+      ? "justify-start"
+      : legendSlot.align === "center"
+        ? "justify-center"
+        : "justify-end";
+
+  const renderLegend = (overlay: boolean) => (
+    <div
+      className={`flex flex-wrap items-center gap-3 px-4 select-none ${legendJustify} ${
+        overlay ? "pointer-events-auto absolute inset-x-4 top-1/2 -translate-y-1/2" : "py-2"
+      }`}
+    >
+      {categories.map((name) => {
+        const item = config[name];
+        const colorsCount = item ? getColorsCount(item) : 1;
+        const isActive = selectedBar === null || selectedBar === name;
+        return (
+          <div
+            key={name}
+            className={`flex items-center gap-1.5 transition-opacity ${
+              !isActive ? "opacity-30" : ""
+            } ${legendSlot.isClickable ? "cursor-pointer" : ""}`}
+            onClick={() => {
+              if (legendSlot.isClickable) toggleSelection(name);
+            }}
+          >
+            <LegendIndicator
+              variant={legendSlot.variant}
+              dataKey={name}
+              colorsCount={colorsCount}
+            />
+            {item?.label ?? name}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const showLegend = legendSlot.present && !isLoading;
+  const legendTop = showLegend && legendSlot.verticalAlign === "top";
+  const legendBottom = showLegend && legendSlot.verticalAlign === "bottom";
+  const legendMiddle = showLegend && legendSlot.verticalAlign === "middle";
+
+  return (
+    <div
+      ref={containerRef}
+      data-chart={chartId}
+      className={`relative flex flex-col text-xs ${className ?? ""}`}
+    >
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+
+      {legendTop && renderLegend(false)}
+
+      <div className="relative min-h-0 w-full flex-1">
+        {backgroundVariant && <ChartBackground variant={backgroundVariant} />}
+        {/* Canvas is transparent, so the background SVG shows through behind it. */}
+        <div ref={mountRef} className="relative z-10 h-full min-h-0 w-full" />
+        {legendMiddle && renderLegend(true)}
+      </div>
+
+      {legendBottom && renderLegend(false)}
+
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+          <motion.div
+            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+            className="flex items-center justify-center gap-2 rounded-md border bg-background px-2 py-0.5 text-sm text-primary"
+          >
+            <div className="h-3 w-3 animate-spin rounded-full border border-border border-t-primary" />
+            <span>Loading</span>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+EChartsRadialChart.RadialBar = RadialBar;
+EChartsRadialChart.Tooltip = Tooltip;
+EChartsRadialChart.Legend = Legend;

--- a/packages/charts/src/components/evilcharts/charts/echarts-sankey-chart.tsx
+++ b/packages/charts/src/components/evilcharts/charts/echarts-sankey-chart.tsx
@@ -1,0 +1,1418 @@
+"use client";
+
+import type { ComposeOption } from "echarts/core";
+
+import {
+  buildChartCss,
+  getColorsCount,
+  resolveColors,
+  withAlpha,
+  type ChartConfig,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+import {
+  formatTooltipValue,
+  resolveTooltipPosition,
+  roundnessClass,
+  tooltipIndicatorHtml,
+  tooltipRow,
+  tooltipVariantClass,
+  type TooltipPosition,
+  type TooltipRoundness,
+  type TooltipVariant,
+} from "@harmony/charts/components/evilcharts/ui/echarts-tooltip";
+import { SankeyChart, type SankeySeriesOption } from "echarts/charts";
+import { TooltipComponent, type TooltipComponentOption } from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { motion, useReducedMotion } from "motion/react";
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+  type ReactNode,
+} from "react";
+
+// Re-export the shared types that were previously declared inline here, so
+// existing consumers/examples keep importing them from the chart module.
+export type { ChartConfig, TooltipPosition, TooltipRoundness, TooltipVariant };
+
+// Modular registration keeps the bundle lean — only the pieces this chart needs.
+// A sankey draws its own node/link geometry, so there is no grid, axis, or
+// dataZoom here; the tooltip is the one extra component. GraphicComponent is
+// deliberately NOT registered — this chart adds no raw graphic overlays.
+echarts.use([SankeyChart, TooltipComponent, CanvasRenderer]);
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+// The exact option surface this chart uses — a sankey series plus the tooltip.
+// Narrower than echarts' full EChartsOption, so a misspelled key fails the
+// compile instead of silently reaching setOption.
+type EChartsOption = ComposeOption<SankeySeriesOption | TooltipComponentOption>;
+
+// Single-item views of the composed series' node/link arrays — the modular entry
+// points don't export the sankey node/edge item option types directly, so derive
+// them from the composed series to keep the builders fully type-checked.
+type SankeyNodeItem = NonNullable<SankeySeriesOption["data"]>[number];
+type SankeyEdgeItem = NonNullable<SankeySeriesOption["links"]>[number];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Intro reveal — the diagram assembles itself column by column. Each node grows
+// out of its own vertical centre, then its outgoing bands draw toward the next
+// column, which pulls the eye along the flow. (Echarts' native sankey entrance is
+// a single clip rect sweeping across the whole diagram; it ignores the graph, so
+// bands appear before the nodes they leave. This one is driven frame by frame
+// instead — see the intro rAF effect.) Times are in milliseconds.
+const INTRO_COLUMN_STAGGER = 130; // delay between one column and the next
+const INTRO_NODE_GROW = 340; // a single node opening from its centre
+const INTRO_LINK_DELAY = 90; // head start a column's nodes get over their bands
+const INTRO_LINK_DRAW = 520; // a band drawing from its source to its target
+const INTRO_FEATHER = 0.05; // softening on the growing/drawing edge, in gradient offset
+const INTRO_NODE_SCALE_FROM = 0.8; // a node opens from this fraction of its height, not from nothing
+const LOADING_ANIMATION_DURATION = 2000; // shimmer loop, in milliseconds
+const DEFAULT_NODE_WIDTH = 10;
+const DEFAULT_NODE_PADDING = 10;
+const DEFAULT_LINK_CURVATURE = 0.5;
+const DEFAULT_ITERATIONS = 32;
+const GRAY = "rgba(120, 120, 120, 1)"; // fallback when a node has no resolved color
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Theme knobs — every opacity in the diagram draws from these. Base colors come
+// from the consumer's CSS tokens (resolved from the live DOM), so only the
+// opacity factors live here. `withAlpha` MULTIPLIES a token's own alpha, so a
+// translucent background/border token stays honest. Tune here, not inline.
+// ─────────────────────────────────────────────────────────────────────────────
+const NODE_FILL_OPACITY = 1; // resting/selected node rectangle — the bold, opaque element (stroke analogue) reads solid at full opacity (bumped from Recharts fillOpacity 0.9)
+const NODE_DIM_OPACITY = 0.3; // node not connected to the current selection (stroke-dim analogue — kept)
+const LINK_FILL_OPACITY = 0.4; // resting link band (Recharts fillOpacity 0.4 — the translucent fill base, kept)
+const LINK_DIM_OPACITY = 0.05; // link not touching the current selection — the translucent band (fill analogue) recedes further (halved from 0.1)
+const LABEL_DIM_OPACITY = 0.3; // node label faded when its node is dimmed
+const INSIDE_PLATE_ALPHA = 0.55; // inside-label plate fill, × background alpha (twin's white/50 · black/60 wash)
+const INSIDE_RIM_WIDTH = 1; // colored rim around the inside-label plate, in pixels (matches the twin's 1px inset edge)
+
+// The loading skeleton is a fixed gray sankey swept by a shimmer band. Unlike the
+// area chart's clip window (fully transparent outside the sweep), the sankey keeps
+// a low BASE floor so the blocky node/link geometry stays legible between sweeps —
+// the bright band still rides across as an absolute-pixel gradient shared by nodes
+// and links, sine-feathered at its edges.
+const LOADING_NODE_FLOOR = 0.1; // node fill outside the sweep, × foreground alpha
+const LOADING_NODE_PEAK = 0.42; // node fill inside the sweep, × foreground alpha
+const LOADING_LINK_FLOOR = 0.04; // link fill outside the sweep, × foreground alpha
+const LOADING_LINK_PEAK = 0.16; // link fill inside the sweep, × foreground alpha
+const LOADING_SHIMMER_BAND = 0.22; // sweep half-width, fraction of chart width
+const LOADING_SHIMMER_FEATHER = 0.22; // eased edge softening of the sweep
+
+// Fixed skeleton graph — three columns, auto-laid-out by echarts. Values are
+// arbitrary; only the shape matters while loading.
+const SKELETON_NODES = [
+  { name: "s0" },
+  { name: "s1" },
+  { name: "s2" },
+  { name: "m0" },
+  { name: "m1" },
+  { name: "m2" },
+  { name: "e0" },
+  { name: "e1" },
+];
+const SKELETON_LINKS = [
+  { source: "s0", target: "m0", value: 8 },
+  { source: "s0", target: "m1", value: 5 },
+  { source: "s1", target: "m1", value: 7 },
+  { source: "s1", target: "m2", value: 4 },
+  { source: "s2", target: "m1", value: 5 },
+  { source: "s2", target: "m2", value: 6 },
+  { source: "m0", target: "e0", value: 7 },
+  { source: "m1", target: "e0", value: 9 },
+  { source: "m1", target: "e1", value: 6 },
+  { source: "m2", target: "e1", value: 8 },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type LinkVariant = "gradient" | "solid" | "source" | "target";
+export type NodeLabelPosition = "inside" | "outside";
+// TooltipVariant and TooltipRoundness now live in @/registry/ui/echarts-tooltip and
+// are imported + re-exported at the top of this file.
+// Sankey has no directional draw-in — its entrance follows the graph, not an
+// axis: "default" plays the column cascade, "none" turns it off. Kept as a small
+// union for copy-paste parity with the other EvilCharts entrance off-switches.
+export type SankeyAnimationType = "none" | "default";
+
+// ChartConfig (and its AtLeastOneThemeColor constraint) now lives in the shared
+// @/registry/ui/echarts-chart module and is imported + re-exported at the top.
+
+// A single flow node. `icon` mirrors the Recharts twin's data shape for source
+// compatibility, but canvas can't mount a React node, so it is not rendered.
+export type SankeyNode = {
+  name: string;
+  icon?: ReactNode;
+};
+
+// A single directed flow. `source`/`target` are indices into `nodes`, matching
+// the Recharts Sankey data contract.
+export type SankeyLink = {
+  source: number;
+  target: number;
+  value: number;
+};
+
+export type SankeyData = {
+  nodes: SankeyNode[];
+  links: SankeyLink[];
+};
+
+export interface EChartsSankeyChartProps {
+  data: SankeyData; // nodes + links rendered by the chart
+  config: ChartConfig; // node colors + labels keyed by node name
+  children: ReactNode; // composed parts — <Node>, <NodeLabel>, <Link>, <Tooltip>
+  className?: string; // extra classes for the chart container
+  nodeWidth?: number; // width of each node in pixels
+  nodePadding?: number; // vertical gap between nodes (echarts nodeGap)
+  linkCurvature?: number; // link curve amount, 0 (straight) to 1 (maximum)
+  iterations?: number; // layout iterations — higher is more accurate
+  // `sort` and `verticalAlign` mirror the Recharts twin's prop surface but have
+  // no ECharts sankey equivalent (the layout always sorts + distributes
+  // vertically). They are accepted and ignored; see the port notes.
+  sort?: boolean;
+  align?: "left" | "justify"; // horizontal node alignment (echarts nodeAlign)
+  verticalAlign?: "justify" | "top";
+  defaultSelectedNode?: string | null; // node selected on first render
+  onSelectionChange?: (selection: { dataKey: string; value: number } | null) => void; // fires when the selected node changes
+  isLoading?: boolean; // shows the animated loading skeleton
+  animation?: boolean; // master switch for the intro draw-in — false renders instantly
+  animationType?: SankeyAnimationType; // "none" disables the intro reveal
+  chartOptions?: Record<string, unknown>; // escape hatch merged over the built ECharts option
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Composible parts — DECLARATIVE CONFIG. Every part renders `null`; the root
+// walks `children` by reference (child.type === Node, …) to collect its props.
+// A sankey's nodes and links are intrinsic to its data, so <Node>/<Link> always
+// render — they only CONFIGURE the diagram. <NodeLabel> and <Tooltip> follow the
+// twin's presence semantics: omit them and that part does not render.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface NodeProps {
+  radius?: number; // corner radius of node rectangles in pixels
+  isClickable?: boolean; // lets nodes be selected by clicking them
+  children?: ReactNode; // optional <NodeLabel> composition
+}
+
+/**
+ * Configures how the sankey nodes render. A configuration slot — the root reads
+ * its props and wires them into the ECharts sankey series, so it renders nothing
+ * itself. Compose a <NodeLabel> inside it to show labels.
+ */
+const Node: FC<NodeProps> = () => null;
+
+export interface NodeLabelProps {
+  position?: NodeLabelPosition; // places labels inside or beside the nodes
+  showValues?: boolean; // appends each node's total flow value
+  valueFormatter?: (value: number) => string; // formats node values when shown
+}
+
+/**
+ * Declares labels for the <Node> it is composed inside. Like <Node>, it is a
+ * configuration slot and renders nothing on its own. With no `position`, no
+ * labels show — matching the Recharts twin.
+ */
+const NodeLabel: FC<NodeLabelProps> = () => null;
+
+export interface LinkProps {
+  variant?: LinkVariant; // coloring strategy for the link bands
+  verticalPadding?: number; // reserved for parity with the Recharts twin (see notes)
+}
+
+/**
+ * Configures how the sankey links render. Like <Node>, it is a configuration slot
+ * read by the root and renders nothing itself. The `variant` controls how each
+ * link band is colored.
+ */
+const Link: FC<LinkProps> = () => null;
+
+export interface TooltipProps {
+  variant?: TooltipVariant; // visual style of the tooltip surface
+  roundness?: TooltipRoundness; // border-radius of the tooltip
+  position?: TooltipPosition; // "variable" follows the pointer (default); "fixed" pins the tooltip near the top and tracks the pointer's X
+  defaultIndex?: number; // reserved for parity with the Recharts twin (see notes)
+}
+
+/** Presence enables the hover tooltip. Renders nothing. */
+const Tooltip: FC<TooltipProps> = () => null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Children collection — walk the declarative config into plain objects the option
+// builder consumes. <NodeLabel> is read from the <Node>'s own children.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type NodeSlot = {
+  radius: number;
+  isClickable: boolean;
+};
+type NodeLabelSlot = {
+  position?: NodeLabelPosition; // undefined → no labels, like the Recharts twin
+  showValues: boolean;
+  valueFormatter?: (value: number) => string;
+};
+type LinkSlot = {
+  variant: LinkVariant;
+  verticalPadding: number;
+};
+type TooltipSlot = {
+  present: boolean;
+  variant: TooltipVariant;
+  roundness: TooltipRoundness;
+  position: TooltipPosition;
+  defaultIndex?: number;
+};
+
+type CollectedConfig = {
+  nodeConfig: NodeSlot;
+  nodeLabel: NodeLabelSlot | null;
+  linkConfig: LinkSlot;
+  tooltip: TooltipSlot;
+};
+
+function collectConfig(children: ReactNode): CollectedConfig {
+  let nodeConfig: NodeSlot = { radius: 0, isClickable: false };
+  let nodeLabel: NodeLabelSlot | null = null;
+  let linkConfig: LinkSlot = { variant: "gradient", verticalPadding: 0 };
+  let tooltip: TooltipSlot = {
+    present: false,
+    variant: "default",
+    roundness: "lg",
+    position: "variable",
+  };
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const type = child.type;
+
+    if (type === Node) {
+      const props = child.props as NodeProps;
+      nodeConfig = {
+        radius: props.radius ?? 0,
+        isClickable: props.isClickable ?? false,
+      };
+      Children.forEach(props.children, (labelChild) => {
+        if (isValidElement(labelChild) && labelChild.type === NodeLabel) {
+          const lp = labelChild.props as NodeLabelProps;
+          nodeLabel = {
+            position: lp.position,
+            showValues: lp.showValues ?? false,
+            valueFormatter: lp.valueFormatter,
+          };
+        }
+      });
+    } else if (type === Link) {
+      const props = child.props as LinkProps;
+      linkConfig = {
+        variant: props.variant ?? "gradient",
+        verticalPadding: props.verticalPadding ?? 0,
+      };
+    } else if (type === Tooltip) {
+      const props = child.props as TooltipProps;
+      tooltip = {
+        present: true,
+        variant: props.variant ?? "default",
+        roundness: props.roundness ?? "lg",
+        position: props.position ?? "variable",
+        defaultIndex: props.defaultIndex,
+      };
+    }
+  });
+
+  return { nodeConfig, nodeLabel, linkConfig, tooltip };
+}
+
+// Color plumbing (ChartConfig, getColorsCount, distributeColors, buildChartCss,
+// normalizeColor, withAlpha, ResolvedColors, resolveColors) now lives in
+// @/registry/ui/echarts-chart and is imported at the top of this file. `resolveColors`
+// falls back to GRAY (rgba(120, 120, 120, 1)) for an unresolved node slot, matching
+// this file's GRAY constant.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Paint helpers — the ECharts analogue of the Recharts SVG paints. Node fills are
+// a vertical gradient of the node's colors; link fills follow the <Link> variant.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A node's fill: a vertical multi-stop gradient of its color slots (top → bottom),
+// or a solid color when it has only one. Mirrors the twin's `NodeColorGradients`,
+// which paints each node with a `y1=0 → y2=1` linear gradient.
+function nodeGradient(slots: string[]): string | echarts.graphic.LinearGradient {
+  if (slots.length <= 1) return slots[0] ?? GRAY;
+  const stops = slots.map((color, i) => ({ offset: i / (slots.length - 1), color }));
+  return new echarts.graphic.LinearGradient(0, 0, 0, 1, stops);
+}
+
+// A link band's fill for a given variant. `gradient` bakes the twin's 0.2/0.5/0.2
+// source→target stop alphas into the color; `source`/`target` reuse the node's
+// vertical gradient; `solid` is the foreground token. The connected/dimmed alpha
+// is applied separately as `lineStyle.opacity`, matching the twin's `fillOpacity`.
+function edgeColor(
+  variant: LinkVariant,
+  sourceSlots: string[],
+  targetSlots: string[],
+  foreground: string,
+): string | echarts.graphic.LinearGradient {
+  switch (variant) {
+    case "gradient": {
+      const source = sourceSlots[0] ?? GRAY;
+      const target = targetSlots[0] ?? GRAY;
+      return new echarts.graphic.LinearGradient(0, 0, 1, 0, [
+        { offset: 0, color: withAlpha(source, 0.2) },
+        { offset: 0.5, color: withAlpha(source, 0.5) },
+        { offset: 1, color: withAlpha(target, 0.2) },
+      ]);
+    }
+    case "source":
+      return nodeGradient(sourceSlots);
+    case "target":
+      return nodeGradient(targetSlots);
+    case "solid":
+    default:
+      return foreground;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Intro reveal — timing and paint
+//
+// The entrance is a windowed alpha on the SAME paint the element already uses:
+// a node's fill runs vertically, so a window opening from offset 0.5 makes it
+// grow from its centre; a link's gradient runs horizontally across its own
+// bounding box — which spans exactly source edge → target edge — so a window
+// sweeping 0 → 1 makes the band draw out of its source node. Nothing about the
+// layout moves, so no frame re-runs the sankey solver on different geometry.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Paint = string | echarts.graphic.LinearGradient;
+type IntroState = {
+  elapsed: number; // milliseconds since the intro started
+  depths: Record<string, number>; // node name → column index
+};
+
+// Column index per node: the longest path from any source, which is what puts a
+// node in a later column than every node feeding it. Edges are relaxed until the
+// pass stops changing anything; the node-count cap keeps a malformed (cyclic)
+// graph from spinning forever.
+function computeNodeDepths(data: SankeyData): Record<string, number> {
+  const nameOf = (ref: number) => data.nodes[ref]?.name ?? String(ref);
+  const depths: Record<string, number> = {};
+  for (const node of data.nodes) depths[node.name] = 0;
+
+  for (let pass = 0; pass < data.nodes.length; pass++) {
+    let changed = false;
+    for (const link of data.links) {
+      const source = nameOf(link.source);
+      const target = nameOf(link.target);
+      if (depths[target] === undefined || depths[source] === undefined) continue;
+      if (depths[target] < depths[source] + 1) {
+        depths[target] = depths[source] + 1;
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  return depths;
+}
+
+// How long the whole cascade runs: whichever finishes last, the finalmost column
+// of nodes or the bands leaving the column before it.
+function introDuration(depths: Record<string, number>): number {
+  const maxDepth = Math.max(0, ...Object.values(depths));
+  return Math.max(
+    maxDepth * INTRO_COLUMN_STAGGER + INTRO_NODE_GROW,
+    Math.max(0, maxDepth - 1) * INTRO_COLUMN_STAGGER + INTRO_LINK_DELAY + INTRO_LINK_DRAW,
+  );
+}
+
+const clamp01 = (value: number) => (value < 0 ? 0 : value > 1 ? 1 : value);
+const easeOut = (t: number) => 1 - Math.pow(1 - t, 3);
+
+// 0 → 1 for one node's grow, and for one link's draw. Both key off the source
+// node's column, so a band never starts before the node it leaves.
+function nodePhase(intro: IntroState, name: string): number {
+  const start = (intro.depths[name] ?? 0) * INTRO_COLUMN_STAGGER;
+  return easeOut(clamp01((intro.elapsed - start) / INTRO_NODE_GROW));
+}
+function linkPhase(intro: IntroState, sourceName: string): number {
+  const start = (intro.depths[sourceName] ?? 0) * INTRO_COLUMN_STAGGER + INTRO_LINK_DELAY;
+  return easeOut(clamp01((intro.elapsed - start) / INTRO_LINK_DRAW));
+}
+
+// The axis a paint runs along — "y" for a node's vertical gradient, "x" for a
+// link's horizontal one, null for a flat color (which composes with either).
+function paintAxis(paint: Paint): "x" | "y" | null {
+  if (typeof paint === "string") return null;
+  const horizontal = Math.abs((paint.x2 ?? 0) - (paint.x ?? 0));
+  const vertical = Math.abs((paint.y2 ?? 0) - (paint.y ?? 0));
+  return horizontal >= vertical ? "x" : "y";
+}
+
+function paintStops(paint: Paint): { offset: number; color: string }[] {
+  if (typeof paint === "string") {
+    return [
+      { offset: 0, color: paint },
+      { offset: 1, color: paint },
+    ];
+  }
+  const stops = paint.colorStops ?? [];
+  if (stops.length === 0) return [{ offset: 0, color: GRAY }];
+  return stops.map((stop) => ({ offset: stop.offset, color: stop.color }));
+}
+
+// The paint's color at an arbitrary offset, so a window edge inserted between two
+// stops keeps the hue it interrupts.
+function sampleStops(stops: { offset: number; color: string }[], at: number): string {
+  const first = stops[0]!;
+  const last = stops[stops.length - 1]!;
+  if (!first) return GRAY;
+  if (at <= first.offset) return first.color;
+  if (at >= last.offset) return last.color;
+  for (let i = 1; i < stops.length; i++) {
+    const from = stops[i - 1]!;
+    const to = stops[i]!;
+    if (at > to.offset) continue;
+    const span = to.offset - from.offset;
+    if (span <= 1e-6) return to.color;
+    return echarts.color.lerp((at - from.offset) / span, [from.color, to.color]) || from.color;
+  }
+  return last.color;
+}
+
+// Multiply a paint's alpha by a trapezoid window along `axis`: transparent before
+// `edges[0]`, opaque between `edges[1]` and `edges[2]`, transparent again after
+// `edges[3]`. Returns null when the paint runs along the OTHER axis with real
+// color variation — two axes can't be composed into one canvas gradient, so the
+// caller falls back to a plain fade for that (rare) case.
+function windowedPaint(
+  paint: Paint,
+  axis: "x" | "y",
+  edges: [number, number, number, number],
+): Paint | null {
+  const own = paintAxis(paint);
+  if (own !== null && own !== axis) return null;
+
+  const stops = paintStops(paint);
+  const alphaAt = (offset: number) => {
+    if (offset <= edges[0] || offset >= edges[3]) return 0;
+    if (offset >= edges[1] && offset <= edges[2]) return 1;
+    if (offset < edges[1]) return (offset - edges[0]) / Math.max(1e-6, edges[1] - edges[0]);
+    return (edges[3] - offset) / Math.max(1e-6, edges[3] - edges[2]);
+  };
+
+  const offsets = [...new Set([0, 1, ...stops.map((stop) => stop.offset), ...edges])]
+    .filter((offset) => offset >= 0 && offset <= 1)
+    .sort((a, b) => a - b);
+  const windowed = offsets.map((offset) => ({
+    offset,
+    color: withAlpha(sampleStops(stops, offset), alphaAt(offset)),
+  }));
+
+  return axis === "x"
+    ? new echarts.graphic.LinearGradient(0, 0, 1, 0, windowed)
+    : new echarts.graphic.LinearGradient(0, 0, 0, 1, windowed);
+}
+
+// A node scaling up about its own centre: it starts at INTRO_NODE_SCALE_FROM of
+// full height and opens to 1 — a short pop rather than a wipe from nothing. The
+// fade-in rides the same window (applied by the caller as itemStyle.opacity), so
+// the box scales and lightens together.
+function growPaint(paint: Paint, phase: number): Paint | null {
+  const half = (INTRO_NODE_SCALE_FROM + (1 - INTRO_NODE_SCALE_FROM) * phase) / 2;
+  return windowedPaint(paint, "y", [
+    0.5 - half - INTRO_FEATHER,
+    0.5 - half,
+    0.5 + half,
+    0.5 + half + INTRO_FEATHER,
+  ]);
+}
+
+// A band drawing from its source edge toward its target edge.
+function drawPaint(paint: Paint, phase: number): Paint | null {
+  const head = phase * (1 + INTRO_FEATHER);
+  return windowedPaint(paint, "x", [-2, -1, head - INTRO_FEATHER, head]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Selection helpers — a node click highlights the node plus its direct neighbors
+// and dims the rest, exactly like the Recharts twin's `isNodeConnected`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The selected node plus every node one link away from it.
+function connectedNodeSet(data: SankeyData, selected: string): Set<string> {
+  const set = new Set<string>([selected]);
+  const selectedIdx = data.nodes.findIndex((node) => node.name === selected);
+  if (selectedIdx === -1) return set;
+
+  for (const link of data.links) {
+    if (link.source === selectedIdx) {
+      const name = data.nodes[link.target]?.name;
+      if (name) set.add(name);
+    } else if (link.target === selectedIdx) {
+      const name = data.nodes[link.source]?.name;
+      if (name) set.add(name);
+    }
+  }
+  return set;
+}
+
+// Each node's total flow: outgoing sum, falling back to incoming for leaf nodes —
+// the same value the twin surfaces in labels, the tooltip, and `onSelectionChange`.
+function computeNodeValues(data: SankeyData): Record<string, number> {
+  const values: Record<string, number> = {};
+  data.nodes.forEach((node, index) => {
+    let outgoing = 0;
+    let incoming = 0;
+    for (const link of data.links) {
+      if (link.source === index) outgoing += link.value;
+      if (link.target === index) incoming += link.value;
+    }
+    values[node.name] = outgoing > 0 ? outgoing : incoming;
+  });
+  return values;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loading skeleton helper — a hard clip window swept across the fixed skeleton.
+// `floor` keeps the geometry faintly visible between sweeps; `peak` is the bright
+// band. `center` may run outside [0, 1] so the window fully enters and exits.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function shimmerWindowStops(center: number, color: string, floor: number, peak: number) {
+  const half = LOADING_SHIMMER_BAND;
+  const feather = LOADING_SHIMMER_FEATHER;
+
+  const alphaAt = (x: number) => {
+    const dist = Math.abs(x - center);
+    if (dist <= half - feather) return peak;
+    if (dist >= half) return floor;
+    // Sine-eased falloff — a linear ramp still reads as a hard cut.
+    const eased = Math.sin(((1 - (dist - (half - feather)) / feather) * Math.PI) / 2);
+    return floor + (peak - floor) * eased;
+  };
+
+  const offsets = [
+    0,
+    center - half,
+    center - half + feather,
+    center,
+    center + half - feather,
+    center + half,
+    1,
+  ]
+    .filter((x) => x >= 0 && x <= 1)
+    .sort((a, b) => a - b);
+
+  const stops: { offset: number; color: string }[] = [];
+  for (const offset of offsets) {
+    if (stops.length === 0 || offset - stops[stops.length - 1]!.offset > 1e-4) {
+      stops.push({ offset, color: withAlpha(color, alphaAt(offset)) });
+    }
+  }
+  return stops;
+}
+
+// Tooltip HTML primitives (roundnessClass, tooltipVariantClass, tooltipIndicatorHtml,
+// tooltipRow, resolveTooltipPosition, indicatorBackground) now live in
+// @/registry/ui/echarts-tooltip and are imported at the top. The tooltip DOM lives
+// inside `[data-chart={id}]`, so the injected `--color-*` vars and Tailwind classes
+// resolve directly (no color read).
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option builders — pure functions from a snapshot context to ECharts option
+// fragments. The component reads its refs ONCE per build into this context;
+// nothing below touches React state or the chart instance, so each fragment can
+// be reasoned about (and tested) in isolation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OptionBuildContext = {
+  data: SankeyData;
+  config: ChartConfig;
+  nodeConfig: NodeSlot;
+  nodeLabel: NodeLabelSlot | null;
+  linkConfig: LinkSlot;
+  tooltipSlot: TooltipSlot;
+  selectedNode: string | null;
+  nodeWidth: number;
+  nodePadding: number;
+  linkCurvature: number;
+  iterations: number;
+  align: "left" | "justify";
+  isLoading: boolean;
+  resolved: ResolvedColors;
+  nodeValues: Record<string, number>;
+  outsideLabels: boolean; // reserves right padding for outside labels
+  intro: IntroState | null; // mid-entrance cascade, null once the diagram is fully drawn
+};
+
+// The node label config, shared by every node. Two-line rich text when values are
+// shown; per-node opacity (for selection dimming) is applied on the node items.
+function buildNodeLabel(ctx: OptionBuildContext): SankeySeriesOption["label"] {
+  const { nodeLabel, config, nodeValues, resolved } = ctx;
+  const position = nodeLabel?.position;
+
+  // No <NodeLabel>, or one with no position, shows nothing — Recharts parity.
+  if (position !== "inside" && position !== "outside") return { show: false };
+
+  const { tokens } = resolved;
+  const inside = position === "inside";
+  const showValues = nodeLabel?.showValues ?? false;
+  const format = nodeLabel?.valueFormatter ?? ((value: number) => formatTooltipValue(value));
+
+  const labelOf = (name: string) => {
+    const label = config[name]?.label;
+    return typeof label === "string" ? label : name;
+  };
+
+  const formatter = (params: unknown): string => {
+    const name = String((params as { name?: string | number }).name ?? "");
+    const nameText = labelOf(name);
+    if (!showValues) return `{name|${nameText}}`;
+    return `{name|${nameText}}\n{value|${format(nodeValues[name] ?? 0)}}`;
+  };
+
+  return {
+    show: true,
+    // Inside sits centered on the node; outside hangs to the node's right.
+    position: inside ? "inside" : "right",
+    align: inside ? "center" : "left",
+    formatter,
+    rich: {
+      name: {
+        color: tokens.foreground,
+        fontSize: inside ? 10 : 12,
+        fontWeight: 500,
+        lineHeight: 15,
+      },
+      value: {
+        color: withAlpha(tokens.foreground, inside ? 0.6 : 0.5),
+        fontFamily: "monospace",
+        fontSize: inside ? 11 : 12,
+        lineHeight: 15,
+      },
+    },
+    // No label-scoped backing box for inside labels: the whole node is rebuilt as
+    // the plate in buildSankeySeries (a full-rect background wash with the node's
+    // color showing only as a rounded rim), so the text sits centered directly on
+    // that plate — matching the twin, where the plate spans the entire node rect.
+  };
+}
+
+function buildSankeySeries(ctx: OptionBuildContext): SankeySeriesOption {
+  const {
+    config,
+    data,
+    nodeConfig,
+    linkConfig,
+    selectedNode,
+    nodeWidth,
+    nodePadding,
+    linkCurvature,
+    iterations,
+    align,
+    resolved,
+    outsideLabels,
+    intro,
+  } = ctx;
+  const { tokens, series: slotsByName } = resolved;
+  const hasSelection = selectedNode !== null;
+  const connected = hasSelection ? connectedNodeSet(data, selectedNode) : null;
+  // With inside labels the node is rebuilt as a card: a translucent background
+  // plate fills the whole rect and the node's own color/gradient shows only as a
+  // rounded rim (the colored card behind it — the __sankey-plate series — tints
+  // through the plate). Mirrors the twin's full-rect inset plate + 1px colored edge.
+  const insideLabels = ctx.nodeLabel?.position === "inside";
+
+  // Nodes with no incoming link start the diagram, so an outside label reads on
+  // their LEFT; anything downstream keeps its label on the right. Without the split
+  // every label sits to the right of its node, which drops the first column's text
+  // straight onto its own outgoing bands.
+  const targetNames = new Set(
+    data.links.map((link) => data.nodes[link.target]?.name ?? String(link.target)),
+  );
+
+  const nodes: SankeyNodeItem[] = data.nodes.map((node) => {
+    const slots = slotsByName[node.name] ?? [GRAY];
+    const dimmed = connected ? !connected.has(node.name) : false;
+    // Mid-intro the box scales up about its centre and fades in together; the
+    // label just fades with it (rich text has no partial reveal).
+    const phase = intro ? nodePhase(intro, node.name) : 1;
+    const fill = nodeGradient(slots);
+    const grown = phase < 1 ? growPaint(fill, phase) : fill;
+    const nodeAlpha = (dimmed ? NODE_DIM_OPACITY : NODE_FILL_OPACITY) * phase;
+
+    return {
+      name: node.name,
+      itemStyle: insideLabels
+        ? {
+            // Dark card: plate fill spans the full rect, color rides the rim only.
+            color: withAlpha(tokens.background, INSIDE_PLATE_ALPHA * phase),
+            borderColor: grown ?? fill,
+            borderWidth: INSIDE_RIM_WIDTH,
+            borderRadius: nodeConfig.radius,
+            opacity: (dimmed ? NODE_DIM_OPACITY : 1) * phase,
+          }
+        : {
+            color: grown ?? fill,
+            opacity: nodeAlpha,
+            borderWidth: 0,
+            borderRadius: nodeConfig.radius,
+          },
+      // Fade a node's own label with it when the selection dims it. An empty
+      // config label opts a node out entirely — a pass-through hub carries its
+      // total in the surrounding layout, not on the node.
+      label: {
+        ...(config[node.name]?.label === "" ? { show: false } : {}),
+        opacity: (dimmed ? LABEL_DIM_OPACITY : 1) * phase,
+        ...(outsideLabels && !targetNames.has(node.name)
+          ? { position: "left" as const, align: "right" as const }
+          : {}),
+      },
+    };
+  });
+
+  const links: SankeyEdgeItem[] = data.links.map((link) => {
+    const source = data.nodes[link.source]?.name ?? String(link.source);
+    const target = data.nodes[link.target]?.name ?? String(link.target);
+    const sourceSlots = slotsByName[source] ?? [GRAY];
+    const targetSlots = slotsByName[target] ?? [GRAY];
+    // Connected = nothing selected, or this link touches the selected node.
+    const isConnected = !hasSelection || source === selectedNode || target === selectedNode;
+    // Mid-intro the band is windowed along its own bounding box, so it draws out
+    // of the source node rather than fading in place.
+    const phase = intro ? linkPhase(intro, source) : 1;
+    const band = edgeColor(linkConfig.variant, sourceSlots, targetSlots, tokens.foreground);
+    const drawn = phase < 1 ? drawPaint(band, phase) : band;
+
+    return {
+      source,
+      target,
+      value: link.value,
+      lineStyle: {
+        color: drawn ?? band,
+        opacity: (isConnected ? LINK_FILL_OPACITY : LINK_DIM_OPACITY) * (drawn ? 1 : phase),
+      },
+    };
+  });
+
+  return {
+    id: "__sankey",
+    type: "sankey",
+    z: 3,
+    // Outside labels hang past the outermost columns on BOTH sides — reserve room.
+    left: outsideLabels ? 120 : 8,
+    right: outsideLabels ? 120 : 8,
+    top: 12,
+    bottom: 12,
+    nodeWidth,
+    nodeGap: nodePadding,
+    layoutIterations: iterations,
+    nodeAlign: align === "left" ? "left" : "justify",
+    draggable: false,
+    // The twin has no hover-dimming — hovering only shows the tooltip. `focus:
+    // "none"` keeps every element at full styling on hover (no adjacency blur).
+    emphasis: { focus: "none" },
+    lineStyle: { curveness: linkCurvature },
+    label: buildNodeLabel(ctx),
+    data: nodes,
+    links,
+  };
+}
+
+// The colored card drawn UNDER the inside-label plate. With inside labels the
+// real node's fill becomes a translucent background plate (see buildSankeySeries),
+// so this silent duplicate — identical layout, pixel-exact under the real nodes —
+// supplies the node's actual color/gradient behind that plate. The plate's
+// translucency lets this color tint through (a pale card in light, a dark card in
+// dark), matching the Recharts twin's colored rect beneath its white/black wash.
+// Returns null unless inside labels are active, so the extra series is only paid
+// for on demand.
+function buildInsidePlateSeries(ctx: OptionBuildContext): SankeySeriesOption | null {
+  const {
+    data,
+    nodeConfig,
+    nodeLabel,
+    selectedNode,
+    nodeWidth,
+    nodePadding,
+    linkCurvature,
+    iterations,
+    align,
+    resolved,
+    outsideLabels,
+    intro,
+  } = ctx;
+  if (nodeLabel?.position !== "inside") return null;
+
+  const { series: slotsByName } = resolved;
+  const hasSelection = selectedNode !== null;
+  const connected = hasSelection ? connectedNodeSet(data, selectedNode) : null;
+
+  const nodes: SankeyNodeItem[] = data.nodes.map((node) => {
+    const slots = slotsByName[node.name] ?? [GRAY];
+    const dimmed = connected ? !connected.has(node.name) : false;
+    // Grows in step with the real node above it — the card and its plate are one
+    // element to the eye, so they must open together.
+    const phase = intro ? nodePhase(intro, node.name) : 1;
+    const fill = nodeGradient(slots);
+    const grown = phase < 1 ? growPaint(fill, phase) : fill;
+    return {
+      name: node.name,
+      itemStyle: {
+        color: grown ?? fill,
+        opacity: (dimmed ? NODE_DIM_OPACITY : NODE_FILL_OPACITY) * phase,
+        borderWidth: 0,
+        borderRadius: nodeConfig.radius,
+      },
+      label: { show: false },
+    };
+  });
+
+  // Links exist only so the layout matches the main series pixel-exact; they are
+  // fully transparent here — the real bands are drawn by the __sankey series.
+  const links: SankeyEdgeItem[] = data.links.map((link) => ({
+    source: data.nodes[link.source]?.name ?? String(link.source),
+    target: data.nodes[link.target]?.name ?? String(link.target),
+    value: link.value,
+    lineStyle: { opacity: 0 },
+  }));
+
+  return {
+    id: "__sankey-plate",
+    type: "sankey",
+    z: 2, // below the real __sankey series (z: 3)
+    silent: true,
+    left: outsideLabels ? 120 : 8,
+    right: outsideLabels ? 120 : 8,
+    top: 12,
+    bottom: 12,
+    nodeWidth,
+    nodeGap: nodePadding,
+    layoutIterations: iterations,
+    nodeAlign: align === "left" ? "left" : "justify",
+    draggable: false,
+    emphasis: { disabled: true },
+    label: { show: false },
+    lineStyle: { curveness: linkCurvature },
+    data: nodes,
+    links,
+  };
+}
+
+// Tooltip HTML builder, closed over the build context. A sankey fires item events
+// for both nodes (`dataType: "node"`) and links (`dataType: "edge"`); the
+// formatter renders the right row for each.
+function createTooltipFormatter(ctx: OptionBuildContext) {
+  const { config, nodeValues, tooltipSlot } = ctx;
+
+  const labelOf = (name: string) => {
+    const label = config[name]?.label;
+    return typeof label === "string" ? label : name;
+  };
+  const colorsOf = (name: string) => (config[name] ? getColorsCount(config[name]) : 1);
+  // A sankey tooltip carries no axis title — each hovered node/link surfaces a
+  // single indicator+label+value row. The shared tooltipShell always renders a
+  // title slot, so the outer surface stays a chart-local, title-less wrapper
+  // (reusing the shared roundness/variant classes); the row itself is the shared
+  // tooltipRow with the shared indicator swatch and no per-row dim.
+  const wrap = (body: string) =>
+    `<div class="grid min-w-32 items-start gap-1.5 border border-border/50 px-2.5 py-1.5 text-xs shadow-xl ${roundnessClass[tooltipSlot.roundness]} ${tooltipVariantClass[tooltipSlot.variant]}"><div class="grid gap-1.5">${body}</div></div>`;
+
+  return (params: unknown): string => {
+    const p = params as {
+      dataType?: string;
+      name?: string;
+      data?: { source?: string | number; target?: string | number; value?: number };
+    };
+
+    if (p.dataType === "edge") {
+      const source = String(p.data?.source ?? "");
+      const target = String(p.data?.target ?? "");
+      return wrap(
+        tooltipRow({
+          indicatorHtml: tooltipIndicatorHtml(source, colorsOf(source)),
+          labelText: `${labelOf(source)} → ${labelOf(target)}`,
+          valueText: formatTooltipValue(p.data?.value),
+          dimmed: "",
+        }),
+      );
+    }
+
+    const name = String(p.name ?? "");
+    return wrap(
+      tooltipRow({
+        indicatorHtml: tooltipIndicatorHtml(name, colorsOf(name)),
+        labelText: labelOf(name),
+        valueText: formatTooltipValue(nodeValues[name] ?? 0),
+        dimmed: "",
+      }),
+    );
+  };
+}
+
+function buildTooltipOption(ctx: OptionBuildContext): TooltipComponentOption {
+  const { tooltipSlot, isLoading } = ctx;
+  return {
+    show: tooltipSlot.present && !isLoading,
+    trigger: "item",
+    confine: true,
+    backgroundColor: "transparent",
+    borderWidth: 0,
+    padding: 0,
+    extraCssText: "box-shadow:none;",
+    // "variable" (default) keeps ECharts' item-follow position — the current
+    // behavior; "fixed" pins the tooltip near the top and tracks only the
+    // pointer's X. The sankey tooltip is item-triggered (nodes/links, no axis),
+    // so it wires the position directly through resolveTooltipPosition rather
+    // than tooltipBaseOption, which is trigger:"axis" only.
+    position: resolveTooltipPosition(tooltipSlot.position),
+    formatter: createTooltipFormatter(ctx),
+  };
+}
+
+// Loading skeleton — a fixed gray sankey, invisible until the first shimmer tick
+// tints it. Node fills and link fills are set to fully-transparent foreground so
+// there is no flash before the rAF loop positions the sweep.
+function buildLoadingOption(ctx: OptionBuildContext): EChartsOption {
+  const { resolved } = ctx;
+  const transparent = withAlpha(resolved.tokens.foreground, 0);
+
+  return {
+    animation: false,
+    tooltip: { show: false },
+    series: [
+      {
+        id: "__loading",
+        type: "sankey",
+        left: 12,
+        right: 12,
+        top: 12,
+        bottom: 12,
+        nodeWidth: DEFAULT_NODE_WIDTH,
+        nodeGap: DEFAULT_NODE_PADDING,
+        layoutIterations: DEFAULT_ITERATIONS,
+        draggable: false,
+        silent: true,
+        emphasis: { disabled: true },
+        label: { show: false },
+        itemStyle: { color: transparent, borderWidth: 0 },
+        lineStyle: { color: transparent, curveness: DEFAULT_LINK_CURVATURE },
+        data: SKELETON_NODES,
+        links: SKELETON_LINKS,
+      },
+    ],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live imperative state — everything the ECharts event handlers, the shimmer rAF,
+// and the theme repush read or write OUTSIDE the React render cycle, grouped in
+// one ref-stable object. None of it is render output, which is why it is not
+// React state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LiveState = {
+  resolved: ResolvedColors | null; // colors read off the live DOM — feeds builds and the shimmer
+  hasRevealed: boolean; // the intro cascade already played on this chart instance
+  intro: IntroState | null; // current cascade frame, read by every build while it runs
+  // Latest callbacks/flags for the imperative ECharts click handler.
+  handlers: {
+    onSelectionChange?: (selection: { dataKey: string; value: number } | null) => void;
+    isNodeClickable: boolean;
+    nodeValues: Record<string, number>;
+  };
+  // Update-style re-push for paths that bypass React entirely (theme flips,
+  // resizes) — set by the sync effect.
+  repush: () => void;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Apache ECharts port of the EvilCharts sankey chart, exposing a compound-as-config
+ * API so its JSX reads identically to the Recharts twin. The root owns the flow
+ * data, selection state, the loading skeleton, and the intro reveal; the visual
+ * parts — `<Node>`, `<NodeLabel>`, `<Link>`, `<Tooltip>` — are composed as
+ * declarative children that render nothing. The root walks those children by
+ * reference and drives a single imperative ECharts instance. Fully self-contained:
+ * its only dependencies are `react`, `echarts`, and `motion`.
+ */
+export function EChartsSankeyChart({
+  data,
+  config,
+  children,
+  className,
+  nodeWidth = DEFAULT_NODE_WIDTH,
+  nodePadding = DEFAULT_NODE_PADDING,
+  linkCurvature = DEFAULT_LINK_CURVATURE,
+  iterations = DEFAULT_ITERATIONS,
+  align = "justify",
+  defaultSelectedNode = null,
+  onSelectionChange,
+  isLoading = false,
+  animation = true,
+  animationType = "default",
+  chartOptions,
+}: EChartsSankeyChartProps) {
+  const rawId = useId();
+  const chartId = `chart-${rawId.replace(/:/g, "")}`;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<HTMLDivElement>(null);
+  const echartsRef = useRef<EChartsInstance | null>(null);
+
+  // The single imperative surface (see LiveState). `resolved` lives here rather
+  // than in state: as state it would force an extra render pass and an effect
+  // whose only job is to push the option. Object identity is stable for the
+  // component's lifetime.
+  const live = useRef<LiveState>({
+    resolved: null,
+    hasRevealed: false,
+    intro: null,
+    handlers: {
+      onSelectionChange,
+      isNodeClickable: false,
+      nodeValues: {},
+    },
+    repush: () => {},
+  }).current;
+
+  const shouldReduceMotion = useReducedMotion();
+
+  const [selectedNode, setSelectedNode] = useState<string | null>(defaultSelectedNode);
+
+  // ── Declarative config, collected from children by reference ─────────────────
+  const collected = useMemo(() => collectConfig(children), [children]);
+  const { nodeConfig, nodeLabel, linkConfig, tooltip: tooltipSlot } = collected;
+
+  const nodeValues = useMemo(() => computeNodeValues(data), [data]);
+  const outsideLabels = nodeLabel?.position === "outside";
+
+  const css = useMemo(() => buildChartCss(chartId, config), [chartId, config]);
+
+  // Node names double as the color keys — resolve `--color-{name}-{n}` for each.
+  const nodeNames = useMemo(() => data.nodes.map((node) => node.name), [data]);
+
+  // Refresh the click handler's snapshot of the latest callbacks/flags every render.
+  live.handlers = {
+    onSelectionChange,
+    isNodeClickable: nodeConfig.isClickable,
+    nodeValues,
+  };
+
+  const toggleSelection = useCallback(
+    (name: string) => {
+      setSelectedNode((prev) => {
+        const next = prev === name ? null : name;
+        const { onSelectionChange: cb, nodeValues: values } = live.handlers;
+        cb?.(next === null ? null : { dataKey: next, value: values[next] ?? 0 });
+        return next;
+      });
+    },
+    [live],
+  );
+
+  // ── Option builder ───────────────────────────────────────────────────────────
+  // Thin orchestrator over the pure builders above: snapshot the imperative
+  // surface into an OptionBuildContext, then assemble.
+  const buildOption = useCallback((): EChartsOption => {
+    const resolved = live.resolved;
+    if (!resolved) return {};
+
+    const ctx: OptionBuildContext = {
+      data,
+      config,
+      nodeConfig,
+      nodeLabel,
+      linkConfig,
+      tooltipSlot,
+      selectedNode,
+      nodeWidth,
+      nodePadding,
+      linkCurvature,
+      iterations,
+      align,
+      isLoading,
+      resolved,
+      nodeValues,
+      outsideLabels,
+      intro: live.intro,
+    };
+
+    if (isLoading) return buildLoadingOption(ctx);
+
+    // Draw order, bottom → top: the colored card under inside-label plates, then
+    // the real sankey on top.
+    const series: SankeySeriesOption[] = [];
+    const plateSeries = buildInsidePlateSeries(ctx);
+    if (plateSeries) series.push(plateSeries);
+    series.push(buildSankeySeries(ctx));
+
+    return {
+      animation: false,
+      tooltip: buildTooltipOption(ctx),
+      series,
+    };
+  }, [
+    live,
+    data,
+    config,
+    nodeConfig,
+    nodeLabel,
+    linkConfig,
+    tooltipSlot,
+    selectedNode,
+    nodeWidth,
+    nodePadding,
+    linkCurvature,
+    iterations,
+    align,
+    isLoading,
+    nodeValues,
+    outsideLabels,
+  ]);
+
+  // ── Init + resize + theme observer (once) ────────────────────────────────────
+  useEffect(() => {
+    const mount = mountRef.current;
+    const container = containerRef.current;
+    if (!mount || !container) return;
+
+    const chart = echarts.init(mount);
+    echartsRef.current = chart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Observers always fire once right after observe(). Repushing on that no-op
+      // fire would land one frame into the intro and stomp the reveal — only
+      // react when the renderer size actually changed.
+      if (mount.clientWidth === chart.getWidth() && mount.clientHeight === chart.getHeight()) {
+        return;
+      }
+      chart.resize();
+      live.repush();
+    });
+    resizeObserver.observe(mount);
+
+    // Light/dark flips change no React state — re-resolve and push directly.
+    const themeObserver = new MutationObserver(() => {
+      live.repush();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    // Clicking a node toggles its selection. Sankey click params carry
+    // `dataType: "node"` (vs "edge" for links); only nodes are selectable, and
+    // only when <Node isClickable> is set.
+    chart.on("click", (params) => {
+      const { isNodeClickable } = live.handlers;
+      if (!isNodeClickable) return;
+      const p = params as { dataType?: string; name?: string };
+      if (p.dataType !== "node") return;
+      if (typeof p.name === "string") toggleSelection(p.name);
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      chart.dispose();
+      echartsRef.current = null;
+      // The reveal guard belongs to the chart instance it guarded. Without this
+      // reset, StrictMode's dev-only mount→unmount→remount plays the entrance on
+      // the throwaway instance and the surviving one renders without it.
+      live.hasRevealed = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Sync ECharts with props/theme/selection — resolve, build, push ────────────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    const container = containerRef.current;
+    if (!chart || !container) return;
+
+    // Colors come from the <style> committed just before this effect ran — read
+    // them here, right before the push, rather than round-tripping through state.
+    live.resolved = resolveColors(container, config, nodeNames);
+
+    // ECharts' own animation stays off throughout: the entrance is painted by the
+    // option itself (windowed gradients, below), so there is nothing left for the
+    // native tweener to do — and its sankey entrance is the clip sweep this
+    // replaces. Intro frames merge rather than replace, so the chart keeps its
+    // views instead of rebuilding them 60 times a second.
+    const push = (mergeOnly: boolean) => {
+      const option = buildOption();
+      const merged = chartOptions ? { ...option, ...chartOptions } : option;
+      Object.assign(merged, { animation: false, animationDurationUpdate: 0 });
+      // chartOptions is an untyped escape hatch — the spread erases the option's
+      // shape, so re-assert it. The only cast in the file.
+      chart.setOption(
+        merged as EChartsOption,
+        mergeOnly ? { lazyUpdate: true, silent: true } : { notMerge: true },
+      );
+    };
+
+    // Intro cascade, played once per chart instance: columns of nodes grow out of
+    // their centres left to right, each column's bands drawing toward the next as
+    // soon as its nodes are up. Every later push (selection, theme) lands with
+    // `intro` null, so it applies instantly instead of replaying. A loading cycle
+    // re-arms it: the Recharts twin remounts its diagram after loading and replays
+    // the intro, so data → loading → data draws in again here too.
+    if (isLoading) live.hasRevealed = false;
+    const shouldReveal = !live.hasRevealed && !isLoading;
+    if (shouldReveal) live.hasRevealed = true;
+    const revealEnabled =
+      animation && shouldReveal && animationType !== "none" && !shouldReduceMotion;
+
+    let raf = 0;
+    if (revealEnabled) {
+      const depths = computeNodeDepths(data);
+      const duration = introDuration(depths);
+      live.intro = { elapsed: 0, depths };
+      push(false);
+
+      const start = performance.now();
+      const tick = (now: number) => {
+        const elapsed = now - start;
+        const done = elapsed >= duration;
+        live.intro = done ? null : { elapsed, depths };
+        push(true);
+        if (!done) raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    } else {
+      live.intro = null;
+      push(false);
+    }
+
+    // Theme flips and resizes re-enter here without touching React: re-read the
+    // tokens (the .dark class changed, or the renderer resized) and push an
+    // update-style option. Mid-intro that push carries the current cascade frame,
+    // so a theme flip retints the entrance instead of interrupting it.
+    live.repush = () => {
+      live.resolved = resolveColors(container, config, nodeNames);
+      push(false);
+    };
+
+    // Anything that re-runs this effect (a selection, a prop change) ends an
+    // in-flight cascade — the next push draws the finished diagram.
+    return () => {
+      cancelAnimationFrame(raf);
+      live.intro = null;
+    };
+  }, [
+    live,
+    buildOption,
+    chartOptions,
+    data,
+    isLoading,
+    animation,
+    animationType,
+    shouldReduceMotion,
+    config,
+    nodeNames,
+  ]);
+
+  // ── Loading shimmer — rAF sweeps a bright band across the fixed skeleton ──────
+  useEffect(() => {
+    const chart = echartsRef.current;
+    if (!chart || !isLoading) return;
+
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const phase = ((((now - start) / LOADING_ANIMATION_DURATION) % 1) + 1) % 1;
+
+      // Read tokens per frame, so a theme flip mid-loading retints the shimmer.
+      const foreground = live.resolved?.tokens.foreground ?? GRAY;
+      const w = chart.getWidth();
+      const h = chart.getHeight();
+      if (!w || !h) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      // Sweep the clip window from fully off-screen left to fully off-screen
+      // right, leaned 45°. ABSOLUTE pixel coordinates (global gradient) are
+      // shared by nodes and links, so every element lights up as the same band
+      // passes its x-position — nodes in a column brighten together.
+      const maxT = (w + h) / (2 * w);
+      const center = phase * (maxT + 2 * LOADING_SHIMMER_BAND) - LOADING_SHIMMER_BAND;
+      const clip = (floor: number, peak: number) =>
+        new echarts.graphic.LinearGradient(
+          0,
+          0,
+          w,
+          w,
+          shimmerWindowStops(center, foreground, floor, peak),
+          true,
+        );
+      chart.setOption(
+        {
+          series: [
+            {
+              id: "__loading",
+              itemStyle: { color: clip(LOADING_NODE_FLOOR, LOADING_NODE_PEAK), borderWidth: 0 },
+              lineStyle: {
+                color: clip(LOADING_LINK_FLOOR, LOADING_LINK_PEAK),
+                curveness: DEFAULT_LINK_CURVATURE,
+              },
+            },
+          ],
+        },
+        { silent: true, lazyUpdate: true },
+      );
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [live, isLoading]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-chart={chartId}
+      className={`relative flex flex-col text-xs ${className ?? ""}`}
+    >
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+
+      <div className="relative min-h-0 w-full flex-1">
+        <div ref={mountRef} className="h-full min-h-0 w-full" />
+      </div>
+
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+          <motion.div
+            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+            className="flex items-center justify-center gap-2 rounded-md border bg-background px-2 py-0.5 text-sm text-primary"
+          >
+            <div className="h-3 w-3 animate-spin rounded-full border border-border border-t-primary" />
+            <span>Loading</span>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+EChartsSankeyChart.Node = Node;
+EChartsSankeyChart.NodeLabel = NodeLabel;
+EChartsSankeyChart.Link = Link;
+EChartsSankeyChart.Tooltip = Tooltip;

--- a/packages/charts/src/components/evilcharts/index.tsx
+++ b/packages/charts/src/components/evilcharts/index.tsx
@@ -1,0 +1,7 @@
+export { EChartsAreaChart as AreaChart } from "./charts/echarts-area-chart";
+export { EChartsBarChart as BarChart } from "./charts/echarts-bar-chart";
+export { EChartsLineChart as LineChart } from "./charts/echarts-line-chart";
+export { EChartsRadialChart as RadialChart } from "./charts/echarts-radial-chart";
+export { EChartsSankeyChart as SankeyChart } from "./charts/echarts-sankey-chart";
+export { EChartsPieChart as PieChart } from "./charts/echarts-pie-chart";
+export { EChartsRadarChart as RadarChart } from "./charts/echarts-radar-chart";

--- a/packages/charts/src/components/evilcharts/ui/echarts-brush.tsx
+++ b/packages/charts/src/components/evilcharts/ui/echarts-brush.tsx
@@ -1,0 +1,237 @@
+import type { DataZoomComponentOption } from "echarts/components";
+import type { FC } from "react";
+
+import {
+  withAlpha,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+import * as echarts from "echarts/core";
+
+type EChartsInstance = ReturnType<typeof echarts.init>;
+
+const BRUSH_BORDER_OPACITY = 1; // brush frame, × border alpha (evil-brush uses the full token)
+
+export { BRUSH_BORDER_OPACITY };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Brush marker — the declarative `<Chart.Brush/>` child. Rendering nothing, its
+// PRESENCE turns the brush on (replacing the old showBrush prop) and its props
+// carry the brush's height, handle-label formatter, and range callback. Shared
+// so every cartesian chart attaches the SAME component to its root.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface BrushProps {
+  height?: number; // brush preview strip height in px (default 56)
+  formatLabel?: (value: string, index: number) => string; // formats the range-handle labels
+  onChange?: (range: { startIndex: number; endIndex: number }) => void; // fires as the range moves
+}
+
+/** Declares the zoom brush below the chart. Presence renders it; renders nothing itself. */
+export const Brush: FC<BrushProps> = () => null;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Brush overlays — the evil-brush look: a rounded border around the SELECTED
+// range, dimmed unselected sides, centered grip-dot handle pills, and range
+// label pills below the frame. None of that is a dataZoom capability. They are
+// raw zrender elements updated imperatively — routing them through setOption
+// re-renders the dataZoom component mid-drag, resetting its drag anchor (the
+// handle progressively lags the pointer).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BrushRange = { start: number; end: number };
+export type BrushGeometry = { bottom: number; height: number };
+
+export type BrushOverlayParams = {
+  range: BrushRange;
+  geom: BrushGeometry;
+  size: { width: number; height: number };
+  tokens: ResolvedColors["tokens"];
+  labels: { start: string; end: string } | null;
+  showLabels: boolean;
+  hover: { left: boolean; right: boolean };
+};
+
+type ZrRect = InstanceType<typeof echarts.graphic.Rect>;
+type ZrCircle = InstanceType<typeof echarts.graphic.Circle>;
+type ZrText = InstanceType<typeof echarts.graphic.Text>;
+
+export type BrushOverlayElements = {
+  dimLeft: ZrRect;
+  dimRight: ZrRect;
+  frame: ZrRect;
+  pillLeft: ZrRect;
+  pillRight: ZrRect;
+  grips: ZrCircle[]; // 3 left + 3 right
+  labelStart: ZrText;
+  labelEnd: ZrText;
+};
+
+export function syncBrushOverlay(
+  chart: EChartsInstance,
+  store: { brushOverlay: BrushOverlayElements | null },
+  params: BrushOverlayParams | null,
+) {
+  const zr = chart.getZr();
+  if (!zr) return;
+
+  if (!params) {
+    if (store.brushOverlay) {
+      const { grips, ...rest } = store.brushOverlay;
+      [...Object.values(rest), ...grips].forEach((el) => zr.remove(el));
+      store.brushOverlay = null;
+    }
+    return;
+  }
+
+  if (!store.brushOverlay) {
+    const rect = (z: number) => new echarts.graphic.Rect({ silent: true, z, shape: {} });
+    const els: BrushOverlayElements = {
+      dimLeft: rect(100),
+      dimRight: rect(100),
+      frame: rect(101),
+      pillLeft: rect(102),
+      pillRight: rect(102),
+      grips: Array.from(
+        { length: 6 },
+        () => new echarts.graphic.Circle({ silent: true, z: 103, shape: {} }),
+      ),
+      labelStart: new echarts.graphic.Text({ silent: true, z: 104 }),
+      labelEnd: new echarts.graphic.Text({ silent: true, z: 104 }),
+    };
+    const { grips, ...rest } = els;
+    [...Object.values(rest), ...grips].forEach((el) => zr.add(el));
+    store.brushOverlay = els;
+  }
+
+  const els = store.brushOverlay;
+  const { range, geom, size, tokens, labels, showLabels, hover } = params;
+
+  const trackLeft = 8;
+  const trackRight = Math.max(size.width - 8, trackLeft);
+  const trackWidth = trackRight - trackLeft;
+  const top = size.height - geom.bottom - geom.height;
+  const centerY = top + geom.height / 2;
+  const selectionLeft = trackLeft + (trackWidth * range.start) / 100;
+  const selectionRight = trackLeft + (trackWidth * range.end) / 100;
+
+  const dimFill = withAlpha(tokens.background, 0.7);
+  els.dimLeft.setShape({
+    x: trackLeft,
+    y: top,
+    width: Math.max(selectionLeft - trackLeft, 0),
+    height: geom.height,
+  });
+  els.dimLeft.setStyle({ fill: dimFill });
+  els.dimRight.setShape({
+    x: selectionRight,
+    y: top,
+    width: Math.max(trackRight - selectionRight, 0),
+    height: geom.height,
+  });
+  els.dimRight.setStyle({ fill: dimFill });
+
+  els.frame.setShape({
+    x: selectionLeft,
+    y: top,
+    width: Math.max(selectionRight - selectionLeft, 0),
+    height: geom.height,
+    r: 6,
+  });
+  els.frame.setStyle({
+    fill: "none",
+    stroke: withAlpha(tokens.border, BRUSH_BORDER_OPACITY),
+    lineWidth: 1,
+  });
+
+  // Handle pills: evil-brush's 6×16 grip pill, centered on the selection edge,
+  // brightening to foreground on hover/drag.
+  const pill = (el: ZrRect, x: number, hovered: boolean) => {
+    el.setShape({ x: x - 3, y: centerY - 8, width: 6, height: 16, r: 3 });
+    el.setStyle({ fill: hovered ? tokens.foreground : tokens.mutedForeground });
+  };
+  pill(els.pillLeft, selectionLeft, hover.left);
+  pill(els.pillRight, selectionRight, hover.right);
+
+  const gripFill = withAlpha(tokens.background, 0.7);
+  [-4, 0, 4].forEach((offset, i) => {
+    els.grips[i]!.setShape({ cx: selectionLeft, cy: centerY + offset, r: 1 });
+    els.grips[i]!.setStyle({ fill: gripFill });
+    els.grips[i + 3]!.setShape({ cx: selectionRight, cy: centerY + offset, r: 1 });
+    els.grips[i + 3]!.setStyle({ fill: gripFill });
+  });
+
+  // Range label pills straddle the frame's bottom line — an overlay, so they
+  // occupy no layout space; half the pill sits above the line, half below. Each
+  // pill grows INWARD from its handle with a small inset, like the Recharts
+  // labels, instead of hanging past the frame edge.
+  const label = (el: ZrText, text: string, x: number, align: "left" | "right") => {
+    el.setStyle({
+      text,
+      x: align === "left" ? Math.max(x + 6, trackLeft + 2) : Math.min(x - 6, trackRight - 2),
+      y: top + geom.height,
+      align,
+      verticalAlign: "middle",
+      fill: tokens.background,
+      backgroundColor: tokens.foreground,
+      padding: [2, 5],
+      borderRadius: 4,
+      font: "500 9px system-ui, sans-serif",
+    });
+    el.attr("invisible", !showLabels || !text);
+  };
+  label(els.labelStart, labels?.start ?? "", selectionLeft, "left");
+  label(els.labelEnd, labels?.end ?? "", selectionRight, "right");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// dataZoom slider — the transparent drag layer laid over the mini chart. Fully
+// chart-agnostic: the visible frame/handles/labels are the graphic overlays
+// above; this provides interaction only. Both zoom entries target only the MAIN
+// x-axis (index 0), so the mini chart never filters itself. The per-chart
+// mini-series (which differ per chart type) are built by the chart, not here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildBrushDataZoom(params: {
+  brushBottom: number;
+  brushHeight: number;
+  brushRange: BrushRange;
+  fillerColor: string;
+}): DataZoomComponentOption[] {
+  const { brushBottom, brushHeight, brushRange, fillerColor } = params;
+
+  return [
+    {
+      type: "slider",
+      show: true,
+      xAxisIndex: [0],
+      left: 8,
+      right: 8,
+      bottom: brushBottom,
+      height: brushHeight,
+      // Carry the live range through every rebuild — a notMerge push
+      // without start/end would reset the zoom to the full extent.
+      start: brushRange.start,
+      end: brushRange.end,
+      brushSelect: false,
+      // Range labels are overlay pills below the frame (see
+      // syncBrushOverlay) — the native detail text renders INSIDE the
+      // track, which is not the evil-brush look.
+      showDetail: false,
+      backgroundColor: "transparent",
+      // The visible frame is the graphic overlay riding the selection —
+      // the component's own static border stays hidden.
+      borderColor: "transparent",
+      fillerColor,
+      dataBackground: { lineStyle: { opacity: 0 }, areaStyle: { opacity: 0 } },
+      selectedDataBackground: { lineStyle: { opacity: 0 }, areaStyle: { opacity: 0 } },
+      // Interaction only — the visible pills are graphic overlays (see
+      // syncBrushOverlay). Kept generous for an easy grab target.
+      handleIcon: "path://M -3 -5 L -3 5 A 3 3 0 0 0 3 5 L 3 -5 A 3 3 0 0 0 -3 -5 Z",
+      handleSize: "35%",
+      handleStyle: { opacity: 0 },
+      moveHandleSize: 0,
+      emphasis: { handleStyle: { opacity: 0 } },
+    },
+    { type: "inside", xAxisIndex: [0] },
+  ];
+}

--- a/packages/charts/src/components/evilcharts/ui/echarts-chart.tsx
+++ b/packages/charts/src/components/evilcharts/ui/echarts-chart.tsx
@@ -1,0 +1,201 @@
+import type { ComponentType, ReactNode } from "react";
+
+import * as echarts from "echarts/core";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Theme keys + config — replicated from the repo's <ChartStyle> so the ECharts
+// charts stay self-contained (no recharts ui imports). Shared by every ECharts
+// chart and the tooltip/legend/brush ui modules.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Theme selectors mirror the repo's <ChartStyle>: light is the bare root, dark is `.dark`.
+export const THEMES = { light: "", dark: ".dark" } as const;
+export type ThemeKey = keyof typeof THEMES;
+export const THEME_KEYS = Object.keys(THEMES) as ThemeKey[];
+
+// Require at least one theme key — identical constraint to the repo's ChartConfig.
+export type AtLeastOneThemeColor =
+  | { light: string[]; dark?: string[] }
+  | { light?: string[]; dark: string[] };
+
+export type ChartConfig = Record<
+  string,
+  {
+    label?: ReactNode;
+    icon?: ComponentType;
+    colors?: AtLeastOneThemeColor;
+  }
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Color plumbing — replicated from the repo's <ChartStyle> so the charts stay
+// self-contained (no @/registry/ui/recharts imports).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Max slots a key needs = longest color array across themes (min 1). Both themes
+// always emit the same number of `--color-{key}-{n}` vars.
+export function getColorsCount(item: ChartConfig[string]): number {
+  if (!item.colors) return 1;
+  const counts = THEME_KEYS.map((theme) => item.colors?.[theme]?.length ?? 0);
+  return Math.max(...counts, 1);
+}
+
+// Distribute colors evenly across slots; extra slots go to the LAST color(s).
+// 2 colors / 4 slots → [c0, c0, c1, c1]; 3 colors / 4 slots → [c0, c1, c2, c2].
+export function distributeColors(colors: string[], maxCount: number): string[] {
+  const available = colors.length;
+  if (available >= maxCount) return colors.slice(0, maxCount);
+
+  const result: string[] = [];
+  const baseSlots = Math.floor(maxCount / available);
+  const extraSlots = maxCount % available;
+
+  for (let i = 0; i < available; i++) {
+    const isExtra = i >= available - extraSlots;
+    const slots = baseSlots + (isExtra ? 1 : 0);
+    for (let j = 0; j < slots; j++) result.push(colors[i]!);
+  }
+
+  return result;
+}
+
+// Emits the same CSS <ChartStyle> would: `--color-{key}-{n}` scoped to
+// `[data-chart={id}]` (light) and `.dark [data-chart={id}]` (dark).
+export function buildChartCss(id: string, config: ChartConfig): string {
+  const colorConfig = Object.entries(config).filter(([, item]) => item.colors);
+  if (!colorConfig.length) return "";
+
+  const varsFor = (theme: ThemeKey) =>
+    colorConfig
+      .flatMap(([key, item]) => {
+        const authored = item.colors?.[theme];
+        if (!authored || authored.length === 0) return [];
+        return distributeColors(authored, getColorsCount(item)).map(
+          (color, index) => `  --color-${key}-${index}: ${color};`,
+        );
+      })
+      .join("\n");
+
+  return Object.entries(THEMES)
+    .map(([theme, prefix]) => `${prefix} [data-chart=${id}] {\n${varsFor(theme as ThemeKey)}\n}`)
+    .join("\n");
+}
+
+// A single reusable 1×1 canvas normalizes ANY CSS color (hex, named, oklch, …)
+// to a concrete rgba string by painting it and reading the pixel back.
+let normalizerCtx: CanvasRenderingContext2D | null = null;
+export function normalizeColor(value: string): string {
+  const raw = value.trim();
+  if (!raw || typeof document === "undefined") return raw;
+
+  if (!normalizerCtx) {
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    normalizerCtx = canvas.getContext("2d", { willReadFrequently: true });
+  }
+  if (!normalizerCtx) return raw;
+
+  normalizerCtx.clearRect(0, 0, 1, 1);
+  normalizerCtx.fillStyle = "#000";
+  normalizerCtx.fillStyle = raw; // invalid values leave the sentinel in place
+  normalizerCtx.fillRect(0, 0, 1, 1);
+  const [r, g, b, a] = normalizerCtx.getImageData(0, 0, 1, 1).data;
+  return `rgba(${r}, ${g}, ${b}, ${(a! / 255).toFixed(3)})`;
+}
+
+// Scales the alpha of a normalized `rgba(r, g, b, a)` string. Multiplying (not
+// replacing) keeps translucent theme tokens honest: a border that is 10%-white
+// at `withAlpha(border, 0.5)` lands at 5%, matching Tailwind's `border/50`.
+export function withAlpha(color: string, alpha: number): string {
+  const match = color.match(/rgba?\(([^)]+)\)/);
+  if (!match) return color;
+  const [r, g, b, a] = match[1]!.split(",").map((p) => p.trim());
+  const base = a === undefined ? 1 : Number.parseFloat(a) || 0;
+  return `rgba(${r}, ${g}, ${b}, ${(base * alpha).toFixed(3)})`;
+}
+
+export type ResolvedColors = {
+  series: Record<string, string[]>; // normalized `--color-{key}-{n}` slots per key
+  tokens: {
+    mutedForeground: string;
+    border: string;
+    foreground: string;
+    background: string;
+  };
+};
+
+// Reads the injected CSS vars + theme tokens from the live DOM. Series slots come
+// from `getComputedStyle` on the container; tokens are read off a throwaway probe
+// carrying the matching Tailwind class (robust to the var naming a theme uses).
+export function resolveColors(
+  container: HTMLElement,
+  config: ChartConfig,
+  seriesKeys: string[],
+): ResolvedColors {
+  const computed = getComputedStyle(container);
+  const series: Record<string, string[]> = {};
+
+  for (const key of seriesKeys) {
+    const count = getColorsCount(config[key] ?? {});
+    const slots: string[] = [];
+    for (let n = 0; n < count; n++) {
+      const raw = computed.getPropertyValue(`--color-${key}-${n}`).trim();
+      slots.push(raw ? normalizeColor(raw) : "rgba(120, 120, 120, 1)");
+    }
+    series[key] = slots;
+  }
+
+  const probe = document.createElement("span");
+  probe.style.cssText = "position:absolute;width:0;height:0;visibility:hidden;pointer-events:none;";
+  container.appendChild(probe);
+  const readToken = (className: string) => {
+    probe.className = className;
+    return normalizeColor(getComputedStyle(probe).color);
+  };
+  const tokens = {
+    mutedForeground: readToken("text-muted-foreground"),
+    border: readToken("text-border"),
+    foreground: readToken("text-foreground"),
+    background: readToken("text-background"),
+  };
+  container.removeChild(probe);
+
+  return { series, tokens };
+}
+
+// Horizontal multi-stop color for a series — a solid string when there is only
+// one color, else an evenly-distributed left→right LinearGradient. Reused for the
+// stroke, symbol fills, and as the base tint for the area fill.
+export function seriesPaint(slots: string[]): string | echarts.graphic.LinearGradient {
+  if (slots.length <= 1) return slots[0] ?? "rgba(120, 120, 120, 1)";
+  const stops = slots.map((color, i) => ({ offset: i / (slots.length - 1), color }));
+  return new echarts.graphic.LinearGradient(0, 0, 1, 0, stops);
+}
+
+// Solid var / gradient of vars for a series indicator — mirrors getIndicatorColorStyle.
+// Used by BOTH the tooltip rows and the legend indicators.
+export function indicatorBackground(key: string, colorsCount: number): string {
+  if (colorsCount <= 1) return `var(--color-${key}-0)`;
+  const stops = Array.from({ length: colorsCount }, (_, i) => {
+    const offset = (i / (colorsCount - 1)) * 100;
+    return `var(--color-${key}-${i}) ${offset}%`;
+  }).join(", ");
+  return `linear-gradient(to right, ${stops})`;
+}
+
+// Composites a translucent color over an opaque base into a FLAT color. The
+// tick dots need this: a translucent stroke double-paints where its round caps
+// overlap the line body, which reads as two stacked colors.
+export function flattenColor(color: string, base: string): string {
+  const parse = (value: string) =>
+    value
+      .match(/rgba?\(([^)]+)\)/)?.[1]!
+      .split(",")
+      .map((part) => Number.parseFloat(part)) ?? [0, 0, 0, 1];
+  const [r, g, b, a = 1] = parse(color);
+  const [baseR, baseG, baseB] = parse(base);
+  const mix = (channel: number, baseChannel: number) =>
+    Math.round(channel * a + baseChannel * (1 - a));
+  return `rgb(${(mix(r!, baseR!), mix(g!, baseG!), mix(b!, baseB!))})`;
+}

--- a/packages/charts/src/components/evilcharts/ui/echarts-dot.tsx
+++ b/packages/charts/src/components/evilcharts/ui/echarts-dot.tsx
@@ -1,0 +1,111 @@
+import type * as echarts from "echarts/core";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dots — map the resting/active variants onto ECharts symbols. Shared by every
+// ECharts chart that draws point markers.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type DotVariant = "none" | "default" | "border" | "colored-border" | "ping";
+
+// Dot marker paint — structurally assignable to BOTH the series-level and the
+// per-datum itemStyle (the per-datum variant forbids callback color paints, so
+// the broader LineSeriesOption["itemStyle"] cannot be reused for it).
+export type DotItemStyleOption = {
+  color?: string | echarts.graphic.LinearGradient;
+  borderColor?: string | echarts.graphic.LinearGradient;
+  borderWidth?: number;
+  opacity?: number;
+};
+
+export type DotStyle = { size: number; itemStyle: DotItemStyleOption };
+
+// Re-color a solid paint at a given alpha (hex #rgb/#rrggbb or rgb/rgba in, rgba
+// out; named colors pass through). Used for the translucent "ping" halo ring.
+function withAlpha(color: string, alpha: number): string {
+  if (color.startsWith("#")) {
+    let hex = color.slice(1);
+    if (hex.length === 3)
+      hex = hex
+        .split("")
+        .map((c) => c + c)
+        .join("");
+    const n = parseInt(hex, 16);
+    return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+  }
+  const m = color.match(/rgba?\(([^)]+)\)/);
+  if (m) {
+    const [r, g, b] = m[1]!.split(",").map((s) => parseFloat(s));
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+  return color;
+}
+
+export function dotItemStyle(
+  variant: DotVariant,
+  paint: string | echarts.graphic.LinearGradient,
+  background: string,
+): DotItemStyleOption {
+  switch (variant) {
+    case "border":
+      // Series-colored core with a thick background halo (Recharts r6 / sw5).
+      return { color: paint, borderColor: background, borderWidth: 2 };
+    case "colored-border":
+      // Background-filled core with a thin colored ring (Recharts r3 / sw1).
+      return { color: background, borderColor: paint, borderWidth: 1 };
+    case "ping": {
+      // Solid core wrapped in a wide, translucent same-color ring — a static
+      // "ping". The ring is the symbol's BORDER (a stroke ~1.25× the core
+      // radius), which fills out to a soft halo disc; a genuinely large symbol
+      // would silently fail to render on a category-axis line, so we stroke a
+      // small one instead.
+      const halo = typeof paint === "string" ? withAlpha(paint, 0.28) : paint;
+      return { color: paint, borderColor: halo, borderWidth: 10 };
+    }
+    case "default":
+      return { color: paint, borderWidth: 0 };
+    default:
+      return {};
+  }
+}
+
+// Sizes mirror the Recharts markers: default r3, border r6 (mostly halo), and
+// colored-border r3+ring. Flattening these to one size makes the hover ring read
+// LARGER than a haloed resting dot — the opposite of the Recharts twin.
+export const DOT_SIZES: Record<DotVariant, number> = {
+  none: 0,
+  default: 6,
+  border: 8,
+  "colored-border": 6,
+  ping: 8,
+};
+
+export function dotStyle(
+  variant: DotVariant,
+  paint: string | echarts.graphic.LinearGradient,
+  background: string,
+): DotStyle {
+  return { size: DOT_SIZES[variant], itemStyle: dotItemStyle(variant, paint, background) };
+}
+
+// The color the horizontal series gradient shows at position t ∈ [0, 1]. ECharts
+// paints a gradient itemStyle relative to each symbol's own bounding box — a full
+// rainbow inside every dot — while the Recharts dots clip a chart-wide gradient,
+// so each takes the gradient's color at its x-position. Sampling reproduces that.
+export function sampleGradient(slots: string[], t: number): string {
+  if (slots.length <= 1) return slots[0] ?? "rgba(120, 120, 120, 1)";
+
+  const parse = (color: string) =>
+    color
+      .match(/rgba?\(([^)]+)\)/)?.[1]!
+      .split(",")
+      .map(Number) ?? [120, 120, 120, 1];
+
+  const position = t * (slots.length - 1);
+  const index = Math.min(Math.floor(position), slots.length - 2);
+  const fraction = position - index;
+  const [r1, g1, b1, a1 = 1] = parse(slots[index]!);
+  const [r2, g2, b2, a2 = 1] = parse(slots[index + 1]!);
+  const lerp = (from: number, to: number) => from + (to - from) * fraction;
+
+  return `rgba(${Math.round(lerp(r1!, r2!))}, ${Math.round(lerp(g1!, g2!))}, ${Math.round(lerp(b1!, b2!))}, ${lerp(a1!, a2!).toFixed(3)})`;
+}

--- a/packages/charts/src/components/evilcharts/ui/echarts-legend.tsx
+++ b/packages/charts/src/components/evilcharts/ui/echarts-legend.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+import {
+  getColorsCount,
+  indicatorBackground,
+  type ChartConfig,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Legend overlay (React) — replicates ChartLegendContent + its 7 indicators.
+// The legend is HTML inside `[data-chart={id}]`, so it uses the injected
+// `--color-*` vars directly. Shared by every ECharts chart.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type LegendVariant =
+  | "square"
+  | "circle"
+  | "circle-outline"
+  | "rounded-square"
+  | "rounded-square-outline"
+  | "vertical-bar"
+  | "horizontal-bar";
+
+export function legendFillStyle(key: string, colorsCount: number): CSSProperties {
+  if (colorsCount <= 1) return { backgroundColor: `var(--color-${key}-0)` };
+  return { background: indicatorBackground(key, colorsCount) };
+}
+
+// Punches out the centre with a mask-composite so only the "border" shows —
+// works with gradients and border-radius, unlike plain border-color.
+export function legendOutlineStyle(key: string, colorsCount: number): CSSProperties {
+  const mask: CSSProperties = {
+    WebkitMask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+    WebkitMaskComposite: "xor",
+    mask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+    maskComposite: "exclude",
+  };
+  return { ...legendFillStyle(key, colorsCount), ...mask };
+}
+
+export function LegendIndicator({
+  variant,
+  dataKey,
+  colorsCount,
+}: {
+  variant: LegendVariant;
+  dataKey: string;
+  colorsCount: number;
+}) {
+  const fill = legendFillStyle(dataKey, colorsCount);
+  const outline = legendOutlineStyle(dataKey, colorsCount);
+
+  switch (variant) {
+    case "square":
+      return <div className="h-2 w-2 shrink-0" style={fill} />;
+    case "circle":
+      return <div className="h-2 w-2 shrink-0 rounded-full" style={fill} />;
+    case "circle-outline":
+      return <div className="h-2.5 w-2.5 shrink-0 rounded-full p-[1.5px]" style={outline} />;
+    case "vertical-bar":
+      return <div className="h-3 w-1 shrink-0 rounded-[2px]" style={fill} />;
+    case "horizontal-bar":
+      return <div className="h-1 w-3 shrink-0 rounded-[2px]" style={fill} />;
+    case "rounded-square-outline":
+      return <div className="h-2.5 w-2.5 shrink-0 rounded-[3px] p-[1.5px]" style={outline} />;
+    case "rounded-square":
+    default:
+      return <div className="h-2 w-2 shrink-0 rounded-[2px]" style={fill} />;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LegendOverlay — the positioned HTML legend row. The chart computes the
+// absolute-positioned `style` (it owns the brush/verticalAlign layout math) and
+// passes it in; this renders the entries, their indicators, and the
+// selection/hover dim. `verticalAlign` is carried on the props for parity with
+// the chart's LegendSlot even though positioning arrives fully via `style`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LegendOverlayProps = {
+  seriesKeys: string[];
+  config: ChartConfig;
+  variant: LegendVariant;
+  align: "left" | "center" | "right";
+  verticalAlign: "top" | "middle" | "bottom";
+  selectedKey: string | null;
+  hoveredKey: string | null;
+  isClickable: boolean;
+  onToggle: (key: string) => void;
+  style: CSSProperties;
+};
+
+export function LegendOverlay({
+  seriesKeys,
+  config,
+  variant,
+  align,
+  selectedKey,
+  hoveredKey,
+  isClickable,
+  onToggle,
+  style,
+}: LegendOverlayProps) {
+  const legendJustify =
+    align === "left" ? "justify-start" : align === "center" ? "justify-center" : "justify-end";
+
+  return (
+    <div style={style} className={`flex items-center gap-4 select-none ${legendJustify}`}>
+      {seriesKeys.map((key) => {
+        const item = config[key];
+        const colorsCount = item ? getColorsCount(item) : 1;
+        const isSelected =
+          (selectedKey === null || selectedKey === key) &&
+          (hoveredKey === null || hoveredKey === key);
+        return (
+          // No entrance here — the Recharts legend appears instantly, and a
+          // fade-in reads as disconnected from the canvas draw-in.
+          <div
+            key={key}
+            className={`flex items-center gap-1.5 transition-opacity ${
+              !isSelected ? "opacity-30" : ""
+            } ${isClickable ? "cursor-pointer" : ""}`}
+            onClick={() => {
+              if (isClickable) onToggle(key);
+            }}
+          >
+            <LegendIndicator variant={variant} dataKey={key} colorsCount={colorsCount} />
+            {item?.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/charts/src/components/evilcharts/ui/echarts-tooltip.tsx
+++ b/packages/charts/src/components/evilcharts/ui/echarts-tooltip.tsx
@@ -1,0 +1,139 @@
+import type { TooltipComponentOption } from "echarts/components";
+
+import {
+  indicatorBackground,
+  type ResolvedColors,
+} from "@harmony/charts/components/evilcharts/ui/echarts-chart";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tooltip — the shared HTML shell/row primitives and the chart-agnostic option
+// fields. The tooltip DOM lives inside `[data-chart={id}]`, so the injected
+// `--color-*` vars and Tailwind classes resolve directly (no color read). Each
+// chart composes its own rows but shares the shell/styling and base option.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type TooltipVariant = "default" | "frosted-glass";
+export type TooltipRoundness = "sm" | "md" | "lg" | "xl";
+// Tooltip anchoring: "variable" follows both axes (ECharts default, current
+// behavior); "fixed" tracks the pointer's X (centered) but stays pinned near
+// the top (fixed Y).
+export type TooltipPosition = "fixed" | "variable";
+
+const intFmt = new Intl.NumberFormat("en-US").format;
+
+export function formatTooltipValue(value: number | string | null | undefined): string {
+  return typeof value === "number" ? intFmt(value) : String(value ?? "");
+}
+
+export const roundnessClass: Record<TooltipRoundness, string> = {
+  sm: "rounded-sm",
+  md: "rounded-md",
+  lg: "rounded-lg",
+  xl: "rounded-xl",
+};
+
+export const tooltipVariantClass: Record<TooltipVariant, string> = {
+  default: "bg-background",
+  "frosted-glass": "bg-background/50 backdrop-blur-md",
+};
+
+// The standard series indicator swatch — a rounded square filled with the
+// series' solid var or multi-stop gradient (indicatorBackground). A chart drops
+// this into a tooltipRow's `indicatorHtml`.
+export function tooltipIndicatorHtml(key: string, colorsCount: number): string {
+  return `<div class="h-2.5 w-2.5 shrink-0 rounded-[2px]" style="background:${indicatorBackground(key, colorsCount)}"></div>`;
+}
+
+// One tooltip row: indicator swatch + label/value pair. `dimmed` is a class
+// fragment (e.g. " opacity-30") appended to the row so the selection/hover dim
+// stays byte-identical to the inlined markup.
+export function tooltipRow({
+  indicatorHtml,
+  labelText,
+  valueText,
+  suffix,
+  dimmed,
+}: {
+  indicatorHtml: string;
+  labelText: string;
+  valueText: string;
+  suffix?: string;
+  dimmed: string;
+}): string {
+  return `<div class="flex w-full flex-wrap items-center gap-1.5${dimmed}">
+          ${indicatorHtml}
+          <div class="flex flex-1 items-center justify-between gap-2 leading-none">
+            <span class="text-muted-foreground">${labelText}</span>
+            <div class="flex items-center gap-0.5">
+              <span class="font-medium">${valueText}</span>
+              ${suffix ? `<span class="text-muted-foreground">${suffix}</span>` : ""}
+            </div>
+          </div>
+        </div>`;
+}
+
+// The outer tooltip surface — border, padding, shadow, roundness + variant
+// classes — wrapping the axis label and the composed rows.
+export function tooltipShell({
+  label,
+  body,
+  roundness,
+  variant,
+}: {
+  label: string;
+  body: string;
+  roundness: TooltipRoundness;
+  variant: TooltipVariant;
+}): string {
+  return `<div class="grid items-start gap-1.5 border border-border/50 px-2 py-1.5 text-foreground text-xs shadow-xl ${roundnessClass[roundness]} ${tooltipVariantClass[variant]}">
+      <div class="font-medium">${label}</div>
+      <div class="grid gap-1.5">${body}</div>
+    </div>`;
+}
+
+// Maps the TooltipPosition prop onto the ECharts tooltip `position` field.
+// "variable" → undefined (default follow-both-axes, current behavior); "fixed" →
+// a callback that centers the tooltip on the pointer's X but pins it near the
+// top (fixed Y).
+export function resolveTooltipPosition(
+  position: TooltipPosition,
+): TooltipComponentOption["position"] {
+  if (position === "variable") return undefined;
+  return (point, _params, _dom, _rect, size) => [point[0] - size.contentSize[0] / 2, 8];
+}
+
+// The chart-agnostic tooltip option fields (show, trigger, confine,
+// background/border/padding/extraCssText, axisPointer, position). The chart
+// supplies only `formatter` and spreads this in. `axisPointerColor` is the
+// pre-resolved cursor-line color, so this helper needs no live token read.
+export function tooltipBaseOption(params: {
+  present: boolean;
+  cursor: boolean;
+  tokens: ResolvedColors["tokens"];
+  position: TooltipPosition;
+  axisPointerColor: string;
+  strokeWidth: number;
+}): TooltipComponentOption {
+  const { present, cursor, position, axisPointerColor, strokeWidth } = params;
+
+  return {
+    show: present,
+    trigger: "axis",
+    confine: true,
+    backgroundColor: "transparent",
+    borderWidth: 0,
+    padding: 0,
+    extraCssText: "box-shadow:none;",
+    axisPointer: cursor
+      ? {
+          type: "line",
+          lineStyle: {
+            color: axisPointerColor,
+            width: strokeWidth,
+            type: [3, 3] as [number, number],
+          },
+        }
+      : { type: "none" },
+    position: resolveTooltipPosition(position),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       d3-shape:
         specifier: ^3.2.0
         version: 3.2.0
+      echarts:
+        specifier: ^6.1.0
+        version: 6.1.0
       motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2817,6 +2820,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -4546,6 +4552,9 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4945,6 +4954,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
@@ -7213,6 +7225,11 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  echarts@6.1.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.1.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.376: {}
@@ -9044,6 +9061,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1: {}
 
   turbo@2.10.6:
@@ -9312,6 +9331,10 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.3: {}
+
+  zrender@6.1.0:
+    dependencies:
+      tslib: 2.3.0
 
   zustand@5.0.14(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)):
     optionalDependencies:


### PR DESCRIPTION
This pull request migrates the web app's chart components from the older `@harmony/charts/v2` to the new `@harmony/charts/v3` (ECharts-based) implementation. It updates imports, chart usage, and configuration across several dashboard widgets and components, and introduces improved chart customization and consistency. There are also some minor UI tweaks and code cleanups.

**Chart Migration and Updates:**

* Replaced all `@harmony/charts/v2` chart components (e.g., `AreaChart`, `BarChart`, `RadarChart`) with their `@harmony/charts/v3` equivalents throughout the app, updating usage and configuration for improved appearance and customization. [[1]](diffhunk://#diff-e7a6d378d674bb22c2f8bdf523c10120231923ff659c977353fb27a0b0ba09c2L1-R1) [[2]](diffhunk://#diff-77a4757f75914da123fad180facdd9689bd23b2902cdc233fae86a88036e85afL3-R3) [[3]](diffhunk://#diff-e4c8e49f1ac733bf3bc9c94f9e74bffde7ae80c5f05ff6a17cae9ec0a6447901L1-R1) [[4]](diffhunk://#diff-0e30d2b21be23e5bd3ad067877651a5d18cedb24a9ab1bf194bb9345de8cb0bdL1-R1) [[5]](diffhunk://#diff-e6c9d10d0cb452234d328a35c0fee696213838750b14ea89f900757e37cd68b7L1-R1)
* Refactored chart configuration in widgets like `HeroChart`, `LandingHowItWorks`, `MonthlyActivityWidget`, `MetricSparkline`, and `DaysOfWeekWidget` to use the new `config` prop for colors, labels, and styles. [[1]](diffhunk://#diff-e7a6d378d674bb22c2f8bdf523c10120231923ff659c977353fb27a0b0ba09c2L11-R32) [[2]](diffhunk://#diff-77a4757f75914da123fad180facdd9689bd23b2902cdc233fae86a88036e85afL347-R364) [[3]](diffhunk://#diff-0e30d2b21be23e5bd3ad067877651a5d18cedb24a9ab1bf194bb9345de8cb0bdL28-R44) [[4]](diffhunk://#diff-e6c9d10d0cb452234d328a35c0fee696213838750b14ea89f900757e37cd68b7L11-R38) [[5]](diffhunk://#diff-e4c8e49f1ac733bf3bc9c94f9e74bffde7ae80c5f05ff6a17cae9ec0a6447901R13-R41)

**Chart Library and Package Changes:**

* Added ECharts as a dependency, exposed new ECharts-based chart components in `@harmony/charts/v3`, and updated package exports and registry configuration. [[1]](diffhunk://#diff-c20c95d8d4049839c1192e0d63fb6d37a43ee3724529bf811bcdd2262b493e0bL8-R9) [[2]](diffhunk://#diff-c20c95d8d4049839c1192e0d63fb6d37a43ee3724529bf811bcdd2262b493e0bR29) [[3]](diffhunk://#diff-5c959bf598f05aa45db05feed20e9f825ba3a89dbe26fec563339c064ae68b03R13-R25) [[4]](diffhunk://#diff-48f37694bc6f9d90d4e1a77e8fbc653fef6d16d23e6be64fd935f5abb44a5221R1-R7)

**UI and Layout Improvements:**

* Tweaked various UI elements for improved spacing and appearance, such as button paddings, card content margins, and chart container classes. [[1]](diffhunk://#diff-5bb5c4df008f73da8c6832804067d7b547518e81548bdb8224e702e589ce83a5L57-R57) [[2]](diffhunk://#diff-fb41525dd9db852eff7a2f4e6ca8a2ab8b72a72ad90c39d1d6094c1e7815fb1cL32-R32) [[3]](diffhunk://#diff-fb41525dd9db852eff7a2f4e6ca8a2ab8b72a72ad90c39d1d6094c1e7815fb1cL43-R43) [[4]](diffhunk://#diff-7d5eab1e0d24aad3f5038d6df57c79529ca7fae3ea7245d0fb20cd598bdf6765L56-R56) [[5]](diffhunk://#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcdL37-R38)
* Updated navigation and header icons for clarity, and commented out or removed unused UI elements and widgets. [[1]](diffhunk://#diff-027087a8788d6a57d32503bc4511407af07f84b37e9882398956818a4675e569L1-L6) [[2]](diffhunk://#diff-027087a8788d6a57d32503bc4511407af07f84b37e9882398956818a4675e569L21-R29) [[3]](diffhunk://#diff-807a85131462721dfa61daa8b1fdc20f5fffc8d703535fb26d686fb285f6075bL5-R12) [[4]](diffhunk://#diff-807a85131462721dfa61daa8b1fdc20f5fffc8d703535fb26d686fb285f6075bL52-R53) [[5]](diffhunk://#diff-807a85131462721dfa61daa8b1fdc20f5fffc8d703535fb26d686fb285f6075bL71-R66)

**Code Cleanups:**

* Improved code readability and maintainability by formatting props, removing unused imports, and simplifying component structures. [[1]](diffhunk://#diff-c80b727826f0df641d4eaf51ab98d8fe6ccb4c5271d4bad52accc882256b1303L42-R60) [[2]](diffhunk://#diff-5bb5c4df008f73da8c6832804067d7b547518e81548bdb8224e702e589ce83a5L57-R57)

These changes modernize the dashboard's data visualizations, provide a more consistent look and feel, and prepare the codebase for future enhancements using the ECharts-based charting system.