### PR TITLE
ci: release tag into web image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,8 @@ jobs:
           context: .
           file: ${{ matrix.app.dockerfile }}
           push: true
+          build-args: |
+            VITE_APP_VERSION=${{ needs.release.outputs.tag }}
           tags: |
             ghcr.io/abgameur/harmony/${{ matrix.app.name }}:latest
             ghcr.io/abgameur/harmony/${{ matrix.app.name }}:${{ needs.release.outputs.tag }}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,3 @@
 API_URL=http://localhost:3000
 BUCKET_URL=https://bucket.harmony.local/harmony
+VITE_APP_VERSION=v3.0.0

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,6 +11,8 @@ RUN turbo prune web --docker
 
 # ---
 FROM base AS builder
+ARG VITE_APP_VERSION=dev
+ENV VITE_APP_VERSION=$VITE_APP_VERSION
 COPY --from=prepare /app/out/json/ .
 RUN pnpm install --frozen-lockfile
 COPY --from=prepare /app/out/full/ .

--- a/apps/web/src/components/landing/landing-footer.tsx
+++ b/apps/web/src/components/landing/landing-footer.tsx
@@ -127,7 +127,7 @@ export function LandingFooter() {
               @aBgAmeuR
             </Button>
           </p>
-          <p className="text-xs text-muted-foreground">v3.0-beta</p>
+          <p className="text-xs text-muted-foreground">{import.meta.env.VITE_APP_VERSION}</p>
         </div>
         <div className="t-stagger-line t-stagger-line--3">
           <GhostWordmark />


### PR DESCRIPTION
This pull request introduces versioning improvements to the web application by surfacing the app version in the UI and ensuring it is consistently set during builds and in environment configuration. The most important changes are:

**Versioning and Build Process:**

* The build pipeline in `.github/workflows/release.yml` now sets the `VITE_APP_VERSION` build argument to the current release tag, ensuring Docker images are tagged with the correct version.
* The `apps/web/Dockerfile` now accepts a `VITE_APP_VERSION` build argument (defaulting to `dev`) and sets it as an environment variable for the build, making the version available to the application at runtime.

**Environment Configuration:**

* The `.env.example` file in `apps/web` now includes a `VITE_APP_VERSION` variable, documenting the need for this environment variable in local development and deployment.

**User Interface:**

* The app version displayed in the landing footer (`landing-footer.tsx`) now dynamically reads from `import.meta.env.VITE_APP_VERSION`, ensuring the UI always reflects the current build version.