### PR TITLE
feat: listening milestones page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
@@ -62,10 +62,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -81,7 +81,7 @@ jobs:
             type=raw,value=latest,priority=100
 
       - name: Build & push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.app.dockerfile }}
@@ -90,8 +90,8 @@ jobs:
             VITE_APP_VERSION=${{ needs.release.outputs.tag }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.app.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.app.name }}
+          cache-from: type=registry,ref=ghcr.io/abgameur/harmony/${{ matrix.app.name }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/abgameur/harmony/${{ matrix.app.name }}:buildcache,mode=max
 
   pin-compose:
     name: Pin compose image tags

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -39,4 +39,4 @@ COPY --from=builder /app/target/release-ci/server ./server
 
 EXPOSE 3000
 
-CMD ./server
+CMD ["./server"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,4 +34,4 @@ COPY --from=builder /runtime/node_modules ./node_modules
 
 EXPOSE 3001
 
-CMD node .output/server/index.mjs
+CMD ["node", ".output/server/index.mjs"]

--- a/apps/web/src/components/cover/cover.tsx
+++ b/apps/web/src/components/cover/cover.tsx
@@ -36,7 +36,7 @@ export function Cover({ src, alt, className, size = "md", blur = false }: CoverP
         </>
       ) : (
         <div className="flex size-full items-center justify-center rounded-sm bg-muted">
-          <Icon icon={MusicNote03Icon} className="size-3" />
+          <Icon icon={MusicNote03Icon} className="size-3" aria-hidden="true" />
         </div>
       )}
     </div>

--- a/apps/web/src/components/nav/app-nav.config.ts
+++ b/apps/web/src/components/nav/app-nav.config.ts
@@ -64,7 +64,7 @@ export const appNav = {
     },
     {
       title: "Milestones",
-      href: "#",
+      href: "/milestones",
       icon: CheckmarkBadge01Icon,
     },
   ],

--- a/apps/web/src/features/milestones/format.ts
+++ b/apps/web/src/features/milestones/format.ts
@@ -1,0 +1,101 @@
+import type { NextMilestone } from "./types";
+
+const dateFormat = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const longDateFormat = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+});
+
+export function formatCount(value: number): string {
+  return Math.round(value).toLocaleString("en-US");
+}
+
+function parseMilestoneDate(value: string | Date): Date | null {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const ymd = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (ymd) {
+    const date = new Date(Number(ymd[1]), Number(ymd[2]) - 1, Number(ymd[3]));
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatMilestoneDate(value: string | Date | null | undefined): string {
+  if (!value) return "-";
+  const date = parseMilestoneDate(value);
+  if (!date) return "-";
+  return dateFormat.format(date);
+}
+
+export function formatLongDate(value: string | Date | null | undefined): string {
+  if (!value) return "-";
+  const date = parseMilestoneDate(value);
+  if (!date) return "-";
+  return longDateFormat.format(date);
+}
+
+export function yearOf(value: string): number | null {
+  const date = parseMilestoneDate(value);
+  return date ? date.getFullYear() : null;
+}
+
+export function sessionDurationParts(
+  minutes: number,
+  unitStyle: "short" | "long" = "short",
+): { value: number; unit: string } {
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return { value: 0, unit: unitStyle === "short" ? "min" : "minutes" };
+  }
+  if (minutes >= 60) {
+    const hours = Math.round((minutes / 60) * 10) / 10;
+    if (unitStyle === "short") return { value: hours, unit: "h" };
+    return { value: hours, unit: hours === 1 ? "hour" : "hours" };
+  }
+  if (unitStyle === "short") return { value: minutes, unit: "min" };
+  return { value: minutes, unit: minutes === 1 ? "minute" : "minutes" };
+}
+
+export function formatBarCurrent(bar: NextMilestone): string {
+  if (bar.id === "hours") {
+    return bar.current.toLocaleString("en-US", { maximumFractionDigits: 1 });
+  }
+  return formatCount(bar.current);
+}
+
+export function nextMilestoneCopy(bar: NextMilestone): { remaining: string; target: string } {
+  switch (bar.id) {
+    case "hours":
+      return {
+        remaining: `${bar.remaining.toLocaleString("en-US", { maximumFractionDigits: 1 })} h`,
+        target: `${formatCount(bar.target)} h`,
+      };
+    case "streams":
+      return {
+        remaining: `${formatCount(bar.remaining)} streams`,
+        target: `${formatCount(bar.target)} streams`,
+      };
+    case "artists":
+      return {
+        remaining: `${formatCount(bar.remaining)} artists`,
+        target: `${formatCount(bar.target)} unique`,
+      };
+    case "tracks":
+      return {
+        remaining: `${formatCount(bar.remaining)} tracks`,
+        target: `${formatCount(bar.target)} unique tracks`,
+      };
+  }
+}
+
+export function heroHeadline(days: number, streams: number): string {
+  const dayPart = days === 1 ? "1\u00a0listening day" : `${formatCount(days)}\u00a0listening days`;
+  const streamPart = streams === 1 ? "1\u00a0stream" : `${formatCount(streams)}\u00a0streams`;
+  return `${dayPart}, ${streamPart}.`;
+}

--- a/apps/web/src/features/milestones/queries.ts
+++ b/apps/web/src/features/milestones/queries.ts
@@ -1,0 +1,55 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import type { Filter } from "@/lib/filter";
+
+import { firstsFn } from "./queries/firsts";
+import { nextMilestonesFn } from "./queries/next-milestones";
+import { sessionsFn } from "./queries/sessions";
+import { streakFn } from "./queries/streak";
+import { summaryFn } from "./queries/summary";
+import { timelineFn } from "./queries/timeline";
+
+export const milestonesQueries = {
+  summary: {
+    queryOptions: (filter: Filter) =>
+      queryOptions({
+        queryKey: ["milestones", "summary", filter],
+        queryFn: () => summaryFn(filter),
+      }),
+  },
+  nextMilestones: {
+    queryOptions: (filter: Filter) =>
+      queryOptions({
+        queryKey: ["milestones", "next", filter],
+        queryFn: () => nextMilestonesFn(filter),
+      }),
+  },
+  streak: {
+    queryOptions: (filter: Filter) =>
+      queryOptions({
+        queryKey: ["milestones", "streak", filter],
+        queryFn: () => streakFn(filter),
+      }),
+  },
+  sessions: {
+    queryOptions: (filter: Filter) =>
+      queryOptions({
+        queryKey: ["milestones", "sessions", filter],
+        queryFn: () => sessionsFn(filter),
+      }),
+  },
+  timeline: {
+    queryOptions: (filter: Filter) =>
+      queryOptions({
+        queryKey: ["milestones", "timeline", filter],
+        queryFn: () => timelineFn(filter),
+      }),
+  },
+  firsts: {
+    queryOptions: (filter: Filter) =>
+      queryOptions({
+        queryKey: ["milestones", "firsts", filter],
+        queryFn: () => firstsFn(filter),
+      }),
+  },
+};

--- a/apps/web/src/features/milestones/queries/filter.ts
+++ b/apps/web/src/features/milestones/queries/filter.ts
@@ -1,0 +1,16 @@
+import {
+  buildListeningFilter,
+  type ListeningRangeParams,
+} from "@/features/listening/queries/listening-filter";
+
+export function tracksJoin(params: ListeningRangeParams): string {
+  const { artistJoin } = buildListeningFilter(params);
+  return artistJoin || "JOIN tracks t ON t.id = i.track_id";
+}
+
+export function sqlRungValues(rungs: readonly number[]): string {
+  return rungs.map((n) => `(${n})`).join(", ");
+}
+
+export { buildListeningFilter };
+export type { ListeningRangeParams };

--- a/apps/web/src/features/milestones/queries/firsts.ts
+++ b/apps/web/src/features/milestones/queries/firsts.ts
@@ -1,0 +1,65 @@
+import { db } from "@harmony/duckdb";
+
+import type { Discovery } from "../types";
+
+import { buildListeningFilter, tracksJoin, type ListeningRangeParams } from "./filter";
+
+type FirstRow = {
+  id: number;
+  date: string | null;
+  name: string | null;
+  image: string | null;
+  later_rank: number;
+};
+
+export const firstsFn = async (params: ListeningRangeParams): Promise<Discovery[]> => {
+  const { where } = buildListeningFilter(params);
+  const join = tracksJoin(params);
+
+  const rows = await db.query<FirstRow>(`
+    WITH artist_stats AS (
+      SELECT
+        u.artist_id,
+        MIN(i.ts) AS first_ts,
+        SUM(i.ms_played) AS ms
+      FROM interactions i
+      ${join}
+      CROSS JOIN unnest(t.artists) AS u(artist_id)
+      ${where}
+      GROUP BY u.artist_id
+    ),
+    ranked AS (
+      SELECT
+        artist_id,
+        first_ts,
+        ms,
+        ROW_NUMBER() OVER (ORDER BY ms DESC, artist_id ASC)::INTEGER AS later_rank
+      FROM artist_stats
+    )
+    SELECT
+      a.id AS id,
+      CAST(CAST(r.first_ts AS DATE) AS VARCHAR) AS date,
+      a.name AS name,
+      a.image AS image,
+      r.later_rank AS later_rank
+    FROM ranked r
+    JOIN artists a ON a.id = r.artist_id
+    WHERE r.later_rank <= 50
+      AND r.ms >= 1800000
+    ORDER BY r.first_ts ASC
+    LIMIT 12
+  `);
+
+  return rows.flatMap((row) => {
+    if (!row.name || !row.date) return [];
+    return [
+      {
+        id: row.id,
+        date: row.date,
+        name: row.name,
+        image: row.image,
+        laterRank: row.later_rank,
+      },
+    ];
+  });
+};

--- a/apps/web/src/features/milestones/queries/next-milestones.ts
+++ b/apps/web/src/features/milestones/queries/next-milestones.ts
@@ -1,0 +1,83 @@
+import { db } from "@harmony/duckdb";
+
+import { ARTIST_RUNGS, HOUR_RUNGS, STREAM_RUNGS, TRACK_RUNGS, type NextMilestone } from "../types";
+import { buildListeningFilter, tracksJoin, type ListeningRangeParams } from "./filter";
+
+type TotalsRow = {
+  hours: number | null;
+  streams: number | null;
+  tracks: number | null;
+  artists: number | null;
+};
+
+function nextRung(
+  current: number,
+  ladder: readonly number[],
+): { target: number; remaining: number; reached: boolean } {
+  const target = ladder.find((rung) => current < rung);
+  if (target === undefined) {
+    const last = ladder[ladder.length - 1] ?? current;
+    return { target: last, remaining: 0, reached: true };
+  }
+  return { target, remaining: target - current, reached: false };
+}
+
+function barPercent(current: number, target: number): number {
+  if (target <= 0) return 0;
+  return Math.min(100, Math.round((current / target) * 100));
+}
+
+function toBar(
+  id: NextMilestone["id"],
+  label: string,
+  current: number,
+  ladder: readonly number[],
+): NextMilestone {
+  const { target, remaining, reached } = nextRung(current, ladder);
+  return {
+    id,
+    label,
+    current,
+    target,
+    remaining,
+    percent: barPercent(current, target),
+    reached,
+  };
+}
+
+export const nextMilestonesFn = async (params: ListeningRangeParams): Promise<NextMilestone[]> => {
+  const { artistJoin, where } = buildListeningFilter(params);
+  const join = tracksJoin(params);
+
+  const [row] = await db.query<TotalsRow>(`
+    WITH totals AS (
+      SELECT
+        COALESCE(ROUND(SUM(i.ms_played) / 3600000.0, 1), 0)::DOUBLE AS hours,
+        COUNT(*)::INTEGER AS streams,
+        COUNT(DISTINCT i.track_id)::INTEGER AS tracks
+      FROM interactions i
+      ${artistJoin}
+      ${where}
+    ),
+    artist_totals AS (
+      SELECT COUNT(DISTINCT u.artist_id)::INTEGER AS artists
+      FROM interactions i
+      ${join}
+      CROSS JOIN unnest(t.artists) AS u(artist_id)
+      ${where}
+    )
+    SELECT
+      totals.hours,
+      totals.streams,
+      totals.tracks,
+      artist_totals.artists
+    FROM totals, artist_totals
+  `);
+
+  return [
+    toBar("hours", "Hours", row?.hours ?? 0, HOUR_RUNGS),
+    toBar("streams", "Streams", row?.streams ?? 0, STREAM_RUNGS),
+    toBar("artists", "Unique artists", row?.artists ?? 0, ARTIST_RUNGS),
+    toBar("tracks", "Unique tracks", row?.tracks ?? 0, TRACK_RUNGS),
+  ];
+};

--- a/apps/web/src/features/milestones/queries/sessions.ts
+++ b/apps/web/src/features/milestones/queries/sessions.ts
@@ -1,0 +1,75 @@
+import { db } from "@harmony/duckdb";
+
+import type { ListeningSessions } from "../types";
+
+import { buildListeningFilter, type ListeningRangeParams } from "./filter";
+
+/** A new session starts after 30 minutes without a play. */
+const SESSION_GAP_SECONDS = 30 * 60;
+
+type SessionRow = {
+  sessions: number | null;
+  avg_min: number | null;
+  longest_min: number | null;
+  longest_start: string | null;
+};
+
+export const sessionsFn = async (params: ListeningRangeParams): Promise<ListeningSessions> => {
+  const { artistJoin, where } = buildListeningFilter(params);
+
+  const [row] = await db.query<SessionRow>(`
+    WITH plays AS (
+      SELECT i.ts, i.ms_played
+      FROM interactions i
+      ${artistJoin}
+      ${where}
+    ),
+    ordered AS (
+      SELECT
+        ts,
+        ms_played,
+        LAG(ts) OVER (ORDER BY ts, ms_played) AS prev_ts
+      FROM plays
+    ),
+    flagged AS (
+      SELECT
+        ts,
+        ms_played,
+        CASE
+          WHEN prev_ts IS NULL OR date_diff('second', prev_ts, ts) > ${SESSION_GAP_SECONDS} THEN 1
+          ELSE 0
+        END AS new_session
+      FROM ordered
+    ),
+    numbered AS (
+      SELECT
+        ts,
+        ms_played,
+        SUM(new_session) OVER (ORDER BY ts, ms_played ROWS UNBOUNDED PRECEDING) AS session_id
+      FROM flagged
+    ),
+    sessions AS (
+      SELECT
+        MIN(ts) AS started,
+        date_diff('millisecond', MIN(ts), MAX(ts)) + arg_max(ms_played, ts) AS duration_ms
+      FROM numbered
+      GROUP BY session_id
+      HAVING COUNT(*) >= 2
+    )
+    SELECT
+      COUNT(*)::INTEGER AS sessions,
+      COALESCE(ROUND(AVG(duration_ms) / 60000.0, 1), 0)::DOUBLE AS avg_min,
+      COALESCE(ROUND(MAX(duration_ms) / 60000.0, 1), 0)::DOUBLE AS longest_min,
+      CAST((
+        SELECT started FROM sessions ORDER BY duration_ms DESC, started ASC LIMIT 1
+      ) AS VARCHAR) AS longest_start
+    FROM sessions
+  `);
+
+  return {
+    sessions: row?.sessions ?? 0,
+    avgMinutes: row?.avg_min ?? 0,
+    longestMinutes: row?.longest_min ?? 0,
+    longestStart: row?.longest_start ?? null,
+  };
+};

--- a/apps/web/src/features/milestones/queries/streak.ts
+++ b/apps/web/src/features/milestones/queries/streak.ts
@@ -1,0 +1,69 @@
+import { db } from "@harmony/duckdb";
+
+import type { ListeningStreak } from "../types";
+
+import { buildListeningFilter, type ListeningRangeParams } from "./filter";
+
+type StreakRow = {
+  current_days: number | null;
+  longest_days: number | null;
+  longest_start: string | null;
+  longest_end: string | null;
+};
+
+export const streakFn = async (params: ListeningRangeParams): Promise<ListeningStreak> => {
+  const { artistJoin, where } = buildListeningFilter(params);
+
+  const [row] = await db.query<StreakRow>(`
+    WITH play_days AS (
+      SELECT DISTINCT CAST(i.ts AS DATE) AS play_date
+      FROM interactions i
+      ${artistJoin}
+      ${where}
+    ),
+    numbered AS (
+      SELECT
+        play_date,
+        play_date - (ROW_NUMBER() OVER (ORDER BY play_date))::INTEGER AS streak_group
+      FROM play_days
+    ),
+    streaks AS (
+      SELECT
+        MIN(play_date) AS streak_start,
+        MAX(play_date) AS streak_end,
+        COUNT(*)::INTEGER AS streak_days
+      FROM numbered
+      GROUP BY streak_group
+    ),
+    bounds AS (
+      SELECT MAX(play_date) AS last_day FROM play_days
+    ),
+    latest AS (
+      SELECT streak_days
+      FROM streaks, bounds
+      WHERE streak_end = bounds.last_day
+      LIMIT 1
+    ),
+    best AS (
+      SELECT streak_days, streak_start, streak_end
+      FROM streaks
+      ORDER BY streak_days DESC, streak_start ASC
+      LIMIT 1
+    )
+    SELECT
+      COALESCE(latest.streak_days, 0)::INTEGER AS current_days,
+      COALESCE(best.streak_days, 0)::INTEGER AS longest_days,
+      CAST(best.streak_start AS VARCHAR) AS longest_start,
+      CAST(best.streak_end AS VARCHAR) AS longest_end
+    FROM (SELECT 1) AS dummy
+    LEFT JOIN latest ON TRUE
+    LEFT JOIN best ON TRUE
+  `);
+
+  return {
+    currentDays: row?.current_days ?? 0,
+    longestDays: row?.longest_days ?? 0,
+    longestStart: row?.longest_start ?? null,
+    longestEnd: row?.longest_end ?? null,
+  };
+};

--- a/apps/web/src/features/milestones/queries/summary.ts
+++ b/apps/web/src/features/milestones/queries/summary.ts
@@ -1,0 +1,54 @@
+import { db } from "@harmony/duckdb";
+
+import type { MilestoneSummary } from "../types";
+
+import { buildListeningFilter, type ListeningRangeParams } from "./filter";
+
+type SummaryRow = {
+  listening_days: number | null;
+  streams: number | null;
+  range_start: string | null;
+  first_track: string | null;
+  first_artists: string | null;
+};
+
+export const summaryFn = async (params: ListeningRangeParams): Promise<MilestoneSummary> => {
+  const { artistJoin, where } = buildListeningFilter(params);
+
+  const [row] = await db.query<SummaryRow>(`
+    WITH stats AS (
+      SELECT
+        COUNT(DISTINCT CAST(i.ts AS DATE))::INTEGER AS listening_days,
+        COUNT(*)::INTEGER AS streams,
+        MIN(i.ts) AS first_ts
+      FROM interactions i
+      ${artistJoin}
+      ${where}
+    ),
+    first_play AS (
+      SELECT v.track_name, v.track_artists_description
+      FROM interactions i
+      ${artistJoin}
+      JOIN v_tracks_info v ON v.track_id = i.track_id
+      ${where}
+      ORDER BY i.ts, i.track_id
+      LIMIT 1
+    )
+    SELECT
+      COALESCE(stats.listening_days, 0)::INTEGER AS listening_days,
+      COALESCE(stats.streams, 0)::INTEGER AS streams,
+      CAST(stats.first_ts AS VARCHAR) AS range_start,
+      first_play.track_name AS first_track,
+      first_play.track_artists_description AS first_artists
+    FROM stats
+    LEFT JOIN first_play ON TRUE
+  `);
+
+  return {
+    listeningDays: row?.listening_days ?? 0,
+    streams: row?.streams ?? 0,
+    rangeStart: row?.range_start ?? null,
+    firstTrack: row?.first_track ?? null,
+    firstArtists: row?.first_artists ?? null,
+  };
+};

--- a/apps/web/src/features/milestones/queries/timeline.ts
+++ b/apps/web/src/features/milestones/queries/timeline.ts
@@ -1,0 +1,195 @@
+import { db } from "@harmony/duckdb";
+
+import { formatCount } from "../format";
+import { ARTIST_RUNGS, HOUR_RUNGS, STREAM_RUNGS, TRACK_RUNGS, type TimelineEvent } from "../types";
+import {
+  buildListeningFilter,
+  sqlRungValues,
+  tracksJoin,
+  type ListeningRangeParams,
+} from "./filter";
+
+type EventKind = "hours" | "streams" | "artists" | "tracks" | "first";
+
+type LogRow = {
+  date: string;
+  event_kind: string;
+  threshold: number;
+  entity: string | null;
+  subtitle: string | null;
+  image: string | null;
+};
+
+function isEventKind(value: string): value is EventKind {
+  return (
+    value === "hours" ||
+    value === "streams" ||
+    value === "artists" ||
+    value === "tracks" ||
+    value === "first"
+  );
+}
+
+function eventLabel(kind: EventKind, threshold: number): string {
+  if (kind === "hours") return `${formatCount(threshold)} hours listened`;
+  if (kind === "streams") return `${formatCount(threshold)} streams reached`;
+  if (kind === "artists") return `${formatCount(threshold)} unique artists`;
+  if (kind === "tracks") return `${formatCount(threshold)} unique tracks`;
+  return "First listen";
+}
+
+function toEvent(row: LogRow): TimelineEvent | null {
+  if (!isEventKind(row.event_kind)) return null;
+  return {
+    id: `${row.event_kind}-${row.threshold}-${row.date}`,
+    date: row.date,
+    label: eventLabel(row.event_kind, row.threshold),
+    entity: row.entity ?? "",
+    subtitle: row.subtitle ?? "",
+    image: row.image,
+  };
+}
+
+export const timelineFn = async (params: ListeningRangeParams): Promise<TimelineEvent[]> => {
+  const { artistJoin, where } = buildListeningFilter(params);
+  const join = tracksJoin(params);
+
+  const rows = await db.query<LogRow>(`
+    WITH plays AS (
+      SELECT i.ts, i.track_id, i.ms_played
+      FROM interactions i
+      ${artistJoin}
+      ${where}
+    ),
+    ordered AS (
+      SELECT
+        ts,
+        track_id,
+        SUM(ms_played) OVER w AS cum_ms,
+        COUNT(*) OVER w AS cum_n
+      FROM plays
+      WINDOW w AS (ORDER BY ts, track_id ROWS UNBOUNDED PRECEDING)
+    ),
+    lagged AS (
+      SELECT
+        ts,
+        track_id,
+        cum_ms,
+        cum_n,
+        COALESCE(LAG(cum_ms) OVER (ORDER BY ts, track_id), 0) AS prev_ms,
+        COALESCE(LAG(cum_n) OVER (ORDER BY ts, track_id), 0) AS prev_n
+      FROM ordered
+    ),
+    hour_events AS (
+      SELECT
+        CAST(CAST(l.ts AS DATE) AS VARCHAR) AS date,
+        'hours' AS event_kind,
+        t.threshold::INTEGER AS threshold,
+        v.track_name AS entity,
+        v.track_artists_description AS subtitle,
+        v.image AS image
+      FROM lagged l
+      JOIN (VALUES ${sqlRungValues(HOUR_RUNGS)}) AS t(threshold)
+        ON l.prev_ms / 3600000.0 < t.threshold
+       AND l.cum_ms / 3600000.0 >= t.threshold
+      JOIN v_tracks_info v ON v.track_id = l.track_id
+    ),
+    stream_events AS (
+      SELECT
+        CAST(CAST(l.ts AS DATE) AS VARCHAR) AS date,
+        'streams' AS event_kind,
+        t.threshold::INTEGER AS threshold,
+        v.track_name AS entity,
+        v.track_artists_description AS subtitle,
+        v.image AS image
+      FROM lagged l
+      JOIN (VALUES ${sqlRungValues(STREAM_RUNGS)}) AS t(threshold)
+        ON l.prev_n < t.threshold
+       AND l.cum_n >= t.threshold
+      JOIN v_tracks_info v ON v.track_id = l.track_id
+    ),
+    track_firsts AS (
+      SELECT i.track_id, MIN(i.ts) AS first_ts
+      FROM interactions i
+      ${artistJoin}
+      ${where}
+      GROUP BY i.track_id
+    ),
+    track_ranked AS (
+      SELECT
+        track_id,
+        first_ts,
+        ROW_NUMBER() OVER (ORDER BY first_ts, track_id)::INTEGER AS n
+      FROM track_firsts
+    ),
+    track_events AS (
+      SELECT
+        CAST(CAST(r.first_ts AS DATE) AS VARCHAR) AS date,
+        'tracks' AS event_kind,
+        t.threshold::INTEGER AS threshold,
+        v.track_name AS entity,
+        v.track_artists_description AS subtitle,
+        v.image AS image
+      FROM track_ranked r
+      JOIN (VALUES ${sqlRungValues(TRACK_RUNGS)}) AS t(threshold) ON r.n = t.threshold
+      JOIN v_tracks_info v ON v.track_id = r.track_id
+    ),
+    artist_firsts AS (
+      SELECT u.artist_id, MIN(i.ts) AS first_ts
+      FROM interactions i
+      ${join}
+      CROSS JOIN unnest(t.artists) AS u(artist_id)
+      ${where}
+      GROUP BY u.artist_id
+    ),
+    artist_ranked AS (
+      SELECT
+        artist_id,
+        first_ts,
+        ROW_NUMBER() OVER (ORDER BY first_ts, artist_id)::INTEGER AS n
+      FROM artist_firsts
+    ),
+    artist_events AS (
+      SELECT
+        CAST(CAST(r.first_ts AS DATE) AS VARCHAR) AS date,
+        'artists' AS event_kind,
+        t.threshold::INTEGER AS threshold,
+        a.name AS entity,
+        '' AS subtitle,
+        a.image AS image
+      FROM artist_ranked r
+      JOIN (VALUES ${sqlRungValues(ARTIST_RUNGS)}) AS t(threshold) ON r.n = t.threshold
+      JOIN artists a ON a.id = r.artist_id
+    ),
+    first_event AS (
+      SELECT
+        CAST(CAST(i.ts AS DATE) AS VARCHAR) AS date,
+        'first' AS event_kind,
+        1 AS threshold,
+        v.track_name AS entity,
+        v.track_artists_description AS subtitle,
+        v.image AS image
+      FROM interactions i
+      ${artistJoin}
+      JOIN v_tracks_info v ON v.track_id = i.track_id
+      ${where}
+      ORDER BY i.ts, i.track_id
+      LIMIT 1
+    )
+    SELECT * FROM hour_events
+    UNION ALL
+    SELECT * FROM stream_events
+    UNION ALL
+    SELECT * FROM track_events
+    UNION ALL
+    SELECT * FROM artist_events
+    UNION ALL
+    SELECT * FROM first_event
+    ORDER BY date DESC
+  `);
+
+  return rows.flatMap((row) => {
+    const event = toEvent(row);
+    return event ? [event] : [];
+  });
+};

--- a/apps/web/src/features/milestones/types.ts
+++ b/apps/web/src/features/milestones/types.ts
@@ -1,0 +1,53 @@
+export const HOUR_RUNGS = [10, 50, 100, 250, 500, 1000, 2500, 5000, 7000, 10_000] as const;
+export const STREAM_RUNGS = [100, 1000, 5000, 10_000, 25_000, 50_000, 100_000] as const;
+export const ARTIST_RUNGS = [50, 100, 250, 500, 1000, 2500, 5000] as const;
+export const TRACK_RUNGS = [100, 500, 1000, 5000, 10_000] as const;
+
+export type NextMilestone = {
+  id: "hours" | "streams" | "artists" | "tracks";
+  label: string;
+  current: number;
+  target: number;
+  remaining: number;
+  percent: number;
+  reached: boolean;
+};
+
+export type ListeningStreak = {
+  currentDays: number;
+  longestDays: number;
+  longestStart: string | null;
+  longestEnd: string | null;
+};
+
+export type ListeningSessions = {
+  sessions: number;
+  avgMinutes: number;
+  longestMinutes: number;
+  longestStart: string | null;
+};
+
+export type TimelineEvent = {
+  id: string;
+  date: string;
+  label: string;
+  entity: string;
+  subtitle: string;
+  image: string | null;
+};
+
+export type Discovery = {
+  id: number;
+  date: string;
+  name: string;
+  image: string | null;
+  laterRank: number;
+};
+
+export type MilestoneSummary = {
+  listeningDays: number;
+  streams: number;
+  rangeStart: string | null;
+  firstTrack: string | null;
+  firstArtists: string | null;
+};

--- a/apps/web/src/features/milestones/widgets/firsts-widget.tsx
+++ b/apps/web/src/features/milestones/widgets/firsts-widget.tsx
@@ -35,9 +35,7 @@ export function FirstsWidget() {
                   {formatMilestoneDate(row.date)}
                 </p>
               </div>
-              <p className="shrink-0 text-sm font-medium text-primary">
-                #{row.laterRank}
-              </p>
+              <p className="shrink-0 text-sm font-medium text-primary">#{row.laterRank}</p>
             </li>
           ))}
         </ul>

--- a/apps/web/src/features/milestones/widgets/firsts-widget.tsx
+++ b/apps/web/src/features/milestones/widgets/firsts-widget.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { Cover } from "@/components/cover";
+import { useFilter } from "@/lib/filter";
+import { query } from "@/lib/query";
+
+import { formatMilestoneDate } from "../format";
+
+export function FirstsWidget() {
+  const filter = useFilter();
+  const { data = [], isPending } = useQuery(query.milestones.firsts.queryOptions(filter));
+
+  return (
+    <section className="min-w-0 space-y-3" aria-labelledby="discoveries-that-stayed">
+      <header>
+        <h2 id="discoveries-that-stayed" className="text-base font-semibold tracking-tight">
+          Discoveries that stayed
+        </h2>
+        <p className="text-xs text-pretty text-muted-foreground">
+          Artists you first heard in this range, now in your top 50.
+        </p>
+      </header>
+      {!isPending && data.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No top-50 artists were first heard in this range.
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
+          {data.map((row) => (
+            <li key={row.id} className="flex items-center gap-3">
+              <Cover src={row.image} alt={row.name} />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm">{row.name}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {formatMilestoneDate(row.date)}
+                </p>
+              </div>
+              <p className="shrink-0 text-sm font-medium text-primary">
+                #{row.laterRank}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/milestones/widgets/next-milestones-widget.tsx
+++ b/apps/web/src/features/milestones/widgets/next-milestones-widget.tsx
@@ -1,0 +1,56 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { useFilter } from "@/lib/filter";
+import { query } from "@/lib/query";
+
+import { formatBarCurrent, formatCount, nextMilestoneCopy } from "../format";
+
+export function NextMilestonesWidget() {
+  const filter = useFilter();
+  const { data = [] } = useQuery(query.milestones.nextMilestones.queryOptions(filter));
+  const upcoming = data.filter((bar) => !bar.reached);
+
+  return (
+    <section className="min-w-0 space-y-3" aria-labelledby="next-milestones">
+      <h2 id="next-milestones" className="text-base font-semibold tracking-tight">
+        Next Milestones
+      </h2>
+      {upcoming.length === 0 ? (
+        <p className="text-sm text-muted-foreground">You have passed every listed mark.</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-4">
+          {upcoming.map((bar) => {
+            const { remaining, target } = nextMilestoneCopy(bar);
+            const label = `${bar.label}, ${remaining} left before ${target}`;
+            return (
+              <div key={bar.id} className="min-w-0 space-y-1.5">
+                <p className="text-sm text-pretty">
+                  <span className="font-semibold text-primary">{remaining}</span>
+                  {` left before `}
+                  <span>{target}</span>
+                </p>
+                <div
+                  role="progressbar"
+                  aria-label={label}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={bar.percent}
+                  aria-valuetext={label}
+                  className="h-1 overflow-hidden rounded-md bg-muted"
+                >
+                  <div
+                    className="origin-start h-full bg-primary transition-transform duration-200 ease-out motion-reduce:transition-none"
+                    style={{ transform: `scaleX(${bar.percent / 100})` }}
+                  />
+                </div>
+                <p className="text-end text-[10px] text-muted-foreground">
+                  {formatBarCurrent(bar)} / {formatCount(bar.target)}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/milestones/widgets/sessions-streaks-widget.tsx
+++ b/apps/web/src/features/milestones/widgets/sessions-streaks-widget.tsx
@@ -1,0 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { Metric } from "@/components/metric";
+import { useFilter } from "@/lib/filter";
+import { query } from "@/lib/query";
+
+import type { ListeningStreak } from "../types";
+
+import { formatCount, formatMilestoneDate, sessionDurationParts } from "../format";
+
+function streakCaption(streak: ListeningStreak | undefined): string {
+  if (!streak || streak.longestDays < 2 || !streak.longestStart || !streak.longestEnd) {
+    return "Listen on consecutive days to build one";
+  }
+  return `${formatMilestoneDate(streak.longestStart)} to ${formatMilestoneDate(streak.longestEnd)}`;
+}
+
+function Stat({
+  label,
+  value,
+  unit,
+  caption,
+}: {
+  label: string;
+  value: number | undefined;
+  unit: string;
+  caption: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <Metric size="lg" value={value} unit={unit} />
+      <p className="text-[10px] text-pretty text-muted-foreground">{caption}</p>
+    </div>
+  );
+}
+
+export function SessionsStreaksWidget() {
+  const filter = useFilter();
+  const { data: streak } = useQuery(query.milestones.streak.queryOptions(filter));
+  const { data: sessions } = useQuery(query.milestones.sessions.queryOptions(filter));
+
+  const hasStreak = streak !== undefined && streak.longestDays >= 2;
+  const hasSessions = sessions !== undefined && sessions.sessions > 0;
+  const avg = sessionDurationParts(sessions?.avgMinutes ?? 0);
+  const longest = sessionDurationParts(sessions?.longestMinutes ?? 0);
+  const noSessions = "No sessions in this range";
+
+  return (
+    <section className="min-w-0 space-y-3" aria-labelledby="sessions-and-streaks">
+      <h2 id="sessions-and-streaks" className="text-base font-semibold tracking-tight">
+        Sessions and Streaks
+      </h2>
+      <div className="space-y-4">
+        <div className="grid grid-cols-3 gap-4">
+          <Stat
+            label="Average session"
+            value={hasSessions ? avg.value : undefined}
+            unit={avg.unit}
+            caption={hasSessions ? `on ${formatCount(sessions.sessions)} sessions` : noSessions}
+          />
+          <Stat
+            label="Longest session"
+            value={hasSessions ? longest.value : undefined}
+            unit={longest.unit}
+            caption={
+              hasSessions && sessions.longestStart
+                ? formatMilestoneDate(sessions.longestStart)
+                : noSessions
+            }
+          />
+          <Stat
+            label="Longest listening streak"
+            value={hasStreak ? streak.longestDays : undefined}
+            unit="days"
+            caption={streakCaption(hasStreak ? streak : undefined)}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/milestones/widgets/summary-hero.tsx
+++ b/apps/web/src/features/milestones/widgets/summary-hero.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { useFilter } from "@/lib/filter";
+import { query } from "@/lib/query";
+
+import { formatLongDate, heroHeadline } from "../format";
+
+export function SummaryHero() {
+  const filter = useFilter();
+  const { data, isPending } = useQuery(query.milestones.summary.queryOptions(filter));
+
+  return (
+    <header className="min-w-0 space-y-1">
+      <p className="text-xs text-muted-foreground">
+        {isPending
+          ? "Since…"
+          : data?.rangeStart
+            ? `Since ${formatLongDate(data.rangeStart)}`
+            : "Since the first play"}
+      </p>
+      <p className="text-xl font-semibold tracking-tight text-pretty tabular-nums">
+        {data ? heroHeadline(data.listeningDays, data.streams) : "Listening days and streams…"}
+      </p>
+    </header>
+  );
+}

--- a/apps/web/src/features/milestones/widgets/timeline-widget.tsx
+++ b/apps/web/src/features/milestones/widgets/timeline-widget.tsx
@@ -1,0 +1,241 @@
+import { ArrowLeft01Icon, ArrowRight01Icon, Icon } from "@harmony/icons";
+import { Button } from "@harmony/ui/components/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@harmony/ui/components/tooltip";
+import { cn } from "@harmony/ui/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { Cover } from "@/components/cover";
+import { useFilter } from "@/lib/filter";
+import { query } from "@/lib/query";
+
+import type { ListeningSessions, ListeningStreak, TimelineEvent } from "../types";
+
+import { formatCount, formatMilestoneDate, sessionDurationParts, yearOf } from "../format";
+
+function withRecordEvents(
+  events: TimelineEvent[],
+  streak: ListeningStreak | undefined,
+  sessions: ListeningSessions | undefined,
+): TimelineEvent[] {
+  const extra: TimelineEvent[] = [];
+
+  if (sessions && sessions.longestMinutes > 0 && sessions.longestStart) {
+    const duration = sessionDurationParts(sessions.longestMinutes, "long");
+    extra.push({
+      id: `session-${sessions.longestStart}`,
+      date: sessions.longestStart,
+      label: "Record session",
+      entity: `${duration.value} ${duration.unit} of continuous listening`,
+      subtitle: "",
+      image: null,
+    });
+  }
+
+  if (streak && streak.longestDays >= 2 && streak.longestEnd) {
+    extra.push({
+      id: `streak-${streak.longestEnd}`,
+      date: streak.longestEnd,
+      label: "Longest streak",
+      entity: `${formatCount(streak.longestDays)} days of daily listening`,
+      subtitle: "",
+      image: null,
+    });
+  }
+
+  return [...events, ...extra].toSorted(
+    (a, b) => a.date.localeCompare(b.date) || a.id.localeCompare(b.id),
+  );
+}
+
+function TimelineSpine({ isFirst, isLast }: { isFirst: boolean; isLast: boolean }) {
+  const hideLine = isFirst && isLast;
+  return (
+    <div className="relative flex h-4 w-full items-center">
+      {hideLine ? null : (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "absolute top-1/2 h-px -translate-y-1/2 bg-border",
+            isFirst
+              ? "inset-s-3 inset-e-0"
+              : isLast
+                ? "inset-s-0 inset-e-[calc(100%-0.75rem)]"
+                : "inset-x-0",
+          )}
+        />
+      )}
+    </div>
+  );
+}
+
+function useHorizontalPager(itemCount: number) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [canPrev, setCanPrev] = useState(false);
+  const [canNext, setCanNext] = useState(false);
+
+  const update = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    setCanPrev(el.scrollLeft > 8);
+    setCanNext(el.scrollLeft + el.clientWidth < el.scrollWidth - 8);
+  }, []);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", update);
+      observer.disconnect();
+    };
+  }, [itemCount, update]);
+
+  const page = (direction: -1 | 1) => {
+    const el = ref.current;
+    if (!el) return;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    el.scrollBy({
+      left: direction * Math.max(el.clientWidth * 0.7, 208),
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
+  };
+
+  return { ref, canPrev, canNext, page };
+}
+
+export function TimelineWidget() {
+  const filter = useFilter();
+  const { data: events = [], isPending } = useQuery(query.milestones.timeline.queryOptions(filter));
+  const { data: streak } = useQuery(query.milestones.streak.queryOptions(filter));
+  const { data: sessions } = useQuery(query.milestones.sessions.queryOptions(filter));
+
+  const rows = useMemo(
+    () => withRecordEvents(events, streak, sessions),
+    [events, streak, sessions],
+  );
+
+  const { ref, canPrev, canNext, page } = useHorizontalPager(rows.length);
+  const showNav = canPrev || canNext;
+  const showYear = rows.map((event, index) => {
+    const year = yearOf(event.date);
+    if (year === null) return false;
+    const previousEvent = rows[index - 1];
+    const previous = previousEvent ? yearOf(previousEvent.date) : null;
+    return year !== previous;
+  });
+
+  const pager = showNav ? (
+    <div className="flex gap-1">
+      <Button
+        type="button"
+        size="icon"
+        variant="secondary"
+        disabled={!canPrev}
+        aria-label="Previous milestones"
+        onClick={() => page(-1)}
+      >
+        <Icon icon={ArrowLeft01Icon} />
+      </Button>
+      <Button
+        type="button"
+        size="icon"
+        variant="secondary"
+        disabled={!canNext}
+        aria-label="Next milestones"
+        onClick={() => page(1)}
+      >
+        <Icon icon={ArrowRight01Icon} />
+      </Button>
+    </div>
+  ) : null;
+
+  if (!isPending && rows.length === 0) {
+    return (
+      <section className="space-y-3" aria-labelledby="milestones-timeline">
+        <h2 id="milestones-timeline" className="text-base font-semibold tracking-tight">
+          Milestones timeline
+        </h2>
+        <p className="text-sm text-muted-foreground">No milestones in this range.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-1" aria-labelledby="milestones-timeline">
+      <header className="flex items-center justify-between gap-2">
+        <h2 id="milestones-timeline" className="text-base font-semibold tracking-tight">
+          Milestones timeline
+        </h2>
+        {pager}
+      </header>
+      <TooltipProvider delay={80}>
+        <div
+          ref={ref}
+          className="snap-x snap-proximity overflow-x-auto overscroll-x-contain"
+          role="region"
+          aria-label="Milestones timeline"
+        >
+          <ol className="flex w-max min-w-full list-none p-0">
+            {rows.map((event, index) => {
+              const year = yearOf(event.date);
+              const dateValue = event.date.slice(0, 10);
+              const dateLabel = formatMilestoneDate(event.date);
+
+              return (
+                <li key={event.id} className="flex w-52 shrink-0 snap-start flex-col pb-3">
+                  <div className="min-h-7 text-xl font-bold tracking-tight">
+                    {showYear[index] ? year : null}
+                  </div>
+                  <div className="relative w-full">
+                    <TimelineSpine isFirst={index === 0} isLast={index === rows.length - 1} />
+                    <div className="absolute inset-y-0 start-0 flex items-center">
+                      <Tooltip>
+                        <TooltipTrigger
+                          aria-label={`${event.label}, ${dateLabel}`}
+                          className="relative z-1 flex size-6 items-center justify-center rounded-full"
+                        >
+                          <span
+                            className="size-2 rounded-full bg-foreground ring-4 ring-background"
+                            aria-hidden="true"
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <time dateTime={dateValue}>{dateLabel}</time>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </div>
+                  <div className="min-w-0 ps-3">
+                    <p className="truncate text-sm font-medium">{event.label}</p>
+                    {event.entity ? (
+                      <div className="mt-1.5 flex min-w-0 items-center gap-2">
+                        <Cover src={event.image} alt={event.entity} />
+                        <div className="min-w-0">
+                          <p className="truncate text-xs">{event.entity}</p>
+                          {event.subtitle ? (
+                            <p className="truncate text-[10px] text-muted-foreground">
+                              {event.subtitle}
+                            </p>
+                          ) : null}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+      </TooltipProvider>
+    </section>
+  );
+}

--- a/apps/web/src/lib/query.ts
+++ b/apps/web/src/lib/query.ts
@@ -3,6 +3,7 @@ import { artistsQueries } from "@/features/artists/queries";
 import { discoveriesQueries } from "@/features/discoveries/queries";
 import { interactionsQueries } from "@/features/interactions/queries";
 import { listeningQueries } from "@/features/listening/queries";
+import { milestonesQueries } from "@/features/milestones/queries";
 import { packagesQueries } from "@/features/packages/queries";
 import { tracksQueries } from "@/features/tracks/queries";
 
@@ -12,6 +13,7 @@ export const query = {
   discoveries: discoveriesQueries,
   interactions: interactionsQueries,
   listeningHabits: listeningQueries,
+  milestones: milestonesQueries,
   packages: packagesQueries,
   tracks: tracksQueries,
 };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as AppPackageIdAlbumsRouteImport } from './routes/app/$packageId/
 import { Route as AppPackageIdArtistsRouteImport } from './routes/app/$packageId/artists'
 import { Route as AppPackageIdDiscoveriesRouteImport } from './routes/app/$packageId/discoveries'
 import { Route as AppPackageIdListeningRouteImport } from './routes/app/$packageId/listening'
+import { Route as AppPackageIdMilestonesRouteImport } from './routes/app/$packageId/milestones'
 import { Route as AppPackageIdPackageRouteImport } from './routes/app/$packageId/package'
 import { Route as AppPackageIdTracksRouteImport } from './routes/app/$packageId/tracks'
 
@@ -54,6 +55,11 @@ const AppPackageIdListeningRoute = AppPackageIdListeningRouteImport.update({
   path: '/listening',
   getParentRoute: () => AppPackageIdRoute,
 } as any)
+const AppPackageIdMilestonesRoute = AppPackageIdMilestonesRouteImport.update({
+  id: '/milestones',
+  path: '/milestones',
+  getParentRoute: () => AppPackageIdRoute,
+} as any)
 const AppPackageIdPackageRoute = AppPackageIdPackageRouteImport.update({
   id: '/package',
   path: '/package',
@@ -73,6 +79,7 @@ export interface FileRoutesByFullPath {
   '/app/$packageId/artists': typeof AppPackageIdArtistsRoute
   '/app/$packageId/discoveries': typeof AppPackageIdDiscoveriesRoute
   '/app/$packageId/listening': typeof AppPackageIdListeningRoute
+  '/app/$packageId/milestones': typeof AppPackageIdMilestonesRoute
   '/app/$packageId/package': typeof AppPackageIdPackageRoute
   '/app/$packageId/tracks': typeof AppPackageIdTracksRoute
 }
@@ -84,6 +91,7 @@ export interface FileRoutesByTo {
   '/app/$packageId/artists': typeof AppPackageIdArtistsRoute
   '/app/$packageId/discoveries': typeof AppPackageIdDiscoveriesRoute
   '/app/$packageId/listening': typeof AppPackageIdListeningRoute
+  '/app/$packageId/milestones': typeof AppPackageIdMilestonesRoute
   '/app/$packageId/package': typeof AppPackageIdPackageRoute
   '/app/$packageId/tracks': typeof AppPackageIdTracksRoute
 }
@@ -96,6 +104,7 @@ export interface FileRoutesById {
   '/app/$packageId/artists': typeof AppPackageIdArtistsRoute
   '/app/$packageId/discoveries': typeof AppPackageIdDiscoveriesRoute
   '/app/$packageId/listening': typeof AppPackageIdListeningRoute
+  '/app/$packageId/milestones': typeof AppPackageIdMilestonesRoute
   '/app/$packageId/package': typeof AppPackageIdPackageRoute
   '/app/$packageId/tracks': typeof AppPackageIdTracksRoute
 }
@@ -109,6 +118,7 @@ export interface FileRouteTypes {
     | '/app/$packageId/artists'
     | '/app/$packageId/discoveries'
     | '/app/$packageId/listening'
+    | '/app/$packageId/milestones'
     | '/app/$packageId/package'
     | '/app/$packageId/tracks'
   fileRoutesByTo: FileRoutesByTo
@@ -120,6 +130,7 @@ export interface FileRouteTypes {
     | '/app/$packageId/artists'
     | '/app/$packageId/discoveries'
     | '/app/$packageId/listening'
+    | '/app/$packageId/milestones'
     | '/app/$packageId/package'
     | '/app/$packageId/tracks'
   id:
@@ -131,6 +142,7 @@ export interface FileRouteTypes {
     | '/app/$packageId/artists'
     | '/app/$packageId/discoveries'
     | '/app/$packageId/listening'
+    | '/app/$packageId/milestones'
     | '/app/$packageId/package'
     | '/app/$packageId/tracks'
   fileRoutesById: FileRoutesById
@@ -192,6 +204,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppPackageIdListeningRouteImport
       parentRoute: typeof AppPackageIdRoute
     }
+    '/app/$packageId/milestones': {
+      id: '/app/$packageId/milestones'
+      path: '/milestones'
+      fullPath: '/app/$packageId/milestones'
+      preLoaderRoute: typeof AppPackageIdMilestonesRouteImport
+      parentRoute: typeof AppPackageIdRoute
+    }
     '/app/$packageId/package': {
       id: '/app/$packageId/package'
       path: '/package'
@@ -214,6 +233,7 @@ interface AppPackageIdRouteChildren {
   AppPackageIdArtistsRoute: typeof AppPackageIdArtistsRoute
   AppPackageIdDiscoveriesRoute: typeof AppPackageIdDiscoveriesRoute
   AppPackageIdListeningRoute: typeof AppPackageIdListeningRoute
+  AppPackageIdMilestonesRoute: typeof AppPackageIdMilestonesRoute
   AppPackageIdPackageRoute: typeof AppPackageIdPackageRoute
   AppPackageIdTracksRoute: typeof AppPackageIdTracksRoute
 }
@@ -223,6 +243,7 @@ const AppPackageIdRouteChildren: AppPackageIdRouteChildren = {
   AppPackageIdArtistsRoute: AppPackageIdArtistsRoute,
   AppPackageIdDiscoveriesRoute: AppPackageIdDiscoveriesRoute,
   AppPackageIdListeningRoute: AppPackageIdListeningRoute,
+  AppPackageIdMilestonesRoute: AppPackageIdMilestonesRoute,
   AppPackageIdPackageRoute: AppPackageIdPackageRoute,
   AppPackageIdTracksRoute: AppPackageIdTracksRoute,
 }

--- a/apps/web/src/routes/app/$packageId/milestones.tsx
+++ b/apps/web/src/routes/app/$packageId/milestones.tsx
@@ -1,0 +1,54 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { DateRangeFilter } from "@/components/layout/header/date-range-filter";
+import { Pane } from "@/components/pane";
+import { FirstsWidget } from "@/features/milestones/widgets/firsts-widget";
+import { NextMilestonesWidget } from "@/features/milestones/widgets/next-milestones-widget";
+import { SessionsStreaksWidget } from "@/features/milestones/widgets/sessions-streaks-widget";
+import { SummaryHero } from "@/features/milestones/widgets/summary-hero";
+import { TimelineWidget } from "@/features/milestones/widgets/timeline-widget";
+import { readFilter } from "@/lib/filter";
+import { query } from "@/lib/query";
+
+export const Route = createFileRoute("/app/$packageId/milestones")({
+  ssr: false,
+  loader: async ({ context: { queryClient }, parentMatchPromise }) => {
+    await parentMatchPromise;
+    const filter = readFilter();
+    await Promise.all([
+      queryClient.ensureQueryData(query.milestones.summary.queryOptions(filter)),
+      queryClient.ensureQueryData(query.milestones.nextMilestones.queryOptions(filter)),
+      queryClient.ensureQueryData(query.milestones.streak.queryOptions(filter)),
+      queryClient.ensureQueryData(query.milestones.sessions.queryOptions(filter)),
+      queryClient.ensureQueryData(query.milestones.timeline.queryOptions(filter)),
+      queryClient.ensureQueryData(query.milestones.firsts.queryOptions(filter)),
+    ]);
+  },
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return (
+    <Pane>
+      <Pane.Header title="Milestones" artistSelect>
+        <DateRangeFilter />
+      </Pane.Header>
+      <main className="mx-auto max-w-6xl p-4">
+        <SummaryHero />
+
+        <div className="grid grid-cols-1 gap-6 pt-5 md:grid-cols-2">
+          <NextMilestonesWidget />
+          <SessionsStreaksWidget />
+        </div>
+
+        <div className="pt-5">
+          <TimelineWidget />
+        </div>
+
+        <div className="pt-5">
+          <FirstsWidget />
+        </div>
+      </main>
+    </Pane>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new "milestones" feature for the web app, including backend query logic, formatting utilities, and integration with the navigation. It also upgrades several GitHub Actions and Dockerfile commands for improved compatibility and maintainability. The most important changes are grouped below.

Milestones Feature Implementation:

* Added a full set of query functions for milestones data, including summary, next milestones, streaks, sessions, timeline, and firsts, using DuckDB for analytics. These are implemented in new files under `apps/web/src/features/milestones/queries/` and are exposed via a central `milestonesQueries` object. [[1]](diffhunk://#diff-61ed1305cede0f4ab88aac6e61c1f269cdd6909939b97dae055c96634cc07144R1-R55) [[2]](diffhunk://#diff-5128b582e009b84b48468f56d6ecfddc6ecdd16dc8537c3532b79ff0299644f6R1-R65) [[3]](diffhunk://#diff-2cea313f2c4b68412edd437a2db1ae131efa212f25430f5025af6c946fb93fc4R1-R83) [[4]](diffhunk://#diff-364dc16b17b321d7de8d343f0f2b6a73e955076625f80fcf42155f73a447bed5R1-R75) [[5]](diffhunk://#diff-46da966e93774a38047c78e1edca6f38e0cc3aba10568c0f33e1b309e0d44319R1-R69) [[6]](diffhunk://#diff-caf4fbc202485d8e8cbf1e743bad8fa56c1cab5ef60674d8c4bb6f66a4e3930aR1-R54) [[7]](diffhunk://#diff-acb6d558fc453deaedc0347929234a5876aefc737bc854b0b60a6ccf45ab3fb2R1-R16)
* Added formatting utilities for milestone data, such as date formatting, count formatting, and milestone progress bar calculations in `format.ts`.
* Integrated the new milestones page into the navigation by updating the "Milestones" link to point to `/milestones`.

DevOps and Docker Improvements:

* Upgraded GitHub Actions in `.github/workflows/release.yml` to use the latest major versions: `actions/setup-node@v6`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, and `docker/build-push-action@v7`. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L33-R33) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L65-R68) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L84-R84)
* Changed Docker build cache strategy to use the GitHub Container Registry (GHCR) as the cache source and destination, improving build performance and reliability.
* Updated Dockerfile `CMD` instructions to use array syntax for better compatibility and clarity in both `apps/server/Dockerfile` and `apps/web/Dockerfile`. [[1]](diffhunk://#diff-b3eabb46eb10c8c3d81d4564abe4550ddcdc55dc358418bf384465494c95cdc1L42-R42) [[2]](diffhunk://#diff-4eb403c1470ca34300aea23c38f170d0e8b3c16932a5af4c99da390622d3db4eL37-R37)

Accessibility:

* Added `aria-hidden="true"` to the fallback music note icon in the `Cover` component, improving accessibility for screen readers.