### PR TITLE
ci: streamline pipelines & registry buildcache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,16 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  web-lint:
-    name: Web · Lint
+  web:
+    name: Web
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,75 +34,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-lint-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'turbo.json', '.oxlintrc.json') }}
+          key: turbo-web-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'turbo.json', '.oxlintrc.json', '.oxfmtrc.json') }}
           restore-keys: |
-            turbo-lint-${{ runner.os }}-
+            turbo-web-${{ runner.os }}-
 
-      - name: oxlint
-        run: pnpm exec turbo run //#lint
+      - name: Lint, format, types
+        run: pnpm exec turbo run //#lint //#format:check check-types
 
-  web-format:
-    name: Web · Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Cache Turbo
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-format-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'turbo.json', '.oxfmtrc.json') }}
-          restore-keys: |
-            turbo-format-${{ runner.os }}-
-
-      - name: oxfmt --check
-        run: pnpm exec turbo run //#format:check
-
-  web-types:
-    name: Web · Types
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Cache Turbo
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-types-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
-          restore-keys: |
-            turbo-types-${{ runner.os }}-
-
-      - name: Typecheck
-        run: pnpm exec turbo run check-types
-
-  server-fmt:
-    name: Server · Format
+  server:
+    name: Server
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -111,35 +54,16 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/server
+          shared-key: server
 
       - name: cargo fmt --check
         run: cargo fmt --check
-
-  server-clippy:
-    name: Server · Clippy
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/server
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/server
 
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,41 +15,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  lint:
-    name: Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Install JS dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/server
-
-      - name: Run verify
-        run: pnpm verify
-
   release:
     name: Semantic release
-    needs: lint
     runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.semantic.outputs.new_release_published }}
@@ -88,12 +55,8 @@ jobs:
         app:
           - name: api
             dockerfile: apps/server/Dockerfile
-            title: Harmony API
-            description: Rust Axum upload API and Spotify history ingestion pipeline for Harmony
           - name: web
             dockerfile: apps/web/Dockerfile
-            title: Harmony Web
-            description: TanStack Start frontend for Harmony Spotify analytics
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -116,9 +79,6 @@ jobs:
           tags: |
             type=raw,value=${{ needs.release.outputs.tag }},priority=900
             type=raw,value=latest,priority=100
-          labels: |
-            org.opencontainers.image.title=${{ matrix.app.title }}
-            org.opencontainers.image.description=${{ matrix.app.description }}
 
       - name: Build & push image
         uses: docker/build-push-action@v6
@@ -130,8 +90,8 @@ jobs:
             VITE_APP_VERSION=${{ needs.release.outputs.tag }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.app.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.app.name }}
+          cache-from: type=registry,ref=ghcr.io/abgameur/harmony/${{ matrix.app.name }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/abgameur/harmony/${{ matrix.app.name }}:buildcache,mode=max
 
   pin-compose:
     name: Pin compose image tags
@@ -152,13 +112,24 @@ jobs:
           sed -i "s|ghcr.io/abgameur/harmony/api:[^[:space:]]*|ghcr.io/abgameur/harmony/api:${TAG}|" docker-compose.yml
 
       - name: Commit and push pinned compose
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
+          COAUTHOR_NAME: ${{ github.actor }}
+          COAUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docker-compose.yml
           if git diff --staged --quiet; then
-            echo "Compose already pinned to ${{ needs.release.outputs.tag }}"
+            echo "Compose already pinned to ${TAG}"
             exit 0
           fi
-          git commit -m "deploy: pin images to ${{ needs.release.outputs.tag }} [skip ci]"
+          git commit -m "$(cat <<EOF
+          deploy: pin images to ${TAG}
+
+          [skip ci]
+
+          Co-authored-by: ${COAUTHOR_NAME} <${COAUTHOR_EMAIL}>
+          EOF
+          )"
           git push

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -23,6 +23,9 @@ RUN cargo build --profile release-ci --bin server
 
 # ---
 FROM docker.io/library/debian:bookworm-slim AS runner
+LABEL org.opencontainers.image.title="Harmony API" \
+      org.opencontainers.image.description="Rust Axum upload API and Spotify history ingestion pipeline for Harmony"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libpq5 \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -22,6 +22,9 @@ RUN mkdir -p /runtime/node_modules && cp -aL apps/web/node_modules/react /runtim
 
 # ---
 FROM node:${NODE_VERSION}-alpine AS runner
+LABEL org.opencontainers.image.title="Harmony Web" \
+      org.opencontainers.image.description="TanStack Start frontend for Harmony analytics"
+
 RUN addgroup --system --gid 1001 app
 RUN adduser --system --uid 1001 app
 USER app

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -8,11 +8,11 @@ Images are published to GHCR with the release tag, then that tag is pinned in
 Git and redeploys when the pin changes.
 
 ```text
+PR → CI (Web + Server gates)
 merge / push to v3
-  -> lint
   -> semantic-release (GitHub Release + git tag v3.0.0-beta.N)
   -> if new version:
-       build & push
+       build & push (registry buildcache)
          ghcr.io/abgameur/harmony/{web,api}:latest
          ghcr.io/abgameur/harmony/{web,api}:v3.0.0-beta.N
        CI commits pinned tags in docker-compose.yml [skip ci]
@@ -98,9 +98,9 @@ not required as GitHub Actions variables.
 
 ## Manual checks
 
-- Actions → **Release** workflow: lint, semantic release, build matrix, then
+- Actions → **Release** workflow: semantic release, build matrix, then
   **Pin compose image tags**.
 - GitHub → **Releases**: a new `v3.0.0-beta.N` prerelease with notes from commits.
 - Repo: `docker-compose.yml` image lines updated to that tag and a
-  `deploy: pin images to v3.0.0-beta.N [skip ci]` commit.
+  `deploy: pin images to v3.0.0-beta.N` commit (`[skip ci]`, coauthored).
 - Portainer: stack git hash advanced; containers recreated with the new tags.


### PR DESCRIPTION
This pull request streamlines and simplifies the CI/CD workflows for both the web and server components. It consolidates multiple jobs into unified jobs, optimizes caching strategies, and improves image labeling and commit metadata. Additionally, it updates documentation to reflect the revised workflow and build process.

**CI/CD Workflow Consolidation and Optimization:**

- Combined separate web jobs (`lint`, `format`, `types`) into a single `web` job in `.github/workflows/ci.yml`, running all checks together and optimizing the cache key to include all relevant config files. Similarly, merged server formatting and linting (clippy) into a single `server` job, with both `rustfmt` and `clippy` components installed together. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR6-R15) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL94-R45) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL114-L143)

- Removed the `lint` verification job from the release workflow, so releases now proceed directly to semantic release and build steps without a separate pre-release lint step. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L18-L52) [[2]](diffhunk://#diff-34dc4901a4668ea12a302db78e0b4ae1dd10397509a99e7820a6cdc524defeb7L101-R105)

**Docker Image Metadata and Build Improvements:**

- Moved image title and description labels from the workflow matrix to the Dockerfiles themselves (`apps/server/Dockerfile` and `apps/web/Dockerfile`), ensuring images are always labeled regardless of build context. [[1]](diffhunk://#diff-b3eabb46eb10c8c3d81d4564abe4550ddcdc55dc358418bf384465494c95cdc1R26-R28) [[2]](diffhunk://#diff-4eb403c1470ca34300aea23c38f170d0e8b3c16932a5af4c99da390622d3db4eR25-R27) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L91-L96) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L119-L121)

- Changed Docker build cache strategy to use registry-based build cache layers (`cache-from` and `cache-to` now reference the registry instead of GitHub Actions cache), improving cache sharing between builds. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L133-R94) [[2]](diffhunk://#diff-34dc4901a4668ea12a302db78e0b4ae1dd10397509a99e7820a6cdc524defeb7R11-R15)

**Commit Metadata and Automation Enhancements:**

- Updated the compose pinning job to add co-author information to the commit, using the GitHub actor's name and noreply email, and improved commit message formatting.

**Documentation Updates:**

- Updated `docs/DEPLOY.md` to reflect the new CI/CD flow, including the removal of the lint step from the release workflow and the new build cache approach. [[1]](diffhunk://#diff-34dc4901a4668ea12a302db78e0b4ae1dd10397509a99e7820a6cdc524defeb7R11-R15) [[2]](diffhunk://#diff-34dc4901a4668ea12a302db78e0b4ae1dd10397509a99e7820a6cdc524defeb7L101-R105)