### PR TITLE
refactor: unify filters

### DIFF
--- a/apps/web/src/components/cover/cover.tsx
+++ b/apps/web/src/components/cover/cover.tsx
@@ -30,7 +30,7 @@ export function Cover({ src, alt, className, size = "md", blur = false }: CoverP
             alt={alt}
             loading="lazy"
             decoding="async"
-            className="relative z-10 size-full rounded-sm object-cover"
+            className="relative z-2 size-full rounded-sm object-cover"
           />
           {blur && <BlurImage src={src} />}
         </>

--- a/apps/web/src/features/albums/queries.ts
+++ b/apps/web/src/features/albums/queries.ts
@@ -1,15 +1,15 @@
 import { queryOptions } from "@tanstack/react-query";
 
-import { toSqlDate } from "@/lib/sql/date-range";
+import { Filter } from "@/lib/filter";
 
 import { topAlbumsFn } from "./queries/top";
 
 export const albumsQueries = {
   top: {
-    queryOptions: ({ artistId, from, to }: { artistId?: number; from: Date; to: Date }) =>
+    queryOptions: (filter: Filter) =>
       queryOptions({
-        queryKey: ["albums", "top", { artistId, from: toSqlDate(from), to: toSqlDate(to) }],
-        queryFn: () => topAlbumsFn({ artistId, from, to }),
+        queryKey: ["albums", "top", filter],
+        queryFn: () => topAlbumsFn(filter),
       }),
   },
 };

--- a/apps/web/src/features/artists/queries.ts
+++ b/apps/web/src/features/artists/queries.ts
@@ -1,16 +1,16 @@
 import { queryOptions } from "@tanstack/react-query";
 
-import { toSqlDate } from "@/lib/sql/date-range";
+import { Filter } from "@/lib/filter";
 
 import { searchArtistsFn } from "./queries/search";
 import { topArtistsFn } from "./queries/top";
 
 export const artistsQueries = {
   top: {
-    queryOptions: ({ size = 50, from, to }: { size?: number; from: Date; to: Date }) =>
+    queryOptions: (filter: Filter) =>
       queryOptions({
-        queryKey: ["artists", "top", { size, from: toSqlDate(from), to: toSqlDate(to) }],
-        queryFn: () => topArtistsFn({ size, from, to }),
+        queryKey: ["artists", "top", filter],
+        queryFn: () => topArtistsFn(filter),
       }),
   },
   search: {

--- a/apps/web/src/features/artists/queries/top.ts
+++ b/apps/web/src/features/artists/queries/top.ts
@@ -4,12 +4,11 @@ import { Catalog } from "@/components/catalog/catalog";
 import { interactionDateConditions, joinWhere } from "@/lib/sql/date-range";
 
 type TopArtistsParams = {
-  size: number;
   from: Date;
   to: Date;
 };
 
-export const topArtistsFn = async ({ size, from, to }: TopArtistsParams) => {
+export const topArtistsFn = async ({ from, to }: TopArtistsParams) => {
   const conditions = interactionDateConditions(from, to);
 
   return await db.query<Catalog>(`
@@ -34,6 +33,6 @@ export const topArtistsFn = async ({ size, from, to }: TopArtistsParams) => {
     JOIN artists a ON a.id = u.artist_id
     GROUP BY a.id
     ORDER BY playtime DESC
-    LIMIT ${size}
+    LIMIT 50
   `);
 };

--- a/apps/web/src/features/listening/components/metric-card.tsx
+++ b/apps/web/src/features/listening/components/metric-card.tsx
@@ -4,8 +4,7 @@ import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@harmony/u
 import { useQuery } from "@tanstack/react-query";
 
 import { Metric } from "@/components/metric";
-import { useArtistStore } from "@/lib/stores/artist-store";
-import { useInstantRangeQuery } from "@/lib/stores/date-range-store";
+import { useFilter } from "@/lib/filter";
 
 import { listeningQueries } from "../queries";
 import { MetricSparkline } from "./metric-sparkline";
@@ -23,9 +22,8 @@ type MetricCardProps = {
 };
 
 export const MetricCard = ({ label, unit, query }: MetricCardProps) => {
-  const artistId = useArtistStore((s) => s.artist?.id);
-  const { from, to } = useInstantRangeQuery();
-  const { data } = useQuery(query.queryOptions({ artistId, from, to }));
+  const filter = useFilter();
+  const { data } = useQuery(query.queryOptions(filter));
 
   return (
     <Card size="xs">

--- a/apps/web/src/features/listening/queries.ts
+++ b/apps/web/src/features/listening/queries.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 
-import { toSqlDate } from "@/lib/sql/date-range";
+import { Filter } from "@/lib/filter";
 
 import { activeDaysFn } from "./queries/active-days";
 import { daysOfWeekFn } from "./queries/days-of-week";
@@ -16,46 +16,40 @@ import { trackEngagementFn } from "./queries/track-engagement";
 import { uniqueTracksFn } from "./queries/unique-tracks";
 import { whenYouListenFn } from "./queries/when-you-listen";
 
-type ListeningFilterArgs = { artistId?: number; from: Date; to: Date };
-
-function listeningFilterKey({ artistId, from, to }: ListeningFilterArgs) {
-  return { artistId, from: toSqlDate(from), to: toSqlDate(to) };
-}
-
 export const listeningQueries = {
   listeningTime: {
-    queryOptions: (args: ListeningFilterArgs) =>
+    queryOptions: (filter: Filter) =>
       queryOptions({
-        queryKey: ["listening", "listening-time", listeningFilterKey(args)],
-        queryFn: () => listeningTimeFn(args),
+        queryKey: ["listening", "listening-time", filter],
+        queryFn: () => listeningTimeFn(filter),
       }),
   },
   totalStreams: {
-    queryOptions: (args: ListeningFilterArgs) =>
+    queryOptions: (filter: Filter) =>
       queryOptions({
-        queryKey: ["listening", "total-streams", listeningFilterKey(args)],
-        queryFn: () => totalStreamsFn(args),
+        queryKey: ["listening", "total-streams", filter],
+        queryFn: () => totalStreamsFn(filter),
       }),
   },
   activeDays: {
-    queryOptions: (args: ListeningFilterArgs) =>
+    queryOptions: (filter: Filter) =>
       queryOptions({
-        queryKey: ["listening", "active-days", listeningFilterKey(args)],
-        queryFn: () => activeDaysFn(args),
+        queryKey: ["listening", "active-days", filter],
+        queryFn: () => activeDaysFn(filter),
       }),
   },
   uniqueTracks: {
-    queryOptions: (args: ListeningFilterArgs) =>
+    queryOptions: (filter: Filter) =>
       queryOptions({
-        queryKey: ["listening", "unique-tracks", listeningFilterKey(args)],
-        queryFn: () => uniqueTracksFn(args),
+        queryKey: ["listening", "unique-tracks", filter],
+        queryFn: () => uniqueTracksFn(filter),
       }),
   },
   monthlyActivity: {
-    queryOptions: (args: ListeningFilterArgs) =>
+    queryOptions: (filter: Filter) =>
       queryOptions({
-        queryKey: ["listening", "monthly-activity", listeningFilterKey(args)],
-        queryFn: () => monthlyActivityFn(args),
+        queryKey: ["listening", "monthly-activity", filter],
+        queryFn: () => monthlyActivityFn(filter),
       }),
   },
   daysOfWeek: {

--- a/apps/web/src/features/listening/widgets/monthly-activity-widget.tsx
+++ b/apps/web/src/features/listening/widgets/monthly-activity-widget.tsx
@@ -2,16 +2,12 @@ import { BarChart } from "@harmony/charts/v3";
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@harmony/ui/components/card";
 import { useQuery } from "@tanstack/react-query";
 
+import { useFilter } from "@/lib/filter";
 import { query } from "@/lib/query";
-import { useArtistStore } from "@/lib/stores/artist-store";
-import { useInstantRangeQuery } from "@/lib/stores/date-range-store";
 
 export function MonthlyActivityWidget() {
-  const artistId = useArtistStore((s) => s.artist?.id);
-  const { from, to } = useInstantRangeQuery();
-  const { data = [] } = useQuery(
-    query.listeningHabits.monthlyActivity.queryOptions({ artistId, from, to }),
-  );
+  const filter = useFilter();
+  const { data = [] } = useQuery(query.listeningHabits.monthlyActivity.queryOptions(filter));
 
   return (
     <Card size="sm" className="pb-0.5">

--- a/apps/web/src/features/tracks/queries.ts
+++ b/apps/web/src/features/tracks/queries.ts
@@ -1,5 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 
+import { Filter } from "@/lib/filter";
 import { toSqlDate } from "@/lib/sql/date-range";
 
 import { trackBehavioralFn } from "./queries/behavioral";
@@ -16,10 +17,10 @@ type TrackRangeArgs = { trackId: number; from: Date; to: Date };
 
 export const tracksQueries = {
   top: {
-    queryOptions: ({ artistId, from, to }: { artistId?: number; from: Date; to: Date }) =>
+    queryOptions: (filter: Filter) =>
       queryOptions({
-        queryKey: ["tracks", "top", { artistId, from: toSqlDate(from), to: toSqlDate(to) }],
-        queryFn: () => topTracksFn({ artistId, from, to }),
+        queryKey: ["tracks", "top", filter],
+        queryFn: () => topTracksFn(filter),
       }),
   },
   trends: {

--- a/apps/web/src/lib/filter/index.ts
+++ b/apps/web/src/lib/filter/index.ts
@@ -1,0 +1,24 @@
+import { useArtistStore } from "@/lib/stores/artist-store";
+import {
+  buildInstantRangeQuery,
+  useDateRangeStore,
+  useInstantRangeQuery,
+} from "@/lib/stores/date-range-store";
+
+export type Filter = {
+  artistId?: number;
+  from: Date;
+  to: Date;
+};
+
+export function readFilter(): Filter {
+  const artistId = useArtistStore.getState().artist?.id;
+  const { from, to } = buildInstantRangeQuery(useDateRangeStore.getState());
+  return { artistId, from, to };
+}
+
+export function useFilter(): Filter {
+  const artistId = useArtistStore((s) => s.artist?.id);
+  const { from, to } = useInstantRangeQuery();
+  return { artistId, from, to };
+}

--- a/apps/web/src/routes/app/$packageId/albums.tsx
+++ b/apps/web/src/routes/app/$packageId/albums.tsx
@@ -4,29 +4,22 @@ import { createFileRoute } from "@tanstack/react-router";
 import { CatalogTable } from "@/components/catalog/catalog-table";
 import { DateRangeFilter } from "@/components/layout/header/date-range-filter";
 import { Pane } from "@/components/pane";
+import { readFilter, useFilter } from "@/lib/filter";
 import { query } from "@/lib/query";
-import { useArtistStore } from "@/lib/stores/artist-store";
-import {
-  buildInstantRangeQuery,
-  useDateRangeStore,
-  useInstantRangeQuery,
-} from "@/lib/stores/date-range-store";
 
 export const Route = createFileRoute("/app/$packageId/albums")({
   ssr: false,
   loader: async ({ context: { queryClient }, parentMatchPromise }) => {
     await parentMatchPromise;
-    const artistId = useArtistStore.getState().artist?.id;
-    const { from, to } = buildInstantRangeQuery(useDateRangeStore.getState());
-    await queryClient.ensureQueryData(query.albums.top.queryOptions({ artistId, from, to }));
+    const filter = readFilter();
+    await queryClient.ensureQueryData(query.albums.top.queryOptions(filter));
   },
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const artistId = useArtistStore((s) => s.artist?.id);
-  const { from, to } = useInstantRangeQuery();
-  const { data, isLoading } = useQuery(query.albums.top.queryOptions({ artistId, from, to }));
+  const filter = useFilter();
+  const { data, isLoading } = useQuery(query.albums.top.queryOptions(filter));
 
   return (
     <Pane>

--- a/apps/web/src/routes/app/$packageId/artists.tsx
+++ b/apps/web/src/routes/app/$packageId/artists.tsx
@@ -4,26 +4,22 @@ import { createFileRoute } from "@tanstack/react-router";
 import { CatalogTable } from "@/components/catalog/catalog-table";
 import { DateRangeFilter } from "@/components/layout/header/date-range-filter";
 import { Pane } from "@/components/pane";
+import { readFilter, useFilter } from "@/lib/filter";
 import { query } from "@/lib/query";
-import {
-  buildInstantRangeQuery,
-  useDateRangeStore,
-  useInstantRangeQuery,
-} from "@/lib/stores/date-range-store";
 
 export const Route = createFileRoute("/app/$packageId/artists")({
   ssr: false,
   loader: async ({ context: { queryClient }, parentMatchPromise }) => {
     await parentMatchPromise;
-    const { from, to } = buildInstantRangeQuery(useDateRangeStore.getState());
-    await queryClient.ensureQueryData(query.artists.top.queryOptions({ from, to }));
+    const filter = readFilter();
+    await queryClient.ensureQueryData(query.artists.top.queryOptions(filter));
   },
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const { from, to } = useInstantRangeQuery();
-  const { data, isLoading } = useQuery(query.artists.top.queryOptions({ from, to }));
+  const filter = useFilter();
+  const { data, isLoading } = useQuery(query.artists.top.queryOptions(filter));
 
   return (
     <Pane>

--- a/apps/web/src/routes/app/$packageId/listening.tsx
+++ b/apps/web/src/routes/app/$packageId/listening.tsx
@@ -8,17 +8,14 @@ import { ListeningTimeWidget } from "@/features/listening/widgets/listening-time
 import { MonthlyActivityWidget } from "@/features/listening/widgets/monthly-activity-widget";
 import { TotalStreamsWidget } from "@/features/listening/widgets/total-streams-widget";
 import { UniqueTracksWidget } from "@/features/listening/widgets/unique-tracks-widget";
+import { readFilter } from "@/lib/filter";
 import { query } from "@/lib/query";
-import { useArtistStore } from "@/lib/stores/artist-store";
-import { buildInstantRangeQuery, useDateRangeStore } from "@/lib/stores/date-range-store";
 
 export const Route = createFileRoute("/app/$packageId/listening")({
   ssr: false,
   loader: async ({ context: { queryClient }, parentMatchPromise }) => {
     await parentMatchPromise;
-    const artistId = useArtistStore.getState().artist?.id;
-    const { from, to } = buildInstantRangeQuery(useDateRangeStore.getState());
-    const filter = { artistId, from, to };
+    const filter = readFilter();
     await Promise.all([
       queryClient.ensureQueryData(query.listeningHabits.listeningTime.queryOptions(filter)),
       queryClient.ensureQueryData(query.listeningHabits.totalStreams.queryOptions(filter)),

--- a/apps/web/src/routes/app/$packageId/tracks.tsx
+++ b/apps/web/src/routes/app/$packageId/tracks.tsx
@@ -8,36 +8,29 @@ import { CatalogTable } from "@/components/catalog/catalog-table";
 import { DateRangeFilter } from "@/components/layout/header/date-range-filter";
 import { Pane } from "@/components/pane";
 import { TrackDetailsPanel } from "@/features/tracks/components/track-details-panel";
+import { readFilter, useFilter } from "@/lib/filter";
 import { query } from "@/lib/query";
-import { useArtistStore } from "@/lib/stores/artist-store";
-import {
-  buildInstantRangeQuery,
-  useDateRangeStore,
-  useInstantRangeQuery,
-} from "@/lib/stores/date-range-store";
 
 export const Route = createFileRoute("/app/$packageId/tracks")({
   ssr: false,
   loader: async ({ context: { queryClient }, parentMatchPromise }) => {
     await parentMatchPromise;
-    const artistId = useArtistStore.getState().artist?.id;
-    const { from, to } = buildInstantRangeQuery(useDateRangeStore.getState());
-    await queryClient.ensureQueryData(query.tracks.top.queryOptions({ artistId, from, to }));
+    const filter = readFilter();
+    await queryClient.ensureQueryData(query.tracks.top.queryOptions(filter));
   },
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const artistId = useArtistStore((s) => s.artist?.id);
-  const { from, to } = useInstantRangeQuery();
-  const { data, isLoading } = useQuery(query.tracks.top.queryOptions({ artistId, from, to }));
+  const filter = useFilter();
+  const { data, isLoading } = useQuery(query.tracks.top.queryOptions(filter));
   const trackIds = data?.map((track) => track.id) ?? [];
-  const { data: trends } = useQuery(query.tracks.trends.queryOptions({ trackIds, from, to }));
+  const { data: trends } = useQuery(query.tracks.trends.queryOptions({ trackIds, ...filter }));
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   useEffect(() => {
     setSelectedId(null);
-  }, [artistId, from, to]);
+  }, [filter]);
 
   const { data: trackDetails, isLoading: detailsLoading } = useQuery(
     query.tracks.get.queryOptions(selectedId),


### PR DESCRIPTION
This pull request refactors how filtering (by artist and date range) is handled across the app, centralizing filter logic into a new `Filter` type and related hooks. It replaces repeated manual extraction of filter parameters with a single, reusable approach, simplifying query construction and improving maintainability. Additionally, some minor unrelated tweaks are included.

**Filter logic centralization and query refactoring:**

* Introduced a new `Filter` type and utility functions (`readFilter`, `useFilter`) in `apps/web/src/lib/filter/index.ts` to encapsulate artist and date range selection logic for both server and client usage.
* Updated all query modules (`albums`, `artists`, `listening`, `tracks`) to accept a `Filter` object instead of individual parameters, and refactored their query key and function construction accordingly. [[1]](diffhunk://#diff-4ae4fb84b70b059adcdd27c0293763cf82269d1dc6d39f4f46300c0c1389de8cL3-R12) [[2]](diffhunk://#diff-bc67daf4be3b428c12061871d194815d0b0adad07fce113d2f157a7062bd273bL3-R13) [[3]](diffhunk://#diff-03c4c3d575b0217cf292ff42fd64016ecd6bf9c58e1b3d5d8807741d84e3fd32L3-R3) [[4]](diffhunk://#diff-03c4c3d575b0217cf292ff42fd64016ecd6bf9c58e1b3d5d8807741d84e3fd32L19-R52) [[5]](diffhunk://#diff-78200459e377c6be8529b0609759f1bc50af8b0eecd90069f172dbc41878b4aeR3) [[6]](diffhunk://#diff-78200459e377c6be8529b0609759f1bc50af8b0eecd90069f172dbc41878b4aeL19-R23)
* Refactored all route loaders and components for albums, artists, listening, and tracks pages to use the new filter utilities for both SSR and client-side data fetching, reducing duplicated logic and improving consistency. [[1]](diffhunk://#diff-05c37a3319b9d751520b636b2bd65d9f82898df21e88dea3a63a2d34236bdcbdR7-R22) [[2]](diffhunk://#diff-add43c13c7a08766a51354efe8f4b78eadc898ee8003a158ff2283c443178d58R7-R22) [[3]](diffhunk://#diff-807a85131462721dfa61daa8b1fdc20f5fffc8d703535fb26d686fb285f6075bR11-R18) [[4]](diffhunk://#diff-43149824c33c8de0666399fc21e4c85d67e2c1bc86d3689d2f2c3fd4f1edceccR11-R33) [[5]](diffhunk://#diff-0e30d2b21be23e5bd3ad067877651a5d18cedb24a9ab1bf194bb9345de8cb0bdR5-R10) [[6]](diffhunk://#diff-fb41525dd9db852eff7a2f4e6ca8a2ab8b72a72ad90c39d1d6094c1e7815fb1cL7-R7) [[7]](diffhunk://#diff-fb41525dd9db852eff7a2f4e6ca8a2ab8b72a72ad90c39d1d6094c1e7815fb1cL26-R26)

**Backend query simplification:**

* Simplified the `topArtistsFn` backend function by removing the `size` parameter and hardcoding the result limit to 50, reflecting the new filter structure. [[1]](diffhunk://#diff-bfb5a080756d047fae1ed4f00fa2d89999a9e960148cc7e4592f4897b9139fecL7-R11) [[2]](diffhunk://#diff-bfb5a080756d047fae1ed4f00fa2d89999a9e960148cc7e4592f4897b9139fecL37-R36)

**Minor unrelated tweaks:**

* Changed the `z-index` of the image in the `Cover` component from `z-10` to `z-2`, likely to fix a stacking context issue.