### PR TITLE
ci: update caching strategy in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,8 @@ jobs:
             VITE_APP_VERSION=${{ needs.release.outputs.tag }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/abgameur/harmony/${{ matrix.app.name }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/abgameur/harmony/${{ matrix.app.name }}:buildcache,mode=max
+          cache-from: type=gha,scope=${{ matrix.app.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app.name }}
 
   pin-compose:
     name: Pin compose image tags

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -12,7 +12,7 @@ PR → CI (Web + Server gates)
 merge / push to v3
   -> semantic-release (GitHub Release + git tag v3.0.0-beta.N)
   -> if new version:
-       build & push (registry buildcache)
+       build & push (GHA build cache)
          ghcr.io/abgameur/harmony/{web,api}:latest
          ghcr.io/abgameur/harmony/{web,api}:v3.0.0-beta.N
        CI commits pinned tags in docker-compose.yml [skip ci]


### PR DESCRIPTION
This pull request updates the Docker build caching strategy in the release workflow and deployment documentation to use GitHub Actions (GHA) cache instead of the Docker registry build cache. This change aims to improve build performance and reliability by leveraging GHA's native caching capabilities.

**Build cache strategy update:**

* Updated the `release.yml` workflow to use `type=gha` for both `cache-from` and `cache-to` options in the Docker build step, scoped by application name.
* Updated `DEPLOY.md` documentation to reflect the switch from "registry buildcache" to "GHA build cache" for build and push steps.